### PR TITLE
Fix CJK-C CJK-D

### DIFF
--- a/zhengma.dict.yaml
+++ b/zhengma.dict.yaml
@@ -800,6 +800,7 @@ encoder:
 𠮴	aij	0
 政	aim	73700000
 𤓯	aio	0
+𫟧	aiw	0
 邒	aiy	19700
 𨚣	aiy	0
 丐	aiz	8170000
@@ -1556,6 +1557,7 @@ encoder:
 責	clo	5750000
 责	clo	183000000
 𤦚	clo	0
+𫞥	clo	0
 现	clr	275000000
 現	clr	44300000
 耡	cly	61000
@@ -1900,6 +1902,7 @@ encoder:
 𢪠	dji	0
 捛	djj	22400
 操	djj	45300000
+𫝻	djj	0
 损	djl	55100000
 損	djl	26600000
 抧	djo	116000
@@ -2373,6 +2376,7 @@ encoder:
 葉	eef	59900000
 𦳑	eef	0
 𦻆	eef	0
+𫟒	eef	0
 鞯	eeg	561000
 苦	eej	119000000
 𦳦	eej	0
@@ -4528,6 +4532,7 @@ encoder:
 䗈	isl	3780
 蝣	ism	282000
 蚊	iso	14300000
+𫞫	isr	0
 螃	isu	9190000
 𧉼	isu	0
 蟀	isv	1480000
@@ -4563,6 +4568,7 @@ encoder:
 𧌞	iwy	0
 𧌴	iwy	0
 虑	iwz	9960000
+𫝀	ixa	0
 蛏	ixb	346000
 𠁣	ixb	0
 𢍀	ixe	0
@@ -4767,6 +4773,7 @@ encoder:
 𠼉	jgq	0
 㕱	jgr	3890
 𠮾	jgr	0
+𫝘	jgr	0
 吠	jgs	4410000
 呔	jgs	1320000
 啄	jgs	3100000
@@ -5273,6 +5280,7 @@ encoder:
 暙	kco	474000
 晴	kcq	46600000
 𪰑	kcs	0
+𫞂	kcs	0
 旺	kcv	65500000
 最	kcx	1270000000
 𪰸	kcz	0
@@ -5550,6 +5558,7 @@ encoder:
 業	kuc	93900000
 對	kud	187000000
 㫧	kuf	4040
+𫞃	kuj	0
 曦	kum	5840000
 鑿	kun	1460000
 炅	kuo	2060000
@@ -6477,6 +6486,7 @@ encoder:
 签	mob	82700000
 筌	moc	1170000
 失	mod	69600000
+𫝄	mod	0
 稀	mog	23800000
 筕	moi	44000
 稅	moj	20000000
@@ -7280,6 +7290,7 @@ encoder:
 𥃦	odl	0
 舍	odm	58600000
 𠆥	odm	0
+𫝄	odm	0
 亽	ods	346000
 𠇍	odu	0
 令	odw	256000000
@@ -7628,6 +7639,7 @@ encoder:
 鑊	pen	833000
 镬	pen	787000
 鉷	peo	55100
+𫟹	peo	0
 鏾	peq	89700
 鋩	pes	162000
 鑮	pev	36500
@@ -7684,6 +7696,7 @@ encoder:
 𨧧	pgs	0
 鐐	pgu	2290000
 镣	pgu	703000
+𫟼	pgw	0
 鈸	pgx	109000
 钹	pgx	368000
 銕	pgy	96200
@@ -7791,6 +7804,7 @@ encoder:
 鏜	pkw	149000
 镗	pkw	1070000
 铛	pkx	1960000
+𫟰	pkx	0
 翻	pky	244000000
 鏍	pkz	1870000
 镙	pkz	423000
@@ -7964,6 +7978,7 @@ encoder:
 鈠	pqx	20400
 𨱁	pqx	0
 釚	pqy	32100
+𫟲	pqy	0
 縏	pqz	24800
 𧲠	pqz	0
 豹	pra	23400000
@@ -8030,6 +8045,7 @@ encoder:
 铱	psr	930000
 鉝	psu	28800
 镑	psu	2040000
+𫟷	psu	0
 鎊	psw	439000
 鋃	psx	97500
 锒	psx	561000
@@ -8707,6 +8723,7 @@ encoder:
 鯄	rdv	43000
 𫃛	rdz	0
 魽	reb	50500
+𫠐	reb	0
 鯕	rec	61000
 鲯	rec	49200
 𫙏	red	0
@@ -8782,6 +8799,7 @@ encoder:
 䰹	rhm	4220
 𠂎	rhm	0
 氐	rhs	2640000
+𫞕	rhs	0
 鲢	rhw	978000
 鮔	rhx	53700
 卬	rhy	145000
@@ -9339,6 +9357,7 @@ encoder:
 谑	sih	903000
 蠪	sii	29800
 訨	sii	163000
+𫟞	sii	0
 站	sij	2410000000
 詀	sij	115000
 𡃡	sij	0
@@ -9385,6 +9404,7 @@ encoder:
 裏	skb	85400000
 𧨚	skb	0
 𧫔	skb	0
+𫟯	skb	0
 誹	skc	994000
 诽	skc	553000
 䚯	skd	3440
@@ -9673,6 +9693,7 @@ encoder:
 谘	str	948000
 譧	stu	32900
 詊	sub	32600
+𫟟	sub	0
 詳	suc	13500000
 详	suc	34400000
 竎	sue	24600
@@ -9681,6 +9702,7 @@ encoder:
 詸	suf	103000
 䇉	sug	3680
 产	sug	128000000
+𫞼	sug	0
 䇂	sui	4330
 剖	suj	6410000
 咅	suj	34700
@@ -10151,6 +10173,7 @@ encoder:
 阕	txa	3020000
 鹿	txa	42800000
 塵	txb	8570000
+𫞬	txb	0
 阚	txc	1050000
 𤷱	txd	0
 癜	txe	1580000
@@ -11303,6 +11326,7 @@ encoder:
 䢎	wae	3640
 袜	waf	18900000
 宁	wai	90900000
+𫟧	wai	0
 富	waj	126000000
 寅	wak	8060000
 賓	wak	7290000
@@ -11601,6 +11625,7 @@ encoder:
 𥥃	woq	0
 𧦱	wos	0
 窘	wox	3410000
+𫞹	wox	0
 穷	woy	36600000
 𥤣	woy	0
 𥥮	woz	0
@@ -11987,6 +12012,7 @@ encoder:
 𠬹	xsz	0
 买	xtg	627000000
 骥	xtr	5120000
+𫠋	xtx	0
 屏	xue	177000000
 骈	xue	585000
 屎	xuf	24600000
@@ -13933,6 +13959,7 @@ encoder:
 可我	ajmv	18900000
 可气	ajmy	1300000
 可使	ajna	12300000
+𫝁	ajnd	0
 可供	ajne	19200000
 豍	ajne	24300
 𣝐	ajnf	0
@@ -14558,6 +14585,7 @@ encoder:
 殡葬	area	1870000
 𣨴	aref	0
 㱠	arej	4650
+𫞔	arek	0
 㱵	arel	8860
 殖	arel	3420000
 𤳓	areo	0
@@ -14981,6 +15009,7 @@ encoder:
 平息	aunw	7020000
 平行	auoi	19900000
 平谷	auoo	10600000
+𫝃	auoo	0
 平衡	auor	60300000
 平分	auoy	1900000
 平反	aupx	2600000
@@ -15110,6 +15139,7 @@ encoder:
 一具	avlo	1340000
 一瞬	avlp	21500000
 一眼	avlx	48100000
+𫝂	avma	0
 一等	avmb	18800000
 一生	avmc	82500000
 一手	avmd	48000000
@@ -15855,6 +15885,7 @@ encoder:
 𫎁	bdoj	0
 替	bdok	60900000
 𪞾	bdok	0
+𫞄	bdok	0
 規	bdol	20900000
 规	bdol	46000000
 賛	bdol	608000
@@ -16096,6 +16127,7 @@ encoder:
 𡐧	bfke	0
 𪤠	bfki	0
 𡒫	bflb	0
+𫝠	bflc	0
 堜	bflk	717000
 𢽓	bfmo	0
 𡓘	bfni	0
@@ -16461,6 +16493,7 @@ encoder:
 𢀜	biyb	0
 𩢗	biyc	0
 㓛	biyd	4300
+𫠅	biye	0
 𥑙	biyg	0
 𥑱	biyg	0
 盐巴	biyi	283000
@@ -16768,6 +16801,7 @@ encoder:
 堤坝	bkbl	1240000
 来者	bkbm	5400000
 𫀏	bkbr	0
+𫝔	bkbr	0
 壜	bkbz	155000
 来去	bkbz	6150000
 𥜪	bkci	0
@@ -18128,6 +18162,7 @@ encoder:
 壇	bska	11600000
 𡍠	bska	0
 墥	bskb	45500
+𫝟	bskb	0
 墇	bske	29700
 𡑌	bskh	0
 境界	bsko	34200000
@@ -18161,6 +18196,7 @@ encoder:
 境外	bsri	15600000
 𪣱	bsri	0
 𪤪	bsrn	0
+𫟨	bsrw	0
 𪣠	bssj	0
 培训	bssn	243000000
 培育	bssz	29600000
@@ -18302,6 +18338,7 @@ encoder:
 謺	buqs	38000
 慹	buqw	46800
 執	buqy	5610000
+𫝑	buqy	0
 縶	buqz	47300
 𠒀	burd	0
 幸免	burj	6340000
@@ -19221,6 +19258,7 @@ encoder:
 𠬇	bzjk	0
 专员	bzjl	7520000
 动员	bzjl	30000000
+𫞱	bzjl	0
 𡍗	bzjo	0
 动听	bzjp	7140000
 去路	bzjr	3260000
@@ -19934,6 +19972,7 @@ encoder:
 𦗹	ceoo	0
 𦘎	ceoo	0
 𫆊	ceoo	0
+𫞩	ceoo	0
 聄	ceop	57500
 𦗖	ceop	0
 𦡠	ceoq	0
@@ -20048,6 +20087,7 @@ encoder:
 𦗍	cews	0
 耳边	cewy	15500000
 𨟡	cewy	0
+𫞧	cewy	0
 恥	cewz	9040000
 𢚸	cewz	0
 𪫵	cewz	0
@@ -20116,6 +20156,7 @@ encoder:
 𫆆	cezm	0
 𩀳	cezn	0
 𦖶	cezs	0
+𫟉	cezs	0
 䏉	cezu	3490
 聮	cezu	94300
 𤈨	cezu	0
@@ -21261,6 +21302,7 @@ encoder:
 𤥮	ckmj	0
 𦔄	ckml	0
 𪻻	ckml	0
+𫞨	ckml	0
 𢼡	ckmo	0
 𤥟	ckms	0
 理科	ckmt	25400000
@@ -21887,6 +21929,7 @@ encoder:
 㻢	csmy	3600
 𤦽	csmy	0
 玉皇	csnc	853000
+𫞦	csnd	0
 𤫓	csng	0
 斑白	csnk	536000
 玉帛	csnl	533000
@@ -21952,6 +21995,7 @@ encoder:
 瑭	ctxj	556000
 𤨭	ctxl	0
 𤨫	ctxw	0
+𫠉	cuaa	0
 䮗	cuae	3660
 馯	cuae	29100
 駻	cuae	67000
@@ -23351,6 +23395,7 @@ encoder:
 𢹜	deoo	0
 𢺊	deoo	0
 擹	deor	48300
+𫝾	deor	0
 𢺍	deoz	0
 撕	depd	27900000
 𢵛	depf	0
@@ -24045,6 +24090,7 @@ encoder:
 擇	dlbu	6050000
 摆	dlbz	71500000
 摆动	dlbz	4050000
+𫝺	dlbz	0
 摆弄	dlce	2660000
 𢶮	dlcu	0
 㧇	dlda	4040
@@ -24363,6 +24409,7 @@ encoder:
 𢭢	dnmi	0
 搜刮	dnmk	1960000
 推算	dnml	5020000
+𫝽	dnmp	0
 推移	dnmr	12800000
 推辞	dnms	2430000
 搜集	dnnf	28900000
@@ -25015,11 +25062,13 @@ encoder:
 批发	drzv	127000000
 指出	drzz	99200000
 掏出	drzz	11700000
+𫝿	dsaa	0
 拉开	dsae	19900000
 拉丁	dsai	13600000
 𢱏	dsai	0
 𢰤	dsaj	0
 𢷔	dsaj	0
+𫝿	dsbi	0
 𢸛	dsbj	0
 撞塌	dsbk	56400
 接替	dsbo	7100000
@@ -25677,6 +25726,7 @@ encoder:
 𢫫	dxbd	0
 择	dxbi	19700000
 𢲉	dxbk	0
+𫝼	dxbr	0
 扫地	dxbv	3500000
 揵	dxby	125000
 扭动	dxbz	3280000
@@ -26798,6 +26848,7 @@ encoder:
 其余	ecom	28500000
 𦴿	ecow	0
 𠔡	ecoy	0
+𫞪	ecoz	0
 其后	ecpa	12100000
 斯	ecpd	261000000
 𣚄	ecpf	0
@@ -26870,6 +26921,7 @@ encoder:
 𧡪	eczl	0
 𢾤	eczm	0
 藉以	eczo	1530000
+𫞪	eczo	0
 歁	eczr	39200
 𢝖	eczw	0
 𢦊	eczw	0
@@ -27211,6 +27263,7 @@ encoder:
 𦃦	edwz	0
 萚	edxb	58400
 頍	edxg	33700
+𫠆	edxg	0
 疐	edxi	40800
 蓵	edxi	29400
 𦰽	edxi	0
@@ -27248,6 +27301,7 @@ encoder:
 瓳	edys	28000
 𤭱	edys	0
 𠒘	edyt	0
+𫝓	edyv	0
 愂	edyw	30700
 𢚦	edyw	0
 䎁	edyy	4000
@@ -28203,6 +28257,7 @@ encoder:
 𦳙	ehmo	0
 𨯍	ehmp	0
 藏身	ehnc	4440000
+𫟎	ehnd	0
 载体	ehnf	33700000
 栽倒	ehnh	986000
 䘁	ehni	6260
@@ -28253,6 +28308,7 @@ encoder:
 蘙	ehyy	35700
 𦼿	ehzg	0
 藏	ehzh	146000000
+𫟖	ehzh	0
 芚	ehzi	72900
 萅	ehzk	20500
 𢧭	ehzk	0
@@ -28731,6 +28787,7 @@ encoder:
 𦿐	eknh	0
 朝向	eknj	11400000
 黄泉	eknk	3350000
+𫟜	eknl	0
 𢿯	eknm	0
 黄牌	eknn	3910000
 摹仿	ekns	407000
@@ -29275,6 +29332,7 @@ encoder:
 莵	emrs	94500
 𦱜	emrs	0
 𦲦	emrs	0
+𫟏	emrs	0
 𫊎	emsb	0
 蘖	emsf	447000
 𩕸	emsg	0
@@ -29687,6 +29745,7 @@ encoder:
 茶馆	eoow	28600000
 共创	eooy	11700000
 𦭏	eopd	0
+𫟓	eopj	0
 茶盘	eopl	345000
 茶几	eoqd	4870000
 萮	eoqk	28100
@@ -29973,6 +30032,7 @@ encoder:
 葱郁	ergq	1230000
 警犬	ergs	858000
 警戒	erhe	12800000
+𫟌	erid	0
 𦿼	erii	0
 䓘	erij	3560
 𧁰	erix	0
@@ -30056,6 +30116,7 @@ encoder:
 𦽭	errn	0
 𧃄	errn	0
 芘	errr	1430000
+𫟍	errr	0
 茤	errs	151000
 菟	errs	1550000
 𠣷	errs	0
@@ -30394,6 +30455,7 @@ encoder:
 丧葬	euea	1340000
 𦾲	eueo	0
 蕲	euep	816000
+𫟕	euey	0
 䔿	eufd	4730
 𦳷	eufd	0
 𧅘	eufg	0
@@ -30469,6 +30531,7 @@ encoder:
 蒌	euzm	407000
 薮	euzm	1130000
 蒴	euzq	136000
+𫟔	euzr	0
 𦴷	evab	0
 𦹻	evab	0
 䓑	evae	3930
@@ -30948,6 +31011,7 @@ encoder:
 蓂	ewso	121000
 荣立	ewsu	493000
 𦲏	ewsy	0
+𫟐	ewsy	0
 带病	ewta	1030000
 𦮜	ewte	0
 芝麻	ewtf	11500000
@@ -31170,6 +31234,7 @@ encoder:
 𧂰	exul	0
 𧃤	exul	0
 𦳒	exuo	0
+𫟑	exuo	0
 蒸汽	exvm	9190000
 支流	exvs	2660000
 𪜀	exvv	0
@@ -31663,6 +31728,7 @@ encoder:
 木器	fajj	2200000
 楅	fajk	1390000
 槅	fajl	333000
+𫞉	fajn	0
 𣐸	fajo	0
 𣘅	fajr	0
 梪	faju	66800
@@ -32028,6 +32094,7 @@ encoder:
 𨢦	fdcl	0
 釅	fdcm	36100
 𨣅	fdcx	0
+𫟮	fdcz	0
 䣿	fddl	5940
 酎	fdds	1030000
 酣	fdeb	5090000
@@ -32547,6 +32614,7 @@ encoder:
 﨓	fend	26500
 𣟿	fenf	0
 𣝫	feni	0
+𫞐	feni	0
 植保	fenj	1950000
 横向	fenj	19800000
 欟	fenl	52900
@@ -32761,6 +32829,7 @@ encoder:
 林业	ffku	25200000
 𣛺	ffky	0
 禁赌	fflb	277000
+𫞍	fflc	0
 栜	ffld	31000
 楝	fflk	1480000
 𥁹	fflk	0
@@ -32898,6 +32967,7 @@ encoder:
 槈	fgds	325000
 需求	fgdv	303000000
 震荡	fgev	15900000
+𫞒	fgfk	0
 需要	fgfv	591000000
 㮕	fggd	4030
 㰁	fggg	6210
@@ -32915,6 +32985,7 @@ encoder:
 𣕨	fgki	0
 橑	fgkk	30400
 𣞀	fgkl	0
+𫞏	fgkl	0
 𣖔	fgky	0
 㭺	fgkz	4530
 柨	fgli	825000
@@ -32933,6 +33004,7 @@ encoder:
 𣔸	fgoo	0
 杯盘	fgpl	412000
 𪳊	fgqf	0
+𫞎	fgql	0
 㮋	fgqy	3990
 㮷	fgrk	3840
 震颤	fgsj	1630000
@@ -33237,6 +33309,7 @@ encoder:
 樿	fjke	832000
 覃	fjke	2850000
 𧟻	fjke	0
+𫟛	fjke	0
 𣝞	fjkf	0
 𪘼	fjki	0
 西昌	fjkk	2730000
@@ -33662,6 +33735,7 @@ encoder:
 輻	fkjk	1120000
 𨎴	fkjk	0
 𩈻	fkjk	0
+𫞑	fkjk	0
 轎	fkjl	1840000
 𣙟	fkjl	0
 𨍮	fkjl	0
@@ -34273,6 +34347,7 @@ encoder:
 相同	flld	81600000
 𣐶	flld	0
 𣙋	flld	0
+𫝛	flld	0
 𣝇	fllf	0
 𣑹	flli	0
 𧢔	flll	0
@@ -34551,6 +34626,7 @@ encoder:
 柂	fmyi	54000
 𣙭	fmyj	0
 𣒴	fmym	0
+𫞌	fmyq	0
 𣛏	fmys	0
 𪴚	fmyu	0
 槌	fmyw	5530000
@@ -35013,6 +35089,7 @@ encoder:
 㮆	fouc	4200
 䴵	foue	4640
 𪍑	fouf	0
+𫞋	foui	0
 𪍶	fouj	0
 䵂	foul	5250
 覆盖	foul	33800000
@@ -35151,6 +35228,7 @@ encoder:
 𣔙	fpro	0
 𪁻	fprz	0
 𣖅	fpse	0
+𫞊	fpsy	0
 𣔋	fpvv	0
 𣜬	fpwr	0
 𪓫	fpwx	0
@@ -36071,6 +36149,7 @@ encoder:
 𩅉	fvoo	0
 𩅼	fvoo	0
 𩆯	fvoo	0
+𫝃	fvoo	0
 要饭	fvop	1750000
 𩅙	fvop	0
 𣖷	fvoq	0
@@ -36790,6 +36869,7 @@ encoder:
 配备	fyrk	23500000
 配角	fyrl	5030000
 配色	fyry	9370000
+𫞈	fysa	0
 𣑗	fysd	0
 𣚟	fysi	0
 㯁	fysj	3540
@@ -37794,6 +37874,7 @@ encoder:
 𣣚	gdzr	0
 𩿅	gdzr	0
 𫛦	gdzr	0
+𫠖	gdzr	0
 厷	gdzs	666000
 厺	gdzs	108000
 大娘	gdzs	1930000
@@ -38138,6 +38219,7 @@ encoder:
 厤	ggmm	328000
 𩴣	ggmn	0
 𩞨	ggmo	0
+𫝕	ggmo	0
 𨬑	ggmp	0
 𦠓	ggmq	0
 𠪁	ggmr	0
@@ -38173,6 +38255,7 @@ encoder:
 厌倦	ggnu	6980000
 𤎝	ggnu	0
 𠪇	ggnx	0
+𫝗	ggny	0
 𠪳	ggnz	0
 硕	ggoa	71400000
 碩	ggoa	8560000
@@ -38361,12 +38444,14 @@ encoder:
 𠩅	ggys	0
 𠪹	ggys	0
 𥑣	ggys	0
+𫝕	ggyt	0
 励	ggyy	5130000
 厄	ggyy	9070000
 砈	ggyy	62000
 𠠿	ggyy	0
 𥑉	ggyy	0
 𨜸	ggyy	0
+𫟫	ggyy	0
 𡓸	ggzb	0
 𠪸	ggzf	0
 𠩩	ggzg	0
@@ -40388,6 +40473,7 @@ encoder:
 𨐇	hegm	0
 轿	hegn	9510000
 𫐄	hegr	0
+𫟦	hegw	0
 轭	hegy	538000
 𫐆	hegy	0
 车臣	heha	1370000
@@ -40420,6 +40506,7 @@ encoder:
 𫐅	hell	0
 𦣶	helo	0
 𫐇	helo	0
+𫟥	helo	0
 𨐊	helw	0
 车手	hemd	4540000
 𫐓	hemf	0
@@ -40475,12 +40562,14 @@ encoder:
 辘	hetx	285000
 车灯	heua	2300000
 𫐌	heue	0
+𫟦	heug	0
 戒烟	heuj	4700000
 车前	heuq	3380000
 车流	hevs	1740000
 车速	hewf	4330000
 车祸	hewj	12200000
 𠥖	hewl	0
+𫟤	hewr	0
 𫐑	hewy	0
 戒心	hewz	2800000
 车马	hexa	2050000
@@ -41640,6 +41729,7 @@ encoder:
 虫媒	iaze	95900
 𧋝	iazf	0
 𦇂	iazi	0
+𫝅	iazo	0
 卡纸	iazr	880000
 𦲘	iazr	0
 䗡	iazu	3560
@@ -41829,6 +41919,7 @@ encoder:
 鹵	idjo	4110000
 鹸	idjo	125000
 𠧚	idjo	0
+𫠗	idjo	0
 㣌	idjp	4100
 𠧧	idjr	0
 𣢤	idjr	0
@@ -42683,6 +42774,7 @@ encoder:
 𣦉	iiml	0
 𧖭	iiml	0
 𣥨	iims	0
+𫞓	iims	0
 顰	iine	204000
 颦	iine	1840000
 𩖓	iine	0
@@ -42724,6 +42816,7 @@ encoder:
 𪗶	iiri	0
 呰	iirj	861000
 𧿿	iirj	0
+𫠚	iirj	0
 㫮	iirk	3750
 㠿	iirl	5050
 眥	iirl	161000
@@ -42908,6 +43001,7 @@ encoder:
 虚拟	ikdz	91100000
 卓著	ikeb	2150000
 𧏻	ikeb	0
+𫝒	iked	0
 𧑌	ikeo	0
 虚荣	ikew	5640000
 频带	ikew	873000
@@ -43260,6 +43354,7 @@ encoder:
 𪙢	iokh	0
 𪙡	iokk	0
 𪙾	iokl	0
+𫠛	iokm	0
 𪘞	iokq	0
 𪙑	iokq	0
 𪘄	iokr	0
@@ -43286,6 +43381,7 @@ encoder:
 齵	iolz	45600
 𪙥	iolz	0
 𪙺	iolz	0
+𫝏	iolz	0
 蜍	iomf	113000
 𪗮	iomf	0
 𪘐	iomh	0
@@ -43309,6 +43405,7 @@ encoder:
 𪙻	ionh	0
 𪘮	ioni	0
 齯	ionr	36000
+𫠜	ionr	0
 𪘧	iooe	0
 𠒃	ioog	0
 𪚉	ioog	0
@@ -43345,6 +43442,7 @@ encoder:
 𧒰	ioqm	0
 𨰢	ioqp	0
 𪗤	ioqs	0
+𫠙	ioqx	0
 𪘫	iora	0
 𪙝	iord	0
 齿条	iorf	392000
@@ -43821,6 +43919,7 @@ encoder:
 𧑚	iwot	0
 𫋅	iwpd	0
 𧏖	iwpo	0
+𫟗	iwrb	0
 䗦	iwrc	3650
 𧉡	iwrd	0
 𫋍	iwrj	0
@@ -44898,6 +44997,7 @@ encoder:
 𠿣	jfbr	0
 困境	jfbs	18200000
 𠻢	jfbz	0
+𫝚	jfbz	0
 𠾴	jfcb	0
 𡅺	jfch	0
 𣔣	jfcs	0
@@ -44966,6 +45066,7 @@ encoder:
 𠺝	jfrj	0
 𪢐	jfrl	0
 𠿙	jfry	0
+𫝞	jfry	0
 𪁣	jfrz	0
 𠵉	jfsq	0
 哺育	jfsz	2070000
@@ -45472,6 +45573,7 @@ encoder:
 𨅨	jijf	0
 𫏡	jijg	0
 𨅝	jijh	0
+𫟣	jijh	0
 踀	jiji	43500
 蹿	jiji	2540000
 𧒍	jiji	0
@@ -47242,6 +47344,7 @@ encoder:
 𠹻	jqag	0
 㕨	jqda	4220
 𠯥	jqed	0
+𫝜	jqfn	0
 𪡿	jqhb	0
 叽叽	jqjq	763000
 剈	jqkd	22600
@@ -48733,6 +48836,7 @@ encoder:
 𫎇	kdag	0
 𣥠	kdai	0
 师	kdal	416000000
+𫝌	kdao	0
 𩇧	kday	0
 𣥠	kdbi	0
 𤯶	kdbm	0
@@ -48977,6 +49081,7 @@ encoder:
 𣌁	kgbm	0
 𣌂	kgbm	0
 晇	kgbz	47500
+𫝝	kgcm	0
 光热	kgdq	757000
 晨报	kgdy	17400000
 𪰫	kgee	0
@@ -49446,6 +49551,7 @@ encoder:
 㽘	kisq	4210
 甲亢	kisq	3140000
 畩	kisr	106000
+𫞫	kisr	0
 申辩	kiss	1180000
 𤱗	kisu	0
 申说	kisv	119000
@@ -50163,6 +50269,7 @@ encoder:
 𪃅	kokr	0
 𪇁	kokr	0
 𦂗	kokz	0
+𫠝	kokz	0
 𡮝	kolb	0
 尙	kold	948000
 尚	kold	224000000
@@ -51999,6 +52106,7 @@ encoder:
 同情	lduc	25500000
 𦊮	lduf	0
 同类	ldug	53900000
+𫝍	ldui	0
 𠕚	lduk	0
 𦌞	lduk	0
 岡	ldul	11000000
@@ -53341,6 +53449,7 @@ encoder:
 𡹣	llaj	0
 𡼪	llaj	0
 𧯶	llaj	0
+𫝴	llaj	0
 嵗	llak	418000
 𠝦	llak	0
 𡻷	llak	0
@@ -53448,6 +53557,7 @@ encoder:
 𡼙	llbz	0
 𡼰	llbz	0
 𡾀	llbz	0
+𫝵	llcd	0
 㟖	llce	3750
 𡷟	llce	0
 嶯	llch	38600
@@ -54661,6 +54771,7 @@ encoder:
 𡴰	llyz	0
 𪨭	llyz	0
 𪨮	llyz	0
+𫝳	llyz	0
 乢	llza	56200
 屿	llza	3540000
 𡼺	llzb	0
@@ -55429,6 +55540,7 @@ encoder:
 覞	lrlr	36700
 骶骨	lrlw	177000
 𧢅	lrlw	0
+𫞳	lrmb	0
 𧠑	lrmh	0
 购租	lrml	51500
 购物	lrmr	207000000
@@ -57560,6 +57672,7 @@ encoder:
 𣂩	mebp	0
 䳠	mebr	4110
 䳯	mebr	3880
+𫟚	mebr	0
 熏	mebu	14000000
 𤋱	mebu	0
 𢛲	mebw	0
@@ -57681,6 +57794,7 @@ encoder:
 䉈	meqm	4570
 埀	merb	882000
 垂危	merg	2920000
+𫞽	merh	0
 𥰄	merj	0
 𠝍	merk	0
 𡹁	merl	0
@@ -57872,6 +57986,7 @@ encoder:
 𥢚	mfbz	0
 𪏳	mfbz	0
 𫁂	mfbz	0
+𫞷	mfbz	0
 䭰	mfcb	4480
 𥴇	mfcb	0
 𪐃	mfcb	0
@@ -57961,6 +58076,7 @@ encoder:
 䵔	mffk	5550
 𨋟	mffk	0
 𩠼	mffk	0
+𫞸	mffk	0
 𫂡	mffl	0
 𥢖	mffm	0
 𪅌	mffr	0
@@ -59724,6 +59840,7 @@ encoder:
 𥯕	mkro	0
 箟	mkrr	188000
 𥯡	mkrr	0
+𫞾	mkrr	0
 𥮀	mkrs	0
 䈓	mkry	4320
 复读	mkse	6370000
@@ -60825,6 +60942,7 @@ encoder:
 乘坐	mtoo	12400000
 𥵬	mtop	0
 乘船	mtpq	2190000
+𫞿	mtsf	0
 𫂃	mtso	0
 简谱	mtsu	711000
 简讯	mtsy	4340000
@@ -61643,6 +61761,7 @@ encoder:
 𢞋	najw	0
 例题	naka	1890000
 何时	nakd	31100000
+𫝊	nakd	0
 俨	nakm	1180000
 便	nako	437000000
 𠏊	nako	0
@@ -61743,6 +61862,7 @@ encoder:
 𧷈	nbal	0
 𠔜	nbao	0
 𦦲	nbao	0
+𫟋	nbao	0
 𦥩	nbaq	0
 䶄	nbau	3980
 毁灭	nbau	16000000
@@ -61857,6 +61977,7 @@ encoder:
 𢾌	nbix	0
 𪔿	nbix	0
 𪕽	nbix	0
+𫝯	nbiy	0
 𡡋	nbiz	0
 𡡼	nbiz	0
 𥽳	nbjc	0
@@ -63855,6 +63976,8 @@ encoder:
 僼	nkju	60200
 皚	nkju	188000
 𤾢	nkju	0
+𫝋	nkju	0
+𫟪	nkjw	0
 曁	nkka	136000
 𤽔	nkka	0
 㒦	nkkb	4530
@@ -64001,6 +64124,7 @@ encoder:
 偶然	nkrg	35900000
 㑼	nkrj	4200
 𤽥	nkrj	0
+𫞮	nkrj	0
 偶尔	nkrk	33800000
 𣇙	nkrk	0
 𣼙	nkrk	0
@@ -64244,6 +64368,7 @@ encoder:
 𪖡	nlgy	0
 自转	nlhb	971000
 𪖺	nlhr	0
+𫝙	nlia	0
 𧑉	nlii	0
 𪖚	nlij	0
 𣊅	nlik	0
@@ -65452,6 +65577,7 @@ encoder:
 𪝴	nwgy	0
 偏转	nwhb	799000
 𠋤	nwhb	0
+𫝈	nwhe	0
 偏上	nwiv	538000
 𠐏	nwju	0
 𠑅	nwju	0
@@ -66252,6 +66378,7 @@ encoder:
 𨍻	odaf	0
 𠇄	odag	0
 𠓱	odag	0
+𫝆	odag	0
 𠁄	odai	0
 𠁥	odai	0
 𠓪	odai	0
@@ -66330,6 +66457,7 @@ encoder:
 𪜬	odbk	0
 𡎬	odbl	0
 𢁭	odbl	0
+𫝆	odbm	0
 𠐸	odbn	0
 𠊍	odbo	0
 𢒐	odbp	0
@@ -66342,6 +66470,7 @@ encoder:
 𨤾	odbu	0
 佥	odbv	450000
 𢚒	odbw	0
+𫝹	odbw	0
 𪠩	odbx	0
 入场	odby	8020000
 𨛏	odby	0
@@ -66419,6 +66548,7 @@ encoder:
 𢒃	odip	0
 𠆪	odir	0
 𪅰	odir	0
+𫝇	odis	0
 㪁	odix	4010
 㪧	odix	4140
 敆	odix	375000
@@ -66859,6 +66989,7 @@ encoder:
 倉	odxj	9650000
 含	odxj	171000000
 𠑐	odxj	0
+𫝉	odxj	0
 龣	odxk	22700
 𣲎	odxk	0
 貪	odxl	5380000
@@ -67017,6 +67148,7 @@ encoder:
 𢖌	oiak	0
 䘙	oial	4010
 衞	oial	367000
+𫟙	oial	0
 𢖉	oiam	0
 衟	oian	24000
 𧗡	oian	0
@@ -67195,6 +67327,7 @@ encoder:
 𢔸	oijl	0
 𢔹	oijl	0
 𢕪	oijl	0
+𫟘	oijl	0
 㣲	oijm	4200
 徫	oijm	76900
 衛	oijm	17200000
@@ -69275,6 +69408,7 @@ encoder:
 𨮾	pbjd	0
 鎱	pbjr	572000
 𨯨	pbju	0
+𫟱	pbkd	0
 𫒨	pbki	0
 銢	pbkv	36000
 銾	pbkv	22600
@@ -69498,6 +69632,7 @@ encoder:
 逓	pdlw	85200
 遁	pdlw	6120000
 𨟊	pdly	0
+𫟬	pdly	0
 丘县	pdlz	600000
 𧖴	pdml	0
 𧗃	pdml	0
@@ -69761,6 +69896,7 @@ encoder:
 针线	pezh	1170000
 针织	pezj	11900000
 鑉	pezl	22200
+𫠁	pezl	0
 𨦵	pezo	0
 𨰂	pezu	0
 釆	pfaa	3770000
@@ -69937,6 +70073,7 @@ encoder:
 錛	pgee	292000
 锛	pgee	2540000
 䥄	pgek	6640
+𫠀	pgek	0
 𨮭	pgep	0
 须要	pgfv	1860000
 须根	pgfx	435000
@@ -69998,6 +70135,7 @@ encoder:
 銍	phba	46000
 鉽	phbi	51200
 鋞	phbi	70000
+𫟸	phbi	0
 𧸶	phbl	0
 钱票	phfb	107000
 铙	phgr	268000
@@ -70316,6 +70454,7 @@ encoder:
 𨭍	pkwz	0
 铛	pkxb	1960000
 铿	pkxb	624000
+𫟰	pkxb	0
 𨦻	pkym	0
 翻建	pkyx	668000
 鎉	pkyy	26000
@@ -70564,6 +70703,7 @@ encoder:
 𨯥	pmrr	0
 铁证	pmsa	888000
 𨧰	pmtr	0
+𫟽	pmtr	0
 䤣	pmua	5690
 锤炼	pmuh	1520000
 鍬	pmuo	1230000
@@ -70756,6 +70896,7 @@ encoder:
 𨯣	poyb	0
 鈖	poyd	89000
 锉刀	poyd	394000
+𫟴	poyd	0
 𨩣	poyl	0
 兵力	poym	6160000
 鎓	poyy	38100
@@ -70962,6 +71103,7 @@ encoder:
 䝖	pqpv	3520
 貈	pqpy	28400
 銏	pqqa	1120000
+𫟶	pqqa	0
 貐	pqqk	49000
 䝘	pqqx	3620
 铅印	pqra	224000
@@ -71049,6 +71191,7 @@ encoder:
 𧲳	pqzo	0
 貀	pqzz	30100
 𨩰	pram	0
+𫟾	pram	0
 𨭶	prbi	0
 欣喜	prbj	19700000
 𦗦	prce	0
@@ -71320,6 +71463,7 @@ encoder:
 鋶	pszn	218000
 锍	pszn	231000
 䤤	pszo	9520
+𫟺	pszo	0
 錥	pszq	41400
 𨯤	pszq	0
 𫓾	pszq	0
@@ -71371,6 +71515,7 @@ encoder:
 镰刀	ptyd	1950000
 鉱	ptzs	904000
 鎈	pubi	45100
+𫟿	pubi	0
 𨨤	pubz	0
 𨧂	puek	0
 𨯆	puek	0
@@ -71586,6 +71731,7 @@ encoder:
 𤨐	pvnc	0
 𩥓	pvnc	0
 銂	pvnd	44700
+𫟻	pvnd	0
 𤔥	pvnf	0
 𠞞	pvnk	0
 𢅁	pvnl	0
@@ -71817,6 +71963,7 @@ encoder:
 鍕	pwfk	1660000
 鏈	pwfk	9290000
 𨩔	pwfs	0
+𫟼	pwgd	0
 鎵	pwgq	1940000
 镓	pwgq	659000
 錑	pwgs	90100
@@ -72488,6 +72635,7 @@ encoder:
 𫇝	pyxx	0
 𫒶	pyxz	0
 釲	pyyb	20300
+𫟳	pyyb	0
 舠	pyyd	62400
 𦨇	pyyd	0
 𦩣	pyyg	0
@@ -72564,6 +72712,7 @@ encoder:
 𨥡	pzqd	0
 鈗	pzrd	44100
 鏘	pzrd	856000
+𫟵	pzrd	0
 𨮳	pzru	0
 𫔒	pzru	0
 𨰽	pzrz	0
@@ -72813,6 +72962,7 @@ encoder:
 飑	qdor	462000
 风	qdos	312000000
 𠘰	qdos	0
+𫠇	qdos	0
 几个	qdov	170000000
 𫖽	qdox	0
 几分	qdoy	26900000
@@ -72842,6 +72992,7 @@ encoder:
 𠘵	qduz	0
 脙	qdvs	437000
 𫗋	qdwm	0
+𫠈	qdwm	0
 𫗁	qdwx	0
 𫗂	qdwx	0
 𫗈	qdwy	0
@@ -73367,6 +73518,7 @@ encoder:
 𦛉	qjli	0
 䐣	qjlo	4510
 脶	qjlo	43700
+𫞆	qjma	0
 䐃	qjmf	5350
 臊气	qjmy	66300
 𦛗	qjnj	0
@@ -73685,6 +73837,7 @@ encoder:
 㹽	qmhh	4960
 犽	qmhi	620000
 𢦖	qmhm	0
+𫞣	qmhm	0
 𤞄	qmhr	0
 𤡚	qmhr	0
 𤞉	qmhs	0
@@ -74275,6 +74428,7 @@ encoder:
 狁	qmzr	52000
 獗	qmzr	310000
 𤞀	qmzr	0
+𫞤	qmzr	0
 獡	qmzu	46400
 𤡯	qmzu	0
 𤢒	qmzu	0
@@ -74705,6 +74859,7 @@ encoder:
 𫆝	qtdm	0
 𦟉	qteb	0
 𦙒	qted	0
+𫟊	qtel	0
 𦟟	qtff	0
 𦟏	qtfk	0
 𦣆	qtfk	0
@@ -74821,6 +74976,7 @@ encoder:
 膌	qvoq	44700
 脳	qvoz	29000000
 𦞓	qvpr	0
+𫞇	qvqb	0
 朓	qvrd	160000
 脁	qvrd	59000
 月亮	qvsj	31200000
@@ -74904,6 +75060,7 @@ encoder:
 狠毒	qxcz	2410000
 𦟼	qxdm	0
 狠抓	qxdp	6640000
+𫞅	qxds	0
 䏔	qxed	3610
 𦟌	qxeh	0
 腒	qxej	28100
@@ -75403,6 +75560,7 @@ encoder:
 䱨	rflk	7350
 鰊	rflk	361000
 𩼜	rfll	0
+𫠎	rflo	0
 𩸳	rfmo	0
 条例	rfna	112000000
 𩽤	rfnj	0
@@ -75419,6 +75577,7 @@ encoder:
 𫙤	rfsq	0
 𩺹	rfsy	0
 𩵦	rfvv	0
+𫠏	rfvv	0
 𩻕	rfwr	0
 鱈	rfxb	2010000
 鳕	rfxb	2340000
@@ -75453,6 +75612,7 @@ encoder:
 䱳	rgkb	25700
 𫚆	rgkg	0
 𩻻	rgkk	0
+𫝖	rgko	0
 𩸆	rgkz	0
 鮞	rgla	58500
 鲕	rgla	89200
@@ -75499,6 +75659,7 @@ encoder:
 危害	rgwc	70100000
 危房	rgws	1650000
 𩸺	rgxk	0
+𫝖	rgxk	0
 危难	rgxn	2510000
 鮁	rgxs	26200
 鲅	rgxs	544000
@@ -76585,6 +76746,7 @@ encoder:
 𩺟	rnxm	0
 䱸	rnxs	12000
 𩹹	rnxs	0
+𫠑	rnxs	0
 𫙨	rnxx	0
 𩺫	rnym	0
 𩼾	rnzu	0
@@ -76660,6 +76822,7 @@ encoder:
 鮜	rpaj	96600
 鲘	rpaj	48900
 𩷴	rpay	0
+𫠍	rped	0
 鰩	rpez	71100
 鳐	rpez	257000
 鰀	rpgx	53900
@@ -76758,6 +76921,7 @@ encoder:
 𪉆	rrkr	0
 毕业	rrku	126000000
 𩷛	rrld	0
+𫞲	rrlg	0
 眞	rrlo	6770000
 𠤤	rrlo	0
 𧴦	rrlo	0
@@ -76926,9 +77090,11 @@ encoder:
 夡	rsbj	30500
 𠶰	rsbj	0
 祭	rsbk	81500000
+𫞴	rsbk	0
 留坝	rsbl	140000
 𡖚	rsbn	0
 𩼆	rsbr	0
+𫝣	rsbs	0
 𨝋	rsby	0
 𡖮	rsbz	0
 𪠞	rsbz	0
@@ -76944,6 +77110,7 @@ encoder:
 頯	rseg	24900
 𡖻	rsel	0
 𪤾	rseq	0
+𫝢	rses	0
 𡕛	rseu	0
 𤍙	rseu	0
 㩼	rsex	3810
@@ -77024,6 +77191,7 @@ encoder:
 𪤿	rskb	0
 𡭫	rskd	0
 鱆	rske	68300
+𫠒	rske	0
 㚌	rskf	4360
 𤑗	rskf	0
 𨑊	rskg	0
@@ -77145,6 +77313,7 @@ encoder:
 𡖅	rsrr	0
 𦠺	rsrr	0
 𪀩	rsrr	0
+𫠔	rsrr	0
 多	rsrs	1730000000
 𡖇	rsrs	0
 𡖑	rsrs	0
@@ -77946,6 +78115,7 @@ encoder:
 𠣎	ryzz	0
 𠣖	ryzz	0
 烏	rzaa	13500000
+𫠓	rzaa	0
 𩾝	rzae	0
 䴌	rzag	4130
 𪃆	rzag	0
@@ -78794,6 +78964,7 @@ encoder:
 諫	sflk	1120000
 谏	sflk	6170000
 䜖	sflo	3590
+𫟢	sflo	0
 亲眼	sflx	8780000
 𠣂	sfly	0
 新县	sflz	1040000
@@ -81009,6 +81180,7 @@ encoder:
 辩护	ssdw	6310000
 譲	sser	2480000
 讓	sser	190000000
+𫟝	sser	0
 𧭼	ssfl	0
 諒	ssjk	2380000
 谅	ssjk	2750000
@@ -81130,6 +81302,7 @@ encoder:
 𫁢	suad	0
 𥫉	suae	0
 谈天	suag	2640000
+𫞻	suai	0
 竒	suaj	319000
 𥩤	suaj	0
 𥩻	suaj	0
@@ -81273,6 +81446,7 @@ encoder:
 𥩰	suhx	0
 𥩡	suhz	0
 𦁋	suhz	0
+𫞼	suib	0
 𥩖	suid	0
 𩐮	suie	0
 𣥢	suii	0
@@ -81348,6 +81522,7 @@ encoder:
 章	suke	158000000
 竨	suke	52900
 𥪮	suke	0
+𫟠	suke	0
 𩐣	sukg	0
 𩐳	sukg	0
 𩐻	sukg	0
@@ -81465,6 +81640,7 @@ encoder:
 𪿁	suml	0
 産	summ	34200000
 谈笑	summ	3910000
+𫝸	sumo	0
 彦	sump	11800000
 𣫡	sumq	0
 竷	sumr	725000
@@ -81507,6 +81683,7 @@ encoder:
 谥	suol	2140000
 𧶜	suol	0
 𤙺	suom	0
+𫝸	suom	0
 𧱘	suon	0
 𥪂	suoo	0
 𥪐	suoo	0
@@ -81787,6 +81964,7 @@ encoder:
 誴	swbk	23000
 諠	swbk	326000
 𧫲	swbk	0
+𫟡	swbk	0
 䜔	swbq	3630
 𧨎	swbr	0
 𧬻	swbu	0
@@ -82304,6 +82482,7 @@ encoder:
 旞	syug	26100
 词类	syug	308000
 𣄚	syug	0
+𫞁	syug	0
 记性	syum	2670000
 𣃛	syuo	0
 𣄡	syuu	0
@@ -82350,6 +82529,7 @@ encoder:
 𡟕	syyz	0
 旀	syzk	743000
 词组	syzl	6250000
+𫞀	syzm	0
 旈	syzn	663000
 旒	syzn	319000
 𪔉	syzn	0
@@ -82448,6 +82628,7 @@ encoder:
 𠡤	szny	0
 㐪	szod	4610
 亥	szod	5500000
+𫝅	szod	0
 頦	szog	614000
 颏	szog	694000
 刻	szok	70400000
@@ -82784,6 +82965,7 @@ encoder:
 头	tdgd	340000000
 𣂇	tdgk	0
 𪟅	tdgk	0
+𫝏	tdgp	0
 𠗇	tdgu	0
 𠗊	tdhb	0
 㭍	tdhf	4250
@@ -82848,6 +83030,7 @@ encoder:
 凟	tdll	28400
 凗	tdln	30200
 𪞗	tdlo	0
+𫝎	tdlr	0
 闭眼	tdlx	2290000
 𫑫	tdly	0
 𠘅	tdlz	0
@@ -83618,6 +83801,7 @@ encoder:
 𢈣	tgnr	0
 𪇛	tgnr	0
 𪈲	tgnr	0
+𫠕	tgnr	0
 譍	tgns	28000
 𢋗	tgnu	0
 應	tgnw	46000000
@@ -83630,6 +83814,7 @@ encoder:
 廛	tgob	496000
 瘞	tgob	111000
 𢊃	tgob	0
+𫝶	tgob	0
 庂	tgod	25000
 广德	tgoe	1070000
 𢈰	tgoe	0
@@ -83857,6 +84042,7 @@ encoder:
 㡽	tgxb	3860
 廜	tgxb	26500
 𢉆	tgxb	0
+𫝷	tgxb	0
 𢉹	tgxf	0
 𩒯	tgxg	0
 头皮	tgxi	7250000
@@ -84244,6 +84430,7 @@ encoder:
 㿂	tlcm	7320
 阚	tlcm	1050000
 闭	tldm	57500000
+𫞭	tldm	0
 痶	tleo	25500
 门票	tlfb	17100000
 门禁	tlff	9760000
@@ -84306,6 +84493,7 @@ encoder:
 	tlob	0
 闪	tlod	99200000
 阏	tlot	369000
+𫠂	tlow	0
 门外	tlri	19200000
 阁	tlrj	58400000
 阍	tlrk	487000
@@ -85439,6 +85627,7 @@ encoder:
 𨂝	uakj	0
 普	uakk	177000000
 𣹅	uakk	0
+𫝐	uakk	0
 𢃬	uakl	0
 𢡍	uakl	0
 𢡤	uakl	0
@@ -85605,6 +85794,7 @@ encoder:
 𢆉	ubaa	0
 𦍍	ubaa	0
 半天	ubag	28000000
+𫝤	ubag	0
 𢞄	ubaj	0
 半百	uban	685000
 𪫭	ubaz	0
@@ -85754,6 +85944,7 @@ encoder:
 劵	ubym	2760000
 𤙻	ubym	0
 㥘	ubys	4370
+𫟩	ubyw	0
 勌	ubyy	26200
 卷	ubyy	124000000
 巻	ubyy	47300000
@@ -85891,6 +86082,7 @@ encoder:
 㪨	ucix	4200
 𢼝	ucix	0
 𫅟	ucix	0
+𫝥	ucix	0
 𦎘	ucja	0
 𪬮	ucjc	0
 䍰	ucjd	4000
@@ -86050,6 +86242,7 @@ encoder:
 精良	ucsx	12100000
 羪	ucsx	29800
 養	ucsx	23300000
+𫝥	ucsx	0
 𫑩	ucsy	0
 㕗	ucsz	4220
 精装	uctb	26100000
@@ -86059,6 +86252,7 @@ encoder:
 精度	uctv	19000000
 𩱋	ucua	0
 𫅓	ucuc	0
+𫟈	ucud	0
 䫞	ucug	3490
 情怀	ucug	16800000
 精美	ucug	64300000
@@ -86273,6 +86467,7 @@ encoder:
 𤭌	udys	0
 𤮐	udys	0
 為	udyu	453000000
+𫞟	udyu	0
 递	udyw	27600000
 𢚖	udyw	0
 䎖	udyy	3640
@@ -86527,6 +86722,7 @@ encoder:
 䊛	uffq	3490
 𢟼	uffr	0
 𥽰	uffu	0
+𫟀	uffx	0
 𥹂	ufga	0
 𡔇	ufgb	0
 类	ufgd	534000000
@@ -88793,6 +88989,7 @@ encoder:
 𤑞	uowf	0
 𤑱	uowf	0
 𨍶	uowf	0
+𫞡	uowf	0
 䃕	uowg	4320
 𤌫	uowg	0
 𤐶	uowg	0
@@ -88919,6 +89116,7 @@ encoder:
 𤍝	uoxu	0
 𤏌	uoxu	0
 𤑙	uoxu	0
+𫞠	uoxu	0
 惗	uoxw	62400
 焾	uoxw	274000
 煺	uoxw	55100
@@ -90264,6 +90462,7 @@ encoder:
 𣾸	vdai	0
 湁	vdaj	917000
 兴	vdao	90200000
+𫠘	vdbk	0
 𤃧	vdbu	0
 厳	vdcm	1010000
 戦	vdeh	45000000
@@ -90302,6 +90501,7 @@ encoder:
 峃	vdwl	108000
 覚	vdwl	1980000
 觉	vdwl	57500000
+𫞢	vdwm	0
 鲎	vdwr	713000
 鴬	vdwr	177000
 鸴	vdwr	23400
@@ -90346,6 +90546,7 @@ encoder:
 𣸣	veel	0
 瀻	veeo	338000
 潮	veeq	47500000
+𫞙	vees	0
 𣿯	veex	0
 𪷒	veez	0
 灌木	vefa	4780000
@@ -90406,6 +90607,7 @@ encoder:
 漕	vekk	2770000
 𣿻	vekk	0
 𤄠	vekl	0
+𫞞	vekn	0
 潢	veko	1680000
 㵧	vekr	6540
 湖畔	veku	11600000
@@ -91207,6 +91409,7 @@ encoder:
 温带	vkew	1030000
 消协	vkey	2960000
 𣾙	vkfv	0
+𫞜	vkfv	0
 消极	vkfy	9690000
 油酸	vkfz	1120000
 油压	vkgb	1070000
@@ -91272,6 +91475,7 @@ encoder:
 混同	vkld	3880000
 温	vklk	91100000
 𣹉	vklk	0
+𫞜	vklk	0
 潎	vklm	74200
 温岭	vklo	3460000
 溑	vklo	21400
@@ -91394,6 +91598,7 @@ encoder:
 澲	vkuc	23500
 𣾴	vkuc	0
 濧	vkud	35500
+𫞜	vkuf	0
 灦	vkug	441000
 油烟	vkuj	6590000
 混养	vkun	311000
@@ -91970,6 +92175,7 @@ encoder:
 𤃙	vnue	0
 渊	vnuf	17400000
 澳	vnug	63800000
+𫞘	vnug	0
 潐	vnuo	394000
 𪇶	vnur	0
 淮河	vnva	2360000
@@ -92432,6 +92638,7 @@ encoder:
 𤂂	vsbj	0
 灨	vsbl	40400
 㶆	vsbm	4400
+𫞛	vsbm	0
 游走	vsbo	6300000
 𣿞	vsbr	0
 流动	vsbz	36100000
@@ -92745,11 +92952,13 @@ encoder:
 𤄟	vtoj	0
 渡船	vtpq	1390000
 澬	vtrl	77800
+𫞚	vtrl	0
 𣳩	vtro	0
 𣼀	vtrp	0
 𪶻	vtrq	0
 𣷳	vtrs	0
 润色	vtry	841000
+𫞗	vtso	0
 𪸇	vtub	0
 𤃱	vtuf	0
 瀌	vtuo	32600
@@ -92765,6 +92974,7 @@ encoder:
 滽	vtxl	27700
 𣷄	vtxo	0
 𣾩	vtxu	0
+𫞝	vtzr	0
 𣿕	vtzu	0
 㳕	vubd	3940
 溠	vubi	115000
@@ -93998,6 +94208,7 @@ encoder:
 社论	wbso	2960000
 远离	wbso	20900000
 远望	wbsq	4160000
+𫟨	wbsr	0
 空谈	wbsu	1500000
 远方	wbsy	16300000
 空闲	wbtf	5310000
@@ -94406,6 +94617,7 @@ encoder:
 𡩫	wdjy	0
 𨜱	wdjy	0
 𨝃	wdjy	0
+𫟭	wdjy	0
 𡫤	wdjz	0
 定量	wdka	9290000
 过量	wdka	6310000
@@ -94466,10 +94678,12 @@ encoder:
 𡩯	wdkz	0
 𡪫	wdkz	0
 𡫤	wdkz	0
+𫝰	wdkz	0
 寕	wdla	145000
 寧	wdla	13600000
 过目	wdla	2640000
 𡩬	wdla	0
+𫝱	wdla	0
 㝤	wdlb	4370
 寗	wdlb	68400
 𡩋	wdlb	0
@@ -96163,6 +96377,7 @@ encoder:
 宿州	wnvn	4310000
 迫害	wnwc	10800000
 邉	wnwj	299000
+𫟪	wnwj	0
 窗帘	wnwl	12800000
 𨘢	wnwl	0
 宿迁	wnwm	7090000
@@ -96272,6 +96487,7 @@ encoder:
 𥦈	wofj	0
 𥩉	wofk	0
 𥨾	wofl	0
+𫞺	wofl	0
 𥥇	wofs	0
 𥧞	wofx	0
 𥤮	wogd	0
@@ -96412,6 +96628,7 @@ encoder:
 𥨷	woll	0
 𥩐	woll	0
 𥩓	woll	0
+𫞺	woll	0
 𥨇	wolm	0
 窉	wolo	63900
 窝	wolo	30800000
@@ -97002,6 +97219,7 @@ encoder:
 𥙖	wseo	0
 𥜥	wseo	0
 禳	wser	577000
+𫞶	wseu	0
 䃽	wsex	4570
 䄁	wsez	7030
 祹	wsez	492000
@@ -97358,6 +97576,7 @@ encoder:
 𥚹	wswl	0
 𥛣	wswl	0
 𨘛	wswl	0
+𫞵	wswl	0
 祕	wswm	1890000
 𨖱	wswm	0
 房客	wswr	3390000
@@ -98291,6 +98510,7 @@ encoder:
 灾难	wuxn	19000000
 灾民	wuyh	2260000
 递加	wuyj	64500
+𫟩	wuyy	0
 递	wuyz	27600000
 逆	wuzi	81200000
 𫐷	wuzm	0
@@ -99063,6 +99283,7 @@ encoder:
 𨓁	wzzz	0
 乛	xaaa	175000
 𠃍	xaaa	0
+𫝀	xaaa	0
 𡵽	xaal	0
 马列	xaar	2930000
 𨚑	xaay	0
@@ -99892,6 +100113,7 @@ encoder:
 𡚽	xezm	0
 展出	xezz	11300000
 骠	xfbk	1140000
+𫠌	xfbk	0
 骦	xffl	32100
 𩨉	xfjk	0
 骑	xgaj	87600000
@@ -100213,6 +100435,7 @@ encoder:
 群组	xjzl	8260000
 𩎥	xjzm	0
 𩏨	xjzn	0
+𫠄	xjzo	0
 𩏰	xjzu	0
 𩎢	xjzx	0
 壁垒	xjzz	5360000
@@ -100700,6 +100923,7 @@ encoder:
 𣪍	xmqq	0
 㞍	xmqs	4220
 𦡍	xmqs	0
+𫝲	xmqs	0
 尻	xmqy	24400000
 尾鳍	xmrb	273000
 𡊴	xmrb	0
@@ -101491,6 +101715,7 @@ encoder:
 𠬾	xszz	0
 𠭴	xszz	0
 𥎐	xszz	0
+𫠊	xszz	0
 骥	xteo	5120000
 买卖	xtex	97700000
 买票	xtfb	3210000
@@ -102348,6 +102573,7 @@ encoder:
 𡡙	ygqz	0
 𨻢	yguo	0
 𨺕	yguy	0
+𫝡	ygwb	0
 𫕇	ygyb	0
 阨	ygyy	636000
 䧅	ygyz	3470
@@ -102676,6 +102902,7 @@ encoder:
 隙	ykkk	7880000
 𨻶	ykkk	0
 𨼗	ykkk	0
+𫠃	ykku	0
 阳电	ykkz	131000
 𨺷	ykld	0
 阳山	ykll	805000
@@ -102871,6 +103098,7 @@ encoder:
 𨻾	ymoe	0
 𣏻	ymof	0
 改行	ymoi	23500000
+𫞰	ymol	0
 盈余	ymom	3440000
 𦙲	ymoo	0
 𨼹	ymoo	0
@@ -102892,6 +103120,7 @@ encoder:
 延误	ymsj	4690000
 䪪	ymsk	3920
 𠚵	ymsk	0
+𫞯	ymsl	0
 䲯	ymsr	3610
 袈	ymsr	512000
 㤂	ymsw	7880
@@ -103045,6 +103274,7 @@ encoder:
 𨹉	yokv	0
 𫅮	yokz	0
 𫅲	yokz	0
+𫞯	yolk	0
 险峰	yolr	1440000
 险峻	yolz	2840000
 除	yomf	184000000
@@ -103700,6 +103930,7 @@ encoder:
 𨼭	ywoy	0
 随后	ywpa	53500000
 𡓗	ywqb	0
+𫝡	ywqb	0
 随处	ywri	6270000
 𨻮	ywrm	0
 𫕂	ywrq	0
@@ -103798,6 +104029,7 @@ encoder:
 民	yybh	154000000
 翼城	yybh	494000
 𢁎	yybh	0
+𫞖	yybh	0
 蟁	yybi	45700
 𧊈	yybi	0
 𧓹	yybi	0
@@ -105690,6 +105922,7 @@ encoder:
 𡟪	zmal	0
 𡠱	zmal	0
 𡣓	zmal	0
+𫝬	zmal	0
 㚦	zman	4110
 㜚	zman	4220
 嬶	zman	443000
@@ -105733,7 +105966,9 @@ encoder:
 媗	zmbk	117000
 𡛭	zmbk	0
 𡢱	zmbk	0
+𫝫	zmbk	0
 𡟫	zmbl	0
+𫝪	zmbl	0
 媎	zmbm	37200
 𡢝	zmbm	0
 𦇃	zmbm	0
@@ -105782,6 +106017,7 @@ encoder:
 𪦊	zmbz	0
 𡞗	zmcb	0
 𡤙	zmcc	0
+𫝩	zmcd	0
 㛅	zmce	3770
 㛞	zmce	3610
 𪥽	zmch	0
@@ -105901,6 +106137,7 @@ encoder:
 𡤅	zmfl	0
 𪥱	zmfl	0
 𪦡	zmfl	0
+𫝮	zmfl	0
 𡡵	zmfm	0
 㜛	zmfr	4230
 𡠇	zmfw	0
@@ -106169,6 +106406,7 @@ encoder:
 媑	zmkb	29000
 嬞	zmkb	148000
 緟	zmkb	208000
+𫟆	zmkb	0
 婔	zmkc	49000
 𠚰	zmkd	0
 㜤	zmke	4590
@@ -106300,6 +106538,7 @@ encoder:
 嫃	zmlo	104000
 嬹	zmlo	26300
 𡛦	zmlo	0
+𫝦	zmlo	0
 娊	zmlr	481000
 收购	zmlr	47400000
 𡢚	zmls	0
@@ -106307,10 +106546,12 @@ encoder:
 𡤁	zmlu	0
 嫚	zmlx	1090000
 𡡆	zmlx	0
+𫝧	zmly	0
 媀	zmlz	34900
 孆	zmlz	37800
 𡟠	zmlz	0
 𡢞	zmlz	0
+𫝭	zmlz	0
 妊	zmmb	1670000
 姙	zmmb	240000
 娗	zmmb	63700
@@ -106781,6 +107022,7 @@ encoder:
 𡡪	zmwg	0
 𧰺	zmwg	0
 嬯	zmwh	23200
+𫝨	zmwh	0
 𪦱	zmwi	0
 婶	zmwk	1220000
 㛿	zmwl	5220
@@ -107102,6 +107344,7 @@ encoder:
 綿	znli	14500000
 绵	znli	5370000
 絍	znmb	76200
+𫟃	znmb	0
 绵竹	znmi	732000
 维和	znmj	2700000
 维修	znni	90600000
@@ -107601,6 +107844,7 @@ encoder:
 刣	zsjk	33500
 綡	zsjk	58400
 𠫩	zsjk	0
+𫟅	zsjk	0
 縞	zsjl	1800000
 缟	zsjl	437000
 𥁐	zsjl	0
@@ -107931,6 +108175,7 @@ encoder:
 缠住	ztns	2320000
 纏	ztob	4710000
 𦆲	ztop	0
+𫟇	ztop	0
 絘	ztro	162000
 䋳	ztrq	3710
 娴熟	ztsj	2430000
@@ -108135,6 +108380,7 @@ encoder:
 𫄫	zwgs	0
 编码	zwgx	93900000
 綋	zwgz	399000
+𫟄	zwgz	0
 婉转	zwhb	3200000
 𦄔	zwhb	0
 𦈉	zwhe	0
@@ -108174,6 +108420,7 @@ encoder:
 𦇶	zwoi	0
 𫃻	zwoj	0
 缩微	zwol	530000
+𫟂	zwot	0
 编创	zwoy	407000
 𦇶	zwoy	0
 缤	zwpo	24400000
@@ -108240,6 +108487,7 @@ encoder:
 䋖	zxbd	4180
 绎	zxbi	1170000
 经	zxbi	423000000
+𫟁	zxbq	0
 绿地	zxbv	6610000
 𦄥	zxbw	0
 纽埃	zxbz	365000
@@ -108304,6 +108552,7 @@ encoder:
 经受	zxpw	12100000
 𦅛	zxqd	0
 经脉	zxqs	2290000
+𫟁	zxqx	0
 绿肥	zxqy	444000
 𦂋	zxrf	0
 䌵	zxri	4210

--- a/zhengma.dict.yaml
+++ b/zhengma.dict.yaml
@@ -835,6 +835,7 @@ encoder:
 巿	ali	2690000
 帀	ali	187000
 丽	all	115000000
+𪩲	alm	0
 丙	alo	47400000
 迊	alw	57300
 𨙶	aly	0
@@ -940,7 +941,9 @@ encoder:
 坛	bbz	81100000
 埡	bbz	539000
 𡋱	bce	0
+𪣌	bce	0
 㙊	bch	4480
+𪢽	bci	0
 𡋃	bck	0
 堾	bco	23400
 埥	bcq	583000
@@ -952,21 +955,25 @@ encoder:
 𤣪	bdf	0
 亍	bdi	903000
 亘	bdk	1820000
+𪰛	bdk	0
 井	bdn	45100000
 寺	bds	49200000
 邿	bdy	49000
 亏	bdz	21100000
 亐	bdz	84600
 坩	beb	220000
+𪤏	beb	0
 㙋	bec	4110
 𡈿	bed	0
 墳	bee	1660000
 堞	bef	306000
 𡎡	bef	0
 𡊜	bej	0
+𪣤	bek	0
 垬	beo	230000
 墙	beu	78200000
 堪	bez	28600000
+𪣅	bez	0
 𡊖	bfa	0
 埔	bfb	12200000
 堙	bfb	312000
@@ -1005,6 +1012,7 @@ encoder:
 𡎪	bib	0
 圤	bid	105000
 赴	bid	59400000
+𪢱	bid	0
 壉	big	54400
 㙈	bih	4510
 址	bii	54000000
@@ -1014,6 +1022,8 @@ encoder:
 𢀛	bij	0
 墟	bik	4400000
 盐	bil	37400000
+𪤭	bio	0
+𪣩	biq	0
 五	bix	796000000
 𡊊	bix	0
 𢀑	bix	0
@@ -1056,6 +1066,7 @@ encoder:
 𡊰	bki	0
 𡌩	bkk	0
 𣆇	bkk	0
+𪣧	bkk	0
 趟	bkl	29000000
 嫠	bkm	250000
 釐	bkm	2970000
@@ -1063,10 +1074,12 @@ encoder:
 㙕	bkq	4030
 趙	bkq	13200000
 𡌔	bkq	0
+𪣦	bkq	0
 埸	bkr	3410000
 𡑿	bku	0
 堤	bkv	23000000
 𡉺	bkv	0
+𪢿	bkv	0
 塌	bky	7500000
 礼	bkz	5750000
 𡏱	bkz	0
@@ -1080,6 +1093,7 @@ encoder:
 𡉅	bld	0
 𡉉	bld	0
 𡊤	bld	0
+𪣰	ble	0
 堝	blj	1920000
 圸	bll	56300
 賣	bll	88800000
@@ -1107,11 +1121,13 @@ encoder:
 趱	bmr	314000
 趲	bmr	37800
 煮	bmu	49600000
+𪣇	bmw	0
 䎞	bmx	3480
 垖	bmy	43100
 教	bmy	250000000
 都	bmy	1370000000
 𡉛	bmy	0
+𪜕	bmz	0
 𡍤	bnb	0
 堭	bnc	43600
 𡌏	bnc	0
@@ -1171,6 +1187,7 @@ encoder:
 鞏	bqe	743000
 垛	bqf	2820000
 堸	bqi	51300
+𪣈	bqj	0
 堋	bqq	586000
 坍	bqs	982000
 𡉕	bqs	0
@@ -1208,10 +1225,13 @@ encoder:
 趨	brz	4170000
 𡊲	bsc	0
 垶	bse	942000
+𪢷	bsh	0
 壠	bsi	54400
 培	bsj	26800000
+𪣠	bsj	0
 堷	bsk	51900
 境	bsk	96300000
+𪣉	bsk	0
 壞	bsl	24300000
 熬	bsm	28200000
 坟	bso	7250000
@@ -1220,7 +1240,9 @@ encoder:
 垃	bsu	150000000
 坊	bsy	123000000
 垓	bsz	602000
+𪢷	bsz	0
 𡒲	btb	0
+𪣐	btb	0
 圹	btg	316000
 壙	btg	253000
 趑	btr	98100
@@ -1254,10 +1276,12 @@ encoder:
 𥑟	bwg	0
 壶	bwk	22100000
 𡉴	bwm	0
+𪣊	bwm	0
 坹	bwo	26500
 壳	bwq	43600000
 殻	bwq	7680000
 坨	bwr	2250000
+𪣬	bwy	0
 志	bwz	122000000
 𡉾	bwz	0
 𡋀	bwz	0
@@ -1266,6 +1290,7 @@ encoder:
 𡍜	bxd	0
 坡	bxi	29500000
 吾	bxj	34000000
+𪣣	bxj	0
 墹	bxk	60000
 堳	bxl	33900
 声	bxm	391000000
@@ -1277,6 +1302,7 @@ encoder:
 馨	bxq	38600000
 坭	bxr	539000
 㘮	bxs	6050
+𪢲	bxs	0
 燾	bxu	196000
 堀	bxz	6810000
 孝	bya	17900000
@@ -1299,6 +1325,7 @@ encoder:
 起	byy	634000000
 𡉖	byz	0
 𥿚	byz	0
+𪣂	byz	0
 亞	bza	48200000
 堊	bzb	181000
 𡉵	bzb	0
@@ -1322,6 +1349,7 @@ encoder:
 去	bzs	695000000
 运	bzw	361000000
 迲	bzw	171000
+𪢳	bzx	0
 却	bzy	343000000
 坶	bzy	102000
 𨚫	bzy	0
@@ -1338,6 +1366,7 @@ encoder:
 玒	cbi	135000
 髻	cbj	2810000
 𤥐	cbj	0
+𪻘	cbk	0
 琽	cbm	23200
 耕	cbn	11400000
 玩	cbr	372000000
@@ -1351,6 +1380,7 @@ encoder:
 聶	ccc	1560000
 珥	cce	1430000
 聽	cce	66200000
+𪻠	cce	0
 琹	ccf	111000
 玤	cci	26500
 酆	ccl	652000
@@ -1379,6 +1409,7 @@ encoder:
 瑚	cej	1570000
 瑾	cej	5880000
 𦔻	cej	0
+𪻕	cej	0
 𤦘	cek	0
 瑛	cel	5980000
 珙	ceo	1160000
@@ -1389,6 +1420,7 @@ encoder:
 𤦧	cew	0
 耶	cey	62200000
 𨛓	cey	0
+𫆀	cey	0
 㻣	cez	4600
 玴	cez	101000
 耴	cez	52800
@@ -1411,6 +1443,7 @@ encoder:
 㺽	cga	4250
 琦	cga	13900000
 騎	cga	15200000
+𪻗	cgb	0
 㺯	cgd	4070
 耨	cgd	642000
 馱	cgd	892000
@@ -1423,6 +1456,7 @@ encoder:
 㺴	cgs	3810
 琢	cgs	3790000
 髮	cgx	26100000
+𪼅	cgy	0
 珬	cha	21900
 長	cha	159000000
 𤥇	chb	0
@@ -1468,6 +1502,7 @@ encoder:
 珿	cji	67000
 㻁	cjj	3810
 噩	cjj	1320000
+𪡅	cjj	0
 聖	cjm	39400000
 职	cjo	93200000
 琄	cjq	129000
@@ -1487,6 +1522,7 @@ encoder:
 𦓧	cko	0
 琑	ckq	35600
 𤦛	ckq	0
+𪻪	ckq	0
 琨	ckr	1870000
 璟	cks	3830000
 璞	cku	3210000
@@ -1506,6 +1542,9 @@ encoder:
 𤤢	cld	0
 𤤪	cld	0
 𤦇	cld	0
+𪻛	cld	0
+𪻣	cld	0
+𪻫	cld	0
 琠	cle	83800
 瑞	clg	102000000
 𤧗	clj	0
@@ -1544,6 +1583,9 @@ encoder:
 瑝	cnc	89900
 玔	cnd	43400
 髹	cnf	336000
+𪻜	cnf	0
+𪻼	cnf	0
+𪼛	cnf	0
 碧	cng	43500000
 玳	cnh	907000
 琟	cni	22300
@@ -1576,6 +1618,7 @@ encoder:
 鬚	cpg	2260000
 璠	cpk	292000
 瑶	cpm	14400000
+𪻤	cpo	0
 𤤐	cps	0
 𤣺	cpv	0
 璦	cpw	344000
@@ -1631,12 +1674,14 @@ encoder:
 駭	csz	5600000
 㼅	ctg	5200
 驥	ctr	930000
+𪼥	ctu	0
 瑭	ctx	556000
 𤨞	ctx	0
 馬	cua	99400000
 𩡶	cub	0
 珜	cuc	535000
 班	cuc	221000000
+𪻮	cuc	0
 㻂	cue	4810
 馵	cue	50500
 𩡧	cue	0
@@ -1649,6 +1694,7 @@ encoder:
 璔	cul	27300
 耿	cuo	6740000
 𩡩	cuo	0
+𪻓	cuo	0
 𩢋	cuq	0
 璘	cur	850000
 𩥭	cur	0
@@ -1672,7 +1718,9 @@ encoder:
 耽	cwr	3330000
 琯	cwy	553000
 恥	cwz	9040000
+𪻒	cwz	0
 肆	cxb	7490000
+𪼙	cxc	0
 聚	cxg	113000000
 玻	cxi	16200000
 珺	cxj	1430000
@@ -1680,6 +1728,7 @@ encoder:
 瑂	cxl	37100
 珢	cxo	28200
 取	cxs	423000000
+𪻍	cxs	0
 玛	cxv	51300000
 聂	cxx	8410000
 𤧨	cxy	0
@@ -1687,6 +1736,7 @@ encoder:
 㺭	cya	4460
 耔	cya	927000
 𤤻	cyc	0
+𪲑	cyf	0
 契	cyg	23600000
 耙	cyi	2310000
 玿	cyj	98000
@@ -1727,9 +1777,11 @@ encoder:
 㨋	dbm	4030
 拷	dbm	6580000
 扶	dbo	31800000
+𪭴	dbo	0
 挟	dbu	5500000
 捂	dbx	22800000
 𢵋	dby	0
+𪭝	dby	0
 扝	dbz	29700
 掗	dbz	1530000
 揍	dca	9350000
@@ -1842,6 +1894,7 @@ encoder:
 挰	djc	32900
 㧢	djd	3690
 捆	djf	9700000
+𪭷	djf	0
 摑	djh	663000
 捉	dji	18000000
 𢪠	dji	0
@@ -1901,18 +1954,21 @@ encoder:
 搰	dlw	80200
 撾	dlw	106000
 擺	dlz	12300000
+𪭨	dma	0
 𢪧	dmb	0
 𢪭	dmb	0
 抙	dmd	30500
 扦	dme	1160000
 抍	dme	33300
 𣕔	dmf	0
+𪮅	dmf	0
 托	dmh	74600000
 括	dmi	4830000
 捁	dmj	88800
 𢯙	dmj	0
 挿	dmk	867000
 攥	dml	2830000
+𪮑	dml	0
 撬	dmm	5670000
 插	dmn	148000000
 𢪛	dmo	0
@@ -2024,6 +2080,7 @@ encoder:
 拘	drj	11100000
 挌	drj	484000
 𢬸	drj	0
+𪮇	drj	0
 㧦	drk	4650
 指	drk	226000000
 捪	drk	19900
@@ -2040,6 +2097,7 @@ encoder:
 扚	drs	35600
 抵	drs	33800000
 揈	drs	59600
+𪭜	drs	0
 搀	drt	1610000
 掬	dru	4020000
 拸	drv	757000
@@ -2050,6 +2108,7 @@ encoder:
 拄	dsc	2830000
 𢪴	dse	0
 攏	dsi	1890000
+𪮳	dsi	0
 掊	dsj	270000
 𢭹	dsj	0
 揞	dsk	69300
@@ -2075,16 +2134,19 @@ encoder:
 抖	dte	18700000
 攠	dtf	86100
 𢭩	dtf	0
+𪮾	dtf	0
 扩	dtg	16000000
 擴	dtg	3370000
 掂	dti	6310000
 扪	dtl	664000
+𪭾	dtq	0
 揹	dtr	1600000
 搁	dtr	9110000
 攗	dtu	49200
 摝	dtx	123000
 拌	dub	21000000
 𢭭	dub	0
+𪭰	duc	0
 拼	due	61600000
 撙	duf	193000
 𢬊	duf	0
@@ -2186,6 +2248,7 @@ encoder:
 𢩵	dyy	0
 㧈	dyz	4090
 𢪬	dyz	0
+𪭿	dzb	0
 拚	dze	6390000
 掺	dzg	7820000
 掾	dzg	777000
@@ -2244,6 +2307,7 @@ encoder:
 𤯆	ebs	0
 𧨅	ebs	0
 荚	ebu	1390000
+𫇩	ebx	0
 苇	eby	7530000
 邯	eby	2850000
 𦭎	eby	0
@@ -2336,6 +2400,7 @@ encoder:
 茜	efj	18100000
 莕	efj	92900
 𦴖	efj	0
+𫇿	efj	0
 莗	efk	26400
 菄	efk	47200
 蕾	efk	51300000
@@ -2404,6 +2469,7 @@ encoder:
 荿	ehy	153000
 藏	ehz	146000000
 𦀂	ehz	0
+𫇮	ehz	0
 䒙	eia	4140
 𦱱	eie	0
 萀	eih	29700
@@ -2411,6 +2477,7 @@ encoder:
 𧏊	eii	0
 苫	eij	1850000
 蘋	eik	2120000
+𫇰	eik	0
 夔	ein	1700000
 𧀤	eio	0
 茈	eir	336000
@@ -2438,6 +2505,7 @@ encoder:
 𦬹	eka	0
 荲	ekb	40400
 𦯖	ekb	0
+𫇾	ekb	0
 菲	ekc	59500000
 莳	ekd	689000
 戴	eke	91800000
@@ -2486,6 +2554,8 @@ encoder:
 𦯶	eld	0
 𦱌	eld	0
 𧁧	eld	0
+𫇪	eld	0
+𫈂	eld	0
 矗	ele	3860000
 萛	ele	55000
 𦯛	ele	0
@@ -2524,6 +2594,7 @@ encoder:
 䓡	emj	8780
 萂	emj	145000
 𦮽	emj	0
+𫈗	emj	0
 萫	emk	119000
 薰	eml	28600000
 薙	emn	1260000
@@ -2543,6 +2614,7 @@ encoder:
 𦵐	enb	0
 葟	enc	32700
 苻	end	696000
+𫇨	end	0
 萆	ene	192000
 𦻧	ene	0
 茠	enf	154000
@@ -2574,6 +2646,7 @@ encoder:
 𦱉	enz	0
 𢌰	eoa	0
 蔹	eob	182000
+𫇲	eob	0
 荃	eoc	4230000
 𦫸	eod	0
 茶	eof	154000000
@@ -2593,6 +2666,7 @@ encoder:
 苓	eow	5900000
 䓹	eox	3860
 葎	eox	437000
+𫇧	eox	0
 芬	eoy	33300000
 蓊	eoz	488000
 𦬆	eoz	0
@@ -2618,6 +2692,7 @@ encoder:
 荽	epz	1090000
 𦷲	epz	0
 十月	eqa	49800000
+𫈃	eqc	0
 芁	eqd	21700
 䒳	eqf	4260
 获	eqg	150000000
@@ -2640,6 +2715,7 @@ encoder:
 𦰔	erf	0
 芪	erh	633000
 𧊮	eri	0
+𫈖	eri	0
 苟	erj	3820000
 茖	erj	151000
 茗	erj	12200000
@@ -2688,16 +2764,19 @@ encoder:
 芠	eso	288000
 𦬩	eso	0
 裁	esr	8110000
+𫊂	ess	0
 苙	esu	73000
 蒂	esu	44700000
 芳	esy	55400000
 蓄	esz	20900000
 荘	etb	9620000
 薼	etb	38800
+𫇺	etb	0
 蔗	ete	1750000
 蘑	etf	1340000
 蘼	etf	2090000
 燕	etj	64400000
+𫈉	etk	0
 蒺	etm	116000
 蔺	etn	2400000
 茨	etr	24100000
@@ -2984,6 +3063,7 @@ encoder:
 枻	fez	165000
 椹	fez	3000000
 櫀	fez	34500
+𪱻	ffa	0
 埜	ffb	1240000
 禁	ffb	86400000
 𣑛	ffb	0
@@ -3026,6 +3106,7 @@ encoder:
 𥒯	fgb	0
 𣒸	fgc	0
 杕	fgd	47100
+𪥄	fgd	0
 㮟	fgf	3900
 颥	fgg	54200
 桭	fgh	53900
@@ -3071,6 +3152,7 @@ encoder:
 杶	fhz	77300
 𣐋	fhz	0
 椒	fia	19800000
+𪱲	fia	0
 朴	fid	17800000
 𣖪	fif	0
 醵	fig	182000
@@ -3082,6 +3164,7 @@ encoder:
 棹	fik	1720000
 𣐤	fik	0
 楨	fil	1300000
+𪲈	fil	0
 𣔨	fiq	0
 榩	fis	22800
 枵	fja	204000
@@ -3100,6 +3183,7 @@ encoder:
 梱	fjf	10900000
 𣒛	fjf	0
 𣙳	fjf	0
+𪲖	fjf	0
 槶	fjh	359000
 樻	fji	1960000
 𣐄	fji	0
@@ -3115,6 +3199,7 @@ encoder:
 梋	fjq	36500
 𧟩	fjq	0
 露	fjr	94600000
+𫌺	fjs	0
 束	fjv	22900000
 迺	fjw	852000
 速	fjw	272000000
@@ -3163,6 +3248,7 @@ encoder:
 東	fkv	137000000
 軣	fkv	28900
 𣏶	fkv	0
+𪱹	fkv	0
 檔	fkw	56900000
 連	fkw	126000000
 档	fkx	117000000
@@ -3184,9 +3270,11 @@ encoder:
 	fld	0
 𣐒	fld	0
 𣙡	fld	0
+𪱽	fld	0
 柵	fle	3740000
 棘	flf	7550000
 𣕱	flf	0
+𪲷	flf	0
 椯	flg	34200
 𣏑	fli	0
 楇	flj	48600
@@ -3198,6 +3286,7 @@ encoder:
 椇	flo	75600
 贾	flo	52600000
 𧴿	flo	0
+𪱷	flo	0
 𣙌	flp	0
 枧	flr	289000
 梘	flr	58200
@@ -3265,6 +3354,7 @@ encoder:
 靃	fnn	52700
 霓	fnr	6130000
 檄	fns	1530000
+𪲼	fns	0
 櫆	fnt	458000
 樵	fnu	5540000
 櫋	fnw	37000
@@ -3320,6 +3410,7 @@ encoder:
 𣔆	fpy	0
 桵	fpz	102000
 𣏵	fqa	0
+𪣖	fqb	0
 机	fqd	509000000
 𣑫	fqf	0
 楓	fqi	22600000
@@ -3376,6 +3467,7 @@ encoder:
 釀	fsj	2760000
 栐	fsk	98600
 靄	fsk	1660000
+𪳀	fsk	0
 柿	fsl	9480000
 敷	fsm	21500000
 霁	fsn	2280000
@@ -3399,6 +3491,7 @@ encoder:
 桩	ftb	11500000
 櫥	ftb	2330000
 枓	fte	179000
+𪲝	ftf	0
 櫎	ftg	136000
 㭣	ftj	4770
 榈	ftj	364000
@@ -3419,7 +3512,10 @@ encoder:
 𣜆	fus	0
 梯	fuy	9290000
 楼	fuz	444000000
+𪲛	fuz	0
+𪲞	fuz	0
 霈	fva	1180000
+𫕞	fvb	0
 𩂊	fvc	0
 霮	fve	28400
 雬	fvf	32400
@@ -3434,11 +3530,14 @@ encoder:
 𣓭	fvl	0
 酬	fvn	19000000
 霪	fvp	242000
+𪲚	fvq	0
+𫕟	fvq	0
 桃	fvr	46100000
 𩅔	fvr	0
 霅	fvs	144000
 樑	fvy	2160000
 𨜄	fvy	0
+𫕝	fvy	0
 柠	fwa	14300000
 檳	fwa	872000
 棕	fwb	9960000
@@ -3482,6 +3581,7 @@ encoder:
 桾	fxj	84300
 𣙎	fxj	0
 橺	fxk	28400
+𪳛	fxk	0
 桶	fxl	45700000
 楣	fxl	3950000
 橚	fxn	38900
@@ -3510,6 +3610,7 @@ encoder:
 𣏖	fyi	0
 枷	fyj	2360000
 柖	fyj	23000
+𪲂	fyk	0
 㭁	fym	4110
 朸	fym	186000
 柫	fyn	24900
@@ -3529,6 +3630,7 @@ encoder:
 蚻	fzi	47200
 枱	fzj	505000
 輜	fzk	939000
+𪱴	fzm	0
 酸	fzo	89500000
 擊	fzq	14500000
 梭	fzr	19800000
@@ -3596,6 +3698,7 @@ encoder:
 𧥢	gds	0
 𡗜	gdu	0
 达	gdw	393000000
+𪥁	gdx	0
 𥑠	geb	0
 𥕛	geb	0
 䃆	gec	4770
@@ -3627,6 +3730,7 @@ encoder:
 圧	ggb	4590000
 礪	gge	193000
 磊	ggg	21600000
+𪿟	ggh	0
 𥐴	ggi	0
 𥑛	ggj	0
 豳	ggl	341000
@@ -3641,8 +3745,10 @@ encoder:
 厌	ggs	8670000
 硺	ggs	26900
 燹	ggu	138000
+𪠃	ggx	0
 碱	gha	36200000
 𥒓	ghb	0
+𪣗	ghb	0
 辱	ghd	8940000
 砗	ghe	340000
 𣕥	ghf	0
@@ -3676,6 +3782,7 @@ encoder:
 还	giw	1050000000
 存	giy	175000000
 𨚀	giy	0
+𪿒	giy	0
 䂩	gjd	5560
 硱	gjf	38100
 𥒭	gji	0
@@ -3683,12 +3790,14 @@ encoder:
 硘	gjj	20800
 靣	gjj	84500
 面	gjk	905000000
+𪿠	gjq	0
 䂖	gjs	5070
 碍	gka	11700000
 𥑲	gka	0
 厘	gkb	40100000
 𥓄	gkb	0
 厞	gkc	85300
+𪿨	gkc	0
 矵	gkd	27200
 䂺	gkf	5080
 𥓖	gkf	0
@@ -3801,6 +3910,7 @@ encoder:
 𥑸	gpy	0
 磎	gpz	67300
 豕	gqa	3610000
+𫎅	gqa	0
 䝅	gqb	5050
 矶	gqd	2110000
 𢍒	gqe	0
@@ -3828,6 +3938,7 @@ encoder:
 𡯥	gri	0
 硌	grj	1020000
 𥒊	grj	0
+𪿕	grj	0
 碈	grk	83300
 𡯙	grk	0
 𡯟	grk	0
@@ -3849,6 +3960,7 @@ encoder:
 䲽	grz	3900
 鴀	grz	50700
 砫	gsc	163000
+𪿢	gse	0
 飆	gsg	6300000
 飙	gsg	6810000
 𥐞	gsh	0
@@ -3909,6 +4021,7 @@ encoder:
 𥐮	gxs	0
 码	gxv	274000000
 矷	gya	57200
+𪿓	gya	0
 𥐛	gyd	0
 頋	gyg	82300
 顾	gyg	41900000
@@ -3921,6 +4034,7 @@ encoder:
 𥐦	gyy	0
 夷	gyz	9030000
 𠚈	gzi	0
+𪿘	gzj	0
 碌	gzk	2560000
 耍	gzm	41300000
 雄	gzn	84700000
@@ -3995,6 +4109,7 @@ encoder:
 區	hjj	323000000
 轵	hjo	368000
 𠤴	hjo	0
+𪟯	hkb	0
 匪	hkc	16500000
 划	hkd	178000000
 匣	hki	22200000
@@ -4007,6 +4122,7 @@ encoder:
 盏	hlk	11100000
 医	hma	63300000
 戌	hma	7930000
+𪭉	hma	0
 𦣠	hmb	0
 𠤵	hmc	0
 戒	hme	34500000
@@ -4028,6 +4144,7 @@ encoder:
 𧩾	hms	0
 轷	hmu	51400
 成	hmy	723000000
+𫑝	hmy	0
 戉	hmz	62400
 𦃂	hmz	0
 雅	hni	142000000
@@ -4049,6 +4166,7 @@ encoder:
 暂	hpk	298000000
 錾	hpp	408000
 七月	hqa	34900000
+𪤀	hqb	0
 朢	hqc	755000
 𠙉	hqd	0
 㔯	hqj	7100
@@ -4146,6 +4264,7 @@ encoder:
 𧊗	ice	0
 𧋼	ice	0
 䗅	ich	3440
+𫊪	ich	0
 蚌	ici	3830000
 蟶	icj	218000
 𧋆	ick	0
@@ -4160,11 +4279,13 @@ encoder:
 占	idj	174000000
 䖞	ids	3370
 𡬝	ids	0
+𪟽	idy	0
 螨	iea	1790000
 蚶	ieb	822000
 蜞	iec	198000
 蝶	ief	54600000
 蟒	ieg	5450000
+𫋣	iei	0
 蛄	iej	287000
 蜡	iek	12900000
 蠛	iel	59200
@@ -4182,11 +4303,13 @@ encoder:
 蜙	ifo	22800
 蜥	ifp	1450000
 𧉱	ifs	0
+𫋃	ifv	0
 𧉹	ifz	0
 蚽	iga	48700
 蠣	ige	263000
 蜄	igh	32600
 𧉈	igi	0
+𫋏	igj	0
 劇	igk	36300000
 蛖	igm	23600
 螈	ign	319000
@@ -4204,10 +4327,12 @@ encoder:
 虐	ihh	16000000
 蚜	ihi	778000
 蜮	ihj	145000
+𫊝	ihj	0
 䖑	ihk	3760
 蝘	ihk	542000
 𧉦	ihm	0
 𧔼	ihm	0
+𫊣	ihr	0
 𧈺	ihs	0
 𧊥	ihs	0
 蚷	ihx	42400
@@ -4285,6 +4410,7 @@ encoder:
 𧊚	ild	0
 𧍑	ild	0
 𧌹	ilg	0
+𫎎	ili	0
 蝸	ilj	499000
 蛊	ilk	6670000
 蠱	ilk	800000
@@ -4309,14 +4435,17 @@ encoder:
 𧊉	imw	0
 螄	imy	30000
 𧎵	imy	0
+𫊨	imy	0
 𧋬	imz	0
 虧	inb	3830000
 𧌫	inb	0
 蝗	inc	4230000
+𫊾	inc	0
 蜵	ind	21200
 𧈶	ind	0
 蜱	ine	371000
 𣑞	inf	0
+𫋝	inf	0
 蜼	ini	35000
 䖮	inj	3480
 螝	inj	57100
@@ -4326,6 +4455,7 @@ encoder:
 齒	ioa	5400000
 齿	ioa	15400000
 𧊲	ioc	0
+𫊷	iof	0
 䶚	ioi	3500
 𧊽	ioi	0
 蛻	ioj	522000
@@ -4344,7 +4474,9 @@ encoder:
 蛌	ips	439000
 䖣	ipv	3510
 蟋	ipw	445000
+𫋅	ipw	0
 𧊓	ipy	0
+𫋄	ipy	0
 𧋵	iqc	0
 凣	iqd	38400
 虮	iqd	191000
@@ -4358,6 +4490,7 @@ encoder:
 蜂	irc	39200000
 柴	irf	25700000
 蟂	irf	21900
+𫋇	irf	0
 蟾	irg	2890000
 蚔	irh	493000
 𧎓	iri	0
@@ -4375,6 +4508,7 @@ encoder:
 鈭	irp	835000
 處	irq	71700000
 蚍	irr	128000
+𫊤	irr	0
 虳	irs	118000
 蚳	irs	611000
 𧈷	irs	0
@@ -4384,6 +4518,7 @@ encoder:
 紫	irz	138000000
 𧋧	isb	0
 蛀	isc	3290000
+𫋁	ise	0
 虻	ish	1070000
 蠬	isi	23500
 𧏎	isi	0
@@ -4406,6 +4541,7 @@ encoder:
 蛢	iue	22800
 𧏪	iuf	0
 𧑞	iui	0
+𫊦	iui	0
 蜕	iuj	1700000
 蝉	iuk	7600000
 蟻	ium	4780000
@@ -4415,6 +4551,7 @@ encoder:
 蜷	iuy	1720000
 壑	iwa	2830000
 蝊	iwd	26300
+𫋀	iwf	0
 螟	iwk	1730000
 蝙	iwl	291000
 䖩	iwm	4050
@@ -4642,6 +4779,7 @@ encoder:
 哐	jhc	288000
 𠮟	jhd	0
 㖑	jhe	3970
+𪠳	jhe	0
 跷	jhg	3240000
 踐	jhh	891000
 呀	jhi	395000000
@@ -4757,6 +4895,7 @@ encoder:
 𠰩	jld	0
 𠵜	jld	0
 𠵹	jld	0
+𪡔	jle	0
 啱	jlg	754000
 喘	jlg	19400000
 吊	jli	21600000
@@ -4840,6 +4979,7 @@ encoder:
 𠯯	jnx	0
 哈	joa	190000000
 㘴	job	7810
+𪠶	job	0
 跧	joc	38900
 𠱴	joc	0
 㕥	jod	4510
@@ -4847,6 +4987,7 @@ encoder:
 唏	jog	1500000
 哘	joi	186000
 𠮶	joi	0
+𪠷	joj	0
 啥	jom	94100000
 唑	joo	5080000
 嗲	joo	4040000
@@ -4870,10 +5011,12 @@ encoder:
 蹈	jpn	4410000
 𠴇	jpo	0
 躓	jpp	715000
+𪡊	jpq	0
 哌	jpr	1330000
 呱	jps	2930000
 嗳	jpw	2600000
 噯	jpw	2180000
+𪠾	jpy	0
 蹊	jpz	3170000
 叽	jqd	3170000
 哚	jqf	828000
@@ -4909,6 +5052,7 @@ encoder:
 呧	jrs	51200
 𠮭	jrs	0
 𠮻	jrs	0
+𪡡	jrs	0
 图	jrt	941000000
 哆	jrv	10100000
 咆	jry	1090000
@@ -5025,6 +5169,7 @@ encoder:
 叹	jxs	31500000
 呎	jxs	3500000
 𠽹	jxs	0
+𪠲	jxs	0
 嚍	jxu	75300
 吗	jxv	959000000
 嗓	jxx	2870000
@@ -5087,6 +5232,7 @@ encoder:
 题	kag	93700000
 町	kai	148000000
 𣄿	kai	0
+𪰏	kaj	0
 量	kak	723000000
 师	kal	416000000
 曬	kal	8860000
@@ -5096,11 +5242,15 @@ encoder:
 曉	kbb	15200000
 時	kbd	589000000
 𣄾	kbd	0
+𪰆	kbi	0
+𪰙	kbj	0
 晅	kbk	62800
 𣇖	kbk	0
 𥆤	kbl	0
 暏	kbm	169000
 暑	kbm	14500000
+𪰈	kbr	0
+𫙣	kbr	0
 里	kbv	616000000
 曀	kbw	86400
 野	kbx	90800000
@@ -5122,8 +5272,10 @@ encoder:
 𥇖	kcl	0
 暙	kco	474000
 晴	kcq	46600000
+𪰑	kcs	0
 旺	kcv	65500000
 最	kcx	1270000000
+𪰸	kcz	0
 刂	kda	1070000
 时	kds	850000000
 畢	keb	7450000
@@ -5139,6 +5291,7 @@ encoder:
 晎	keo	34700
 暴	keo	83300000
 𨚰	key	0
+𪰐	kfa	0
 晡	kfb	303000
 暷	kfd	29000
 晽	kff	48800
@@ -5200,10 +5353,12 @@ encoder:
 畏	kih	9940000
 𤱥	kih	0
 𤱻	kih	0
+𪰊	kii	0
 胃	kiq	30000000
 𤰾	kiq	0
 鴨	kir	9980000
 鸭	kir	25400000
+𪽟	kir	0
 思	kiw	179000000
 邮	kiy	95100000
 累	kiz	84500000
@@ -5237,6 +5392,7 @@ encoder:
 遝	kkw	133000
 㫣	kkz	6140
 𠃪	kkz	0
+𪱀	kkz	0
 𣅣	kla	0
 𣌬	kla	0
 曙	klb	7410000
@@ -5260,6 +5416,8 @@ encoder:
 曼	klx	64600000
 勖	kly	366000
 愚	klz	18100000
+𪰕	kma	0
+𪰖	kma	0
 𣅫	kmb	0
 𤘵	kmb	0
 星	kmc	393000000
@@ -5267,12 +5425,14 @@ encoder:
 昇	kme	13300000
 𣅮	kme	0
 戥	kmh	249000
+𪰌	kmh	0
 昨	kmi	72600000
 晧	kmj	203000
 临	kmk	61500000
 监	kml	70100000
 览	kml	65800000
 𣆢	kml	0
+𪰋	kmo	0
 鉴	kmp	36400000
 𣆅	kmw	0
 劣	kmy	17500000
@@ -5296,6 +5456,7 @@ encoder:
 昑	koa	91600
 尘	kob	34400000
 𡭤	koc	0
+𪰡	koc	0
 㬰	kod	9760
 𣅁	kod	0
 𡭛	koe	0
@@ -5330,6 +5491,7 @@ encoder:
 逍	kqw	1950000
 旯	kqy	664000
 晷	kri	352000
+𪰇	kri	0
 㫥	krj	4980
 昫	krj	124000
 略	krj	77600000
@@ -5420,6 +5582,7 @@ encoder:
 賞	kwl	55000000
 赏	kwl	81900000
 昈	kwm	43000
+𪰗	kwm	0
 党	kwr	116000000
 畹	kwr	934000
 裳	kws	5280000
@@ -5446,6 +5609,7 @@ encoder:
 㫗	kya	3930
 旫	kyd	14600
 昭	kyj	18800000
+𪰘	kyj	0
 男	kym	516000000
 𣅅	kym	0
 曊	kyn	31300
@@ -5460,6 +5624,7 @@ encoder:
 妟	kzm	51200
 曳	kzm	2710000
 𣅓	kzm	0
+𫌷	kzs	0
 电	kzv	606000000
 顯	kzz	11800000
 𣊡	kzz	0
@@ -5477,6 +5642,8 @@ encoder:
 𥅏	lak	0
 𥄚	lao	0
 睫	lax	2960000
+𪾧	lax	0
+𪾧	lay	0
 䀎	laz	6100
 屿	laz	3540000
 墨	lbb	90600000
@@ -5520,6 +5687,7 @@ encoder:
 𥉊	lcu	0
 䢸	lcy	3470
 𥆍	lcz	0
+𪾵	lcz	0
 𠀃	lda	0
 𠀇	lda	0
 𠔼	lda	0
@@ -5574,6 +5742,7 @@ encoder:
 賻	lfd	65400
 赙	lfd	161000
 𥆺	lfd	0
+𪾭	lff	0
 䀳	lfj	7130
 𥆪	lfj	0
 崠	lfk	518000
@@ -5608,6 +5777,7 @@ encoder:
 鴦	lgr	195000
 鸯	lgr	369000
 𥃺	lgr	0
+𪾡	lgr	0
 狊	lgs	34300
 炭	lgu	19400000
 販	lgx	9950000
@@ -5623,6 +5793,7 @@ encoder:
 嶇	lhj	1120000
 岽	lhk	295000
 贱	lhm	16200000
+𪾤	lhm	0
 岖	lho	225000
 崭	lhp	1290000
 嶜	lhr	23600
@@ -5673,6 +5844,7 @@ encoder:
 罼	lke	36100
 髁	lkf	860000
 𥇬	lkf	0
+𫅂	lkg	0
 岬	lki	7410000
 𠰝	lkj	0
 幌	lkk	2330000
@@ -5685,6 +5857,7 @@ encoder:
 𧵁	lkm	0
 𡭨	lko	0
 𦉵	lko	0
+𫅇	lkp	0
 䁌	lkq	6230
 睄	lkq	439000
 𦊈	lkq	0
@@ -5708,6 +5881,7 @@ encoder:
 𢌲	lle	0
 崾	llf	370000
 𡵬	llf	0
+𪳐	llf	0
 岩	llg	44300000
 𡶌	llg	0
 𥇷	llg	0
@@ -5726,6 +5900,7 @@ encoder:
 崯	llp	458000
 岄	llq	876000
 睍	llr	239000
+𪾢	llr	0
 訔	lls	33900
 㞫	llw	3740
 辿	llw	231000
@@ -5757,6 +5932,7 @@ encoder:
 幯	lmx	79100
 屹	lmy	1720000
 巍	lmz	7400000
+𪾬	lmz	0
 嶼	lna	2730000
 𥃹	lnd	0
 睥	lne	424000
@@ -5793,6 +5969,7 @@ encoder:
 嵢	los	25400
 岭	low	27200000
 嶺	low	6650000
+𪾧	low	0
 盼	loy	37400000
 郥	loy	27400
 骺	lpa	188000
@@ -5845,6 +6022,7 @@ encoder:
 𥋮	lrs	0
 𥋯	lrs	0
 𧠻	lrs	0
+𪾠	lrs	0
 眵	lrv	83300
 睁	lrx	42700000
 䀚	lry	5690
@@ -5859,6 +6037,7 @@ encoder:
 眿	lsk	86400
 罚	lsk	43000000
 罰	lsk	10100000
+𪾲	lsk	0
 𥇋	lsl	0
 嵼	lsm	32700
 盿	lso	111000
@@ -5901,6 +6080,7 @@ encoder:
 眺	lvr	5420000
 貯	lwa	1030000
 贮	lwa	4980000
+𪾣	lwa	0
 崇	lwb	33100000
 瞎	lwc	29100000
 𥇓	lwd	0
@@ -5920,6 +6100,7 @@ encoder:
 瞇	lwu	2220000
 𥋝	lwx	0
 䯆	lwz	3200
+𪫩	lwz	0
 瞪	lxa	19800000
 峄	lxb	1270000
 瞤	lxc	31900
@@ -5974,6 +6155,7 @@ encoder:
 笄	mae	871000
 秣	maf	832000
 𥬎	maf	0
+𪿈	maf	0
 舔	mag	9260000
 卸	mai	37300000
 𥫙	mai	0
@@ -6010,6 +6192,7 @@ encoder:
 筇	mby	280000
 𥳉	mby	0
 𨙼	mby	0
+𫁳	mby	0
 丢	mbz	46500000
 𣬛	mbz	0
 𥫡	mbz	0
@@ -6054,6 +6237,7 @@ encoder:
 午	med	18800000
 𠀆	med	0
 簙	mef	77200
+𫂋	mef	0
 箬	meg	817000
 䇢	mej	3740
 氪	mej	880000
@@ -6066,6 +6250,7 @@ encoder:
 𠄒	mem	0
 穫	men	941000
 𥬹	meo	0
+𫂣	meq	0
 舞	mer	131000000
 無	meu	338000000
 穑	meu	376000
@@ -6096,6 +6281,7 @@ encoder:
 和	mfj	1790000000
 𣏮	mfj	0
 香	mfk	210000000
+𫁿	mfk	0
 箱	mfl	233000000
 籗	mfn	31700
 䄴	mfq	4890
@@ -6121,6 +6307,7 @@ encoder:
 𠂚	mgm	0
 乔	mgn	31400000
 筴	mgo	96700
+𫁾	mgq	0
 稽	mgr	5530000
 𥫵	mgs	0
 𥬇	mgs	0
@@ -6148,7 +6335,9 @@ encoder:
 𥄥	mhl	0
 笺	mhm	2330000
 籃	mhm	11400000
+𫁸	mhm	0
 篋	mho	211000
+𪵗	mhq	0
 簪	mhr	2350000
 𥫝	mhs	0
 矩	mhx	34000000
@@ -6160,6 +6349,7 @@ encoder:
 𨙲	mhy	0
 𦧆	mia	0
 乍	mid	14600000
+𫁰	mid	0
 甜	mie	46400000
 穢	mih	1450000
 箎	mih	53900
@@ -6213,6 +6403,7 @@ encoder:
 复	mkr	83200000
 𥬃	mks	0
 𥴼	mku	0
+𫁺	mku	0
 𥫸	mkv	0
 馝	mkw	96300
 甥	mky	3000000
@@ -6432,10 +6623,13 @@ encoder:
 𦙪	mxq	0
 簢	mxs	30000
 𥫢	mxs	0
+𫁶	mxs	0
 笃	mxv	3350000
 節	mxy	51400000
+𫂉	mxy	0
 季	mya	54000000
 𥫞	mya	0
+𫁱	mya	0
 乞	myd	5090000
 阜	mye	17600000
 頧	myg	42100
@@ -6546,6 +6740,7 @@ encoder:
 倀	nch	96700
 㒥	nci	4440
 仹	nci	52900
+𫏪	nci	0
 𨈖	ncj	0
 㑍	nck	4440
 僵	nck	7870000
@@ -6603,6 +6798,7 @@ encoder:
 俥	nfk	110000
 倲	nfk	269000
 價	nfl	87900000
+𪝋	nfl	0
 輿	nfo	1180000
 鵂	nfr	52300
 鸺	nfr	99300
@@ -6661,6 +6857,7 @@ encoder:
 僭	nhr	1240000
 𩶕	nhr	0
 代	nhs	303000000
+𫌸	nhs	0
 佢	nhx	15500000
 𠉛	nhy	0
 𠇘	nhz	0
@@ -6688,6 +6885,7 @@ encoder:
 鬼	nja	123000000
 堡	njb	36300000
 侱	njc	28400
+𪜶	njd	0
 個	nje	282000000
 𢍉	nje	0
 保	njf	166000000
@@ -6700,6 +6898,7 @@ encoder:
 侣	njj	13400000
 侃	njn	20300000
 伿	njo	41200
+𫙈	njo	0
 𠉌	njq	0
 𩲞	njq	0
 𠇂	njs	0
@@ -6708,6 +6907,7 @@ encoder:
 𧫏	njs	0
 煲	nju	8860000
 仲	njv	61400000
+𪜭	njx	0
 𨝀	njy	0
 𩱺	njy	0
 俁	njz	76700
@@ -6719,6 +6919,7 @@ encoder:
 𠉶	nke	0
 倮	nkf	217000
 𣐩	nkf	0
+𪽻	nkf	0
 偎	nkh	2790000
 佃	nki	2190000
 𤼽	nki	0
@@ -6785,6 +6986,8 @@ encoder:
 𠇷	nmc	0
 㐿	nmd	4970
 仟	nme	4840000
+𪜰	nmf	0
+𪝉	nmf	0
 侨	nmg	14600000
 僑	nmg	6400000
 俄	nmh	47200000
@@ -6839,6 +7042,7 @@ encoder:
 佾	noq	1180000
 伦	nor	49700000
 囟	nos	307000
+𪜧	nos	0
 伶	now	9330000
 𠋡	nox	0
 份	noy	240000000
@@ -6852,6 +7056,7 @@ encoder:
 㑟	npo	4450
 𠉠	npq	0
 𠇗	nps	0
+𪜲	nps	0
 僾	npw	892000
 皈	npx	2270000
 侜	npy	49500
@@ -6883,6 +7088,7 @@ encoder:
 侚	nrk	119000
 𠉣	nrk	0
 𠐔	nrk	0
+𪜵	nrk	0
 貨	nrl	52000000
 货	nrl	240000000
 傑	nrm	21900000
@@ -7312,6 +7518,7 @@ encoder:
 忿	oyw	3270000
 邠	oyy	229000
 瓮	oza	1690000
+𪪳	oze	0
 枀	ozf	35200
 頌	ozg	3710000
 颂	ozg	9440000
@@ -7324,6 +7531,7 @@ encoder:
 鬯	ozr	3550000
 公	ozs	248000000
 翁	ozy	22700000
+𪞈	ozy	0
 後	ozz	423000000
 釪	pad	41400
 鈃	pae	39900
@@ -7341,6 +7549,8 @@ encoder:
 銬	pba	349000
 铐	pba	1830000
 銈	pbb	1680000
+𫒕	pbb	0
+𫓯	pbb	0
 釭	pbi	164000
 銡	pbj	117000
 銾	pbk	22600
@@ -7367,6 +7577,7 @@ encoder:
 铒	pce	390000
 鋹	pch	79100
 𨰘	pci	0
+𫒊	pci	0
 鑩	pcj	24400
 銇	pck	1220000
 𨩃	pco	0
@@ -7398,6 +7609,7 @@ encoder:
 鉗	peb	1210000
 钳	peb	6140000
 錤	pec	64500
+𫓹	pec	0
 針	ped	18700000
 针	ped	49200000
 鐼	pee	33800
@@ -7437,12 +7649,14 @@ encoder:
 𠳅	pfj	0
 𨧃	pfj	0
 𨱈	pfj	0
+𫒖	pfj	0
 錬	pfk	2970000
 镭	pfk	4680000
 鍊	pfl	15000000
 錸	pfo	675000
 彩	pfp	306000000
 鉥	pfs	65800
+𫒧	pfv	0
 鏈	pfw	9290000
 䣋	pfy	3320
 錷	pfz	22200
@@ -7453,6 +7667,7 @@ encoder:
 錛	pge	292000
 锛	pge	2540000
 鋠	pgh	47100
+𫓵	pgh	0
 鈈	pgi	683000
 钚	pgi	760000
 𨥰	pgj	0
@@ -7474,8 +7689,10 @@ encoder:
 銕	pgy	96200
 嬃	pgz	36600
 銊	pha	1520000
+𫓰	pha	0
 銍	phb	46000
 铚	phb	155000
+𫒞	phe	0
 铙	phg	268000
 錢	phh	59200000
 䥺	phi	14400
@@ -7487,6 +7704,7 @@ encoder:
 銭	phm	4740000
 钱	phm	333000000
 𨱆	phm	0
+𫓨	phm	0
 鐕	phr	430000
 釴	phs	68100
 鋮	phv	165000
@@ -7502,6 +7720,7 @@ encoder:
 鉞	phz	306000
 钺	phz	708000
 鉲	pia	172000
+𫒆	pia	0
 釙	pid	47300
 钋	pid	275000
 鐻	pig	34800
@@ -7533,6 +7752,7 @@ encoder:
 锅	pjl	29400000
 鉙	pjo	30300
 鋗	pjq	65100
+𫓶	pjq	0
 钟	pjv	244000000
 鉭	pka	99700
 钽	pka	1300000
@@ -7567,6 +7787,7 @@ encoder:
 𨭥	pku	0
 淾	pkv	26700
 鍉	pkv	73300
+𫒎	pkv	0
 鏜	pkw	149000
 镗	pkw	1070000
 铛	pkx	1960000
@@ -7623,6 +7844,7 @@ encoder:
 鋯	pmj	287000
 锆	pmj	2040000
 𨨛	pmj	0
+𫓼	pmj	0
 鍾	pmk	9100000
 锺	pmk	2710000
 𨩢	pml	0
@@ -7630,6 +7852,7 @@ encoder:
 锸	pmn	184000
 鉄	pmo	14200000
 铁	pmo	137000000
+𫒋	pmo	0
 鑽	pmr	9890000
 铣	pmr	4010000
 鍬	pmu	1230000
@@ -7644,6 +7867,7 @@ encoder:
 锈	pmy	19800000
 𨥊	pmy	0
 鋂	pmz	80900
+𫒠	pmz	0
 舀	pnb	2200000
 𨦁	pnb	0
 銵	pnc	101000
@@ -7756,6 +7980,7 @@ encoder:
 錉	prk	21000
 鑥	prk	29500
 镥	prk	136000
+𫓲	prk	0
 覛	prl	24000
 鉚	prm	186000
 铆	prm	2330000
@@ -7780,6 +8005,7 @@ encoder:
 铇	pry	55700
 钩	prz	14100000
 鵭	prz	20200
+𫒜	psb	0
 鉒	psc	337000
 鋅	pse	1760000
 锌	pse	14300000
@@ -7890,9 +8116,11 @@ encoder:
 悉	pwz	8270000
 鈊	pwz	1640000
 𨦂	pwz	0
+𫓳	pwz	0
 鐙	pxa	837000
 爭	pxb	17000000
 释	pxb	16700000
+𫒔	pxb	0
 𨬔	pxc	0
 鍆	pxd	115000
 鋸	pxe	2300000
@@ -7927,6 +8155,7 @@ encoder:
 釨	pya	416000
 𠔾	pya	0
 𨥂	pya	0
+𫓦	pya	0
 釖	pyd	62900
 㭧	pyf	4320
 鈱	pyh	87400
@@ -7970,6 +8199,7 @@ encoder:
 亂	pzl	43600000
 釹	pzm	988000
 钕	pzm	714000
+𫒈	pzm	0
 鋑	pzo	43800
 𨰼	pzp	0
 鏘	pzr	856000
@@ -8002,6 +8232,7 @@ encoder:
 肤	qbo	96000000
 𦛣	qbo	0
 朊	qbr	366000
+𫆖	qbs	0
 狭	qbu	5600000
 肚	qbv	40900000
 𦙗	qbx	0
@@ -8034,6 +8265,7 @@ encoder:
 𠙍	qdi	0
 肘	qds	15400000
 䢳	qdy	3880
+𫃛	qdz	0
 𦚕	qeb	0
 𦝁	qec	0
 䐙	qee	4020
@@ -8101,6 +8333,7 @@ encoder:
 肫	qhz	415000
 胩	qia	105000
 風	qia	145000000
+𪱚	qia	0
 𦘱	qid	0
 臄	qig	31500
 𦞐	qih	0
@@ -8109,6 +8342,7 @@ encoder:
 臚	qik	211000
 𦢠	qio	0
 𦜨	qiq	0
+𪱚	qiv	0
 𩖳	qiw	0
 胪	qix	924000
 脭	qjc	130000
@@ -8155,6 +8389,7 @@ encoder:
 胴	qld	5160000
 𦙸	qld	0
 𦝓	qld	0
+𪱣	qld	0
 腆	qle	5530000
 𦙱	qle	0
 腡	qlj	30400
@@ -8205,6 +8440,7 @@ encoder:
 𦛓	qnb	0
 𦞆	qnb	0
 凰	qnc	7190000
+𪱦	qnc	0
 𦘶	qnd	0
 脾	qne	6950000
 䏫	qnf	3260
@@ -8274,6 +8510,7 @@ encoder:
 胝	qrs	421000
 狰	qrx	6740000
 胞	qry	7840000
+𫆗	qry	0
 鳩	qrz	6340000
 鸠	qrz	4200000
 𩿊	qrz	0
@@ -8372,6 +8609,7 @@ encoder:
 𦚣	qxo	0
 𦠥	qxq	0
 肞	qxs	34800
+𪱙	qxs	0
 腿	qxw	84300000
 猱	qxx	352000
 䐚	qxy	3870
@@ -8432,6 +8670,7 @@ encoder:
 鮭	rbb	4770000
 鲑	rbb	863000
 魟	rbi	684000
+𫚉	rbi	0
 鮚	rbj	47100
 鲒	rbj	81600
 䱈	rbk	4490
@@ -8450,6 +8689,7 @@ encoder:
 𩸕	rch	0
 䰷	rci	3790
 鱷	rcj	972000
+𫙛	rck	0
 鰿	rcl	23500
 䲠	rco	27800
 鰆	rco	223000
@@ -8462,11 +8702,14 @@ encoder:
 鲰	rcx	84000
 𩸾	rcy	0
 鮿	rcz	22800
+𫚚	rcz	0
 𩵝	rdm	0
 鯄	rdv	43000
+𫃛	rdz	0
 魽	reb	50500
 鯕	rec	61000
 鲯	rec	49200
+𫙏	red	0
 鱝	ree	24600
 鲼	ree	75700
 鰈	ref	294000
@@ -8490,9 +8733,12 @@ encoder:
 鰈	rez	294000
 鲽	rez	486000
 䱁	rfa	7430
+𫚏	rfa	0
 鯆	rfb	62100
+𫚙	rfb	0
 鯂	rfd	17500
 𩺤	rff	0
+𫙘	rfj	0
 鯟	rfk	42200
 鯠	rfo	62700
 𩶄	rfs	0
@@ -8514,6 +8760,7 @@ encoder:
 顷	rgo	7280000
 鮪	rgq	2880000
 鲔	rgq	525000
+𫙠	rgq	0
 魷	rgr	1370000
 鱿	rgr	2960000
 然	rgs	97100000
@@ -8558,6 +8805,7 @@ encoder:
 象	rjg	191000000
 𩵵	rji	0
 鮰	rjj	247000
+𫚔	rjj	0
 雒	rjn	873000
 鮂	rjo	27600
 𩷫	rjq	0
@@ -8573,17 +8821,20 @@ encoder:
 𠜪	rkd	0
 鸔	rke	35100
 𩸄	rkf	0
+𫚝	rkf	0
 潁	rkg	663000
 鰃	rkh	47000
 鳂	rkh	31200
 备	rki	709000000
 甸	rki	15300000
+𫊱	rki	0
 鯧	rkk	95900
 鲳	rkk	906000
 𩷽	rkk	0
 鰻	rkl	3780000
 鳗	rkl	4050000
 魦	rkm	37400
+𫚌	rkm	0
 尔	rko	175000000
 𩵖	rko	0
 鮹	rkq	85400
@@ -8615,6 +8866,7 @@ encoder:
 𧢲	rld	0
 𩶠	rld	0
 𩸒	rld	0
+𫙑	rld	0
 𢍅	rle	0
 觫	rlf	105000
 奂	rlg	2100000
@@ -8699,6 +8951,7 @@ encoder:
 魜	rod	1030000
 𩶼	rof	0
 𩸈	roi	0
+𫙚	roi	0
 咎	roj	4640000
 刎	rok	578000
 鮽	rom	99600
@@ -8751,7 +9004,9 @@ encoder:
 鲍	rry	22100000
 𠨐	rry	0
 鷠	rrz	10700
+𪟨	rrz	0
 夊	rsa	2010000
+𪢶	rsb	0
 𩶃	rsc	0
 𢌳	rse	0
 𩷔	rse	0
@@ -8793,6 +9048,7 @@ encoder:
 麁	rtx	75000
 𩺮	rtx	0
 𩶐	rub	0
+𫙝	rub	0
 鮮	ruc	12700000
 鲜	ruc	41800000
 鮩	rue	31100
@@ -8820,7 +9076,9 @@ encoder:
 鳊	rwl	620000
 魲	rwm	56900
 鮅	rwm	28200
+𫚑	rwm	0
 鰫	rwo	34000
+𫙕	rwo	0
 鴕	rwr	77300
 鸵	rwr	400000
 迻	rwv	82700
@@ -8862,6 +9120,7 @@ encoder:
 𠣜	ryi	0
 𠤋	ryi	0
 𩵔	ryi	0
+𫙒	ryi	0
 句	ryj	179000000
 鮉	ryj	16800
 𩶛	ryj	0
@@ -9004,6 +9263,7 @@ encoder:
 𧧍	sfj	0
 諌	sfk	102000
 谭	sfk	29400000
+𫌼	sfk	0
 親	sfl	82000000
 谏	sfl	6170000
 誺	sfo	63200
@@ -9011,8 +9271,10 @@ encoder:
 訹	sfs	26700
 𣞇	sfs	0
 謰	sfw	40200
+𫌶	sga	0
 誇	sgb	1460000
 誫	sgh	21000
+𫍨	sgh	0
 㕻	sgj	3580
 斋	sgl	21400000
 產	sgm	19200000
@@ -9081,6 +9343,7 @@ encoder:
 詀	sij	115000
 𡃡	sij	0
 𧮪	sij	0
+𪜢	sik	0
 謯	sil	30300
 謼	sim	36700
 𠔂	sio	0
@@ -9090,6 +9353,7 @@ encoder:
 讋	sis	67100
 让	siv	694000000
 𧦫	six	0
+𫑰	siy	0
 誤	sja	17300000
 误	sja	92200000
 諿	sjc	28400
@@ -9147,12 +9411,14 @@ encoder:
 谡	sko	599000
 䥆	skp	5830
 銮	skp	845000
+𫒣	skp	0
 誚	skq	78400
 謂	skq	2930000
 诮	skq	408000
 谓	skq	9790000
 𠅥	skq	0
 𦚍	skq	0
+𪵵	skq	0
 竟	skr	93100000
 𧬬	sku	0
 氷	skv	9900000
@@ -9181,6 +9447,8 @@ encoder:
 𧧜	sld	0
 𧨋	sld	0
 𧨝	sld	0
+𫍣	sld	0
+𫍬	sld	0
 𢍓	sle	0
 𧧚	sle	0
 端	slg	128000000
@@ -9236,6 +9504,7 @@ encoder:
 𧪢	smy	0
 誨	smz	614000
 诲	smz	3360000
+𫌾	smz	0
 䜃	snb	4580
 譭	snb	144000
 𧧖	snb	0
@@ -9252,6 +9521,7 @@ encoder:
 褒	snj	3610000
 謉	snj	136000
 𧧦	snj	0
+𫍷	snj	0
 剂	snk	57400000
 詯	snl	25300
 亦	sno	122000000
@@ -9275,12 +9545,14 @@ encoder:
 蚉	soi	34900
 吝	soj	1670000
 刻	sok	70400000
+𪰎	sok	0
 离	sol	693000000
 𥄈	sol	0
 效	som	64300000
 交	soo	348000000
 診	sop	7170000
 诊	sop	8140000
+𪯧	sop	0
 𦙟	soq	0
 论	sor	132000000
 𩵳	sor	0
@@ -9377,7 +9649,9 @@ encoder:
 谚	ssm	1100000
 詨	sso	148000
 议	sso	55500000
+𫌴	sso	0
 襲	ssr	9610000
+𫌻	ssr	0
 譶	sss	32700
 辩	sss	14600000
 辯	sss	2300000
@@ -9469,6 +9743,7 @@ encoder:
 诐	sxi	49000
 諱	sxj	431000
 𧨡	sxj	0
+𫍋	sxj	0
 𧬘	sxk	0
 誦	sxl	1270000
 诵	sxl	5190000
@@ -9491,6 +9766,7 @@ encoder:
 氓	syh	1640000
 訑	syi	39300
 訠	syi	20500
+𫍙	syi	0
 詔	syj	1170000
 诏	syj	3420000
 𧦤	syj	0
@@ -9516,6 +9792,7 @@ encoder:
 𠲯	szj	0
 妄	szm	8510000
 娈	szm	1090000
+𫌳	szm	0
 刻	szo	70400000
 颏	szo	694000
 育	szq	70300000
@@ -9564,6 +9841,7 @@ encoder:
 闻	tce	82000000
 𤶦	tce	0
 痮	tch	23600
+𪽪	tch	0
 廒	tcr	87000
 癍	tcs	372000
 㾺	tcu	5450
@@ -9630,6 +9908,7 @@ encoder:
 𤷁	tgb	0
 𤷀	tgc	0
 头	tgd	340000000
+𪽲	tgd	0
 床	tgf	105000000
 庆	tgg	61900000
 库	tgh	622000000
@@ -9661,6 +9940,7 @@ encoder:
 阈	thj	1230000
 冻	thk	36900000
 戕	thm	372000
+𪽭	thm	0
 𤴵	ths	0
 丬	tia	283000
 壮	tib	22800000
@@ -9679,6 +9959,7 @@ encoder:
 阃	tjf	656000
 𤶭	tjf	0
 冲	tji	96900000
+𪽰	tji	0
 㾔	tjj	4820
 痐	tjj	196000
 癌	tjj	37800000
@@ -9717,6 +9998,7 @@ encoder:
 间	tlk	378000000
 疝	tll	1050000
 𤷢	tlo	0
+𫔮	tlq	0
 𤶻	tlr	0
 訚	tls	43500
 痈	tlv	845000
@@ -9778,6 +10060,7 @@ encoder:
 𤷕	tpf	0
 瘢	tpq	976000
 㽿	tps	8230
+𪽫	tpv	0
 阌	tpw	290000
 凈	tpx	2110000
 𤷸	tpy	0
@@ -9929,6 +10212,7 @@ encoder:
 𢗿	uaf	0
 关	uag	93600000
 忊	uai	280000
+𪫧	uaj	0
 粳	uak	932000
 𢘆	uak	0
 𣅑	uak	0
@@ -9940,6 +10224,7 @@ encoder:
 悽	uax	1500000
 𠔃	uaz	0
 𠔄	uaz	0
+𪫝	uaz	0
 烤	uba	30800000
 㤬	ubb	5080
 燒	ubb	28100000
@@ -10012,23 +10297,27 @@ encoder:
 𢛻	ueq	0
 慌	ues	21400000
 迸	uew	3260000
+𪫿	uew	0
 忮	uex	254000
 怈	uez	22200
 愖	uez	32700
 㤓	ufa	4580
 悑	ufb	154000
 煙	ufb	16100000
+𪬉	ufb	0
 精	ufc	220000000
 尊	ufd	30600000
 𥸭	ufe	0
 惏	uff	42000
 慄	uff	1700000
 奠	ufg	2200000
+𫂹	ufg	0
 𧊾	ufi	0
 恓	ufj	148000
 悚	ufj	11100000
 𢚷	ufk	0
 𢛔	ufk	0
+𫂵	ufk	0
 煉	ufl	5740000
 慚	ufp	336000
 𥺻	ufp	0
@@ -10080,12 +10369,14 @@ encoder:
 炼	uhy	30900000
 怴	uhz	58600
 𢜜	uih	0
+𪫣	uii	0
 怗	uij	75100
 粘	uij	60400000
 悼	uik	3020000
 爐	uik	6660000
 夔	uin	1700000
 燦	uir	3350000
+𪫢	uiy	0
 悜	ujc	633000
 烟	ujd	96800000
 𢙫	ujd	0
@@ -10137,6 +10428,7 @@ encoder:
 惘	uld	1160000
 𢘭	uld	0
 𢜟	uld	0
+𪫪	uld	0
 惴	ulg	1890000
 𢝸	ulj	0
 怬	ulk	44500
@@ -10191,6 +10483,7 @@ encoder:
 恰	uoa	17000000
 𤆂	uoa	0
 灶	uob	12500000
+𪢾	uob	0
 恮	uoc	20900
 𤆦	uoc	0
 灷	uoe	21200
@@ -10265,6 +10558,7 @@ encoder:
 炮	ury	28200000
 𢗾	ury	0
 炷	usc	1670000
+𪫬	usc	0
 忙	ush	107000000
 忭	usi	163000
 𢤱	usi	0
@@ -10427,6 +10721,7 @@ encoder:
 濤	vbx	3740000
 涍	vby	41400
 𣲗	vby	0
+𪵹	vby	0
 汚	vbz	5710000
 污	vbz	37300000
 𣲅	vbz	0
@@ -10453,6 +10748,7 @@ encoder:
 滠	vcx	142000
 潔	vcy	14400000
 𣵮	vcy	0
+𪶘	vcy	0
 㳧	vcz	9910
 溸	vcz	32300
 𣵱	vdc	0
@@ -10505,6 +10801,7 @@ encoder:
 濡	vfg	6800000
 洒	vfj	22200000
 涑	vfj	646000
+𪵾	vfj	0
 涷	vfk	165000
 潭	vfk	28800000
 𣵐	vfk	0
@@ -10542,6 +10839,7 @@ encoder:
 洧	vgq	287000
 漘	vgq	34600
 𣵠	vgq	0
+𫆬	vgq	0
 沋	vgr	52100
 𣲍	vgr	0
 𤀸	vgr	0
@@ -10572,6 +10870,7 @@ encoder:
 浳	vhq	33200
 潛	vhr	4730000
 㳚	vhs	4090
+𪵫	vhs	0
 汇	vhv	81900000
 涟	vhw	3510000
 洰	vhx	489000
@@ -10654,6 +10953,7 @@ encoder:
 澤	vlb	9320000
 𣲹	vlb	0
 沮	vlc	1550000
+𪶁	vlc	0
 泂	vld	185000
 洞	vld	27300000
 浻	vld	75000
@@ -10676,6 +10976,7 @@ encoder:
 滑	vlw	76100000
 濄	vlw	889000
 湃	vma	1120000
+𪵳	vma	0
 汼	vmb	81600
 𡎒	vmb	0
 泩	vmc	290000
@@ -10702,6 +11003,7 @@ encoder:
 洗	vmr	114000000
 湫	vmu	1240000
 涐	vmv	165000
+𪵯	vmv	0
 泛	vmw	68900000
 汽	vmy	72500000
 滊	vmy	556000
@@ -10761,6 +11063,7 @@ encoder:
 泝	vps	75000
 沠	vpv	25300
 𣲖	vpv	0
+𪵯	vpv	0
 淨	vpx	16000000
 洀	vpy	52800
 浮	vpy	32300000
@@ -10796,6 +11099,7 @@ encoder:
 洛	vrj	67900000
 洺	vrj	302000
 𣴠	vrj	0
+𪡌	vrj	0
 洵	vrk	1600000
 涽	vrk	70000
 澛	vrk	66200
@@ -10817,6 +11121,7 @@ encoder:
 漁	vrv	7800000
 逃	vrw	56200000
 泡	vry	98200000
+𫑜	vry	0
 沟	vrz	26500000
 𩾯	vrz	0
 𡔆	vsb	0
@@ -10843,6 +11148,7 @@ encoder:
 汸	vsy	90700
 濟	vsy	6830000
 澈	vsz	3900000
+𪶸	vsz	0
 润	vtc	45400000
 渡	vte	74800000
 澜	vtf	9050000
@@ -10872,6 +11178,7 @@ encoder:
 㳾	vuz	4080
 滋	vuz	18600000
 潫	vuz	25900
+𪶈	vuz	0
 洮	vvr	1690000
 演	vwa	49400000
 淙	vwb	1930000
@@ -10904,6 +11211,8 @@ encoder:
 澄	vxa	12900000
 泽	vxb	80000000
 𣲾	vxb	0
+𪣭	vxb	0
+𪫆	vxb	0
 潤	vxc	13400000
 浔	vxd	3700000
 𣶯	vxd	0
@@ -10952,6 +11261,7 @@ encoder:
 𥒟	vyg	0
 泯	vyh	3610000
 池	vyi	55400000
+𪵰	vyi	0
 沼	vyj	5640000
 泇	vyj	49200
 㳱	vyk	4240
@@ -10987,6 +11297,8 @@ encoder:
 灣	vzy	15800000
 𣳠	vzy	0
 滲	vzz	1670000
+𪷜	vzz	0
+𪜊	waa	0
 迂	wad	1390000
 䢎	wae	3640
 袜	waf	18900000
@@ -11053,6 +11365,7 @@ encoder:
 守	wds	67500000
 过	wds	744000000
 㝎	wdw	6670
+𫐲	wdw	0
 𡧁	wdx	0
 㝋	wdy	3860
 官	wdy	108000000
@@ -11060,6 +11373,7 @@ encoder:
 𨑬	wea	0
 塞	web	74400000
 祺	wec	7890000
+𫐬	wec	0
 辻	wed	7150000
 𨒍	wee	0
 𨔷	wee	0
@@ -11067,6 +11381,7 @@ encoder:
 𨔋	wef	0
 𨔘	wef	0
 祜	wej	796000
+𫐢	wej	0
 逪	wek	26300
 遭	wek	113000000
 宽	wel	192000000
@@ -11086,6 +11401,7 @@ encoder:
 補	wfb	21900000
 逋	wfb	1110000
 𨕅	wfb	0
+𫑄	wfc	0
 逎	wfd	44900
 𨔰	wfe	0
 襟	wff	6470000
@@ -11109,6 +11425,7 @@ encoder:
 𨒩	wgl	0
 宠	wgm	22200000
 𨔞	wgo	0
+𫐴	wgo	0
 迶	wgq	250000
 逐	wgq	28100000
 𨑫	wgr	0
@@ -11129,6 +11446,7 @@ encoder:
 迓	whi	237000
 襤	whm	106000
 𨑘	whm	0
+𫐟	whs	0
 𨒑	whx	0
 窃	why	9120000
 窀	whz	210000
@@ -11338,6 +11656,7 @@ encoder:
 𨑑	wsh	0
 寵	wsi	3740000
 福	wsj	263000000
+𪠹	wsj	0
 神	wsk	295000000
 𥘗	wsk	0
 祖	wsl	41100000
@@ -11346,6 +11665,7 @@ encoder:
 这	wso	1090000000
 祈	wsp	19700000
 𨘔	wss	0
+𫀎	wss	0
 適	wsu	9670000
 祃	wsx	39100
 䢍	wsy	4250
@@ -11356,6 +11676,7 @@ encoder:
 遮	wte	22900000
 𧘬	wte	0
 褲	wtf	11600000
+𫑃	wtf	0
 实	wtg	151000000
 袥	wtg	152000
 裤	wth	67400000
@@ -11370,6 +11691,7 @@ encoder:
 裙	wtx	69900000
 襏	wtx	37800
 𧘈	wty	0
+𫋼	wtz	0
 袢	wub	1080000
 𨒃	wub	0
 祥	wuc	47900000
@@ -11393,9 +11715,11 @@ encoder:
 窕	wvr	1240000
 逃	wvr	56200000
 冖	wwa	290000
+𫐲	wwd	0
 運	wwf	53000000
 𣎾	wwf	0
 军	wwh	142000000
+𫐸	wwh	0
 蜜	wwi	42600000
 𠕾	wwk	0
 遍	wwl	68800000
@@ -11417,6 +11741,7 @@ encoder:
 避	wxj	72000000
 逮	wxk	9490000
 通	wxl	521000000
+𫐹	wxl	0
 迉	wxm	80100
 退	wxo	198000000
 迟	wxs	54800000
@@ -11496,8 +11821,10 @@ encoder:
 䦒	xdg	3790
 閩	xdi	4220000
 𨷷	xdi	0
+𫔘	xdi	0
 問	xdj	124000000
 間	xdk	180000000
+𫔝	xdl	0
 閁	xdm	60600
 閉	xdm	9060000
 䦦	xdp	3880
@@ -11519,6 +11846,7 @@ encoder:
 𨙺	xey	0
 屉	xez	786000
 𩧾	xfb	0
+𫘢	xfj	0
 闌	xfl	341000
 骑	xga	87600000
 夬	xgd	322000
@@ -11527,6 +11855,7 @@ encoder:
 頗	xgo	8850000
 颇	xgo	46500000
 屋	xhb	208000000
+𫘠	xhb	0
 暨	xhk	71400000
 戏	xhm	46800000
 𢦐	xhm	0
@@ -11567,6 +11896,7 @@ encoder:
 𡭖	xko	0
 屑	xkq	11900000
 𩨅	xkq	0
+𪱝	xkq	0
 尿	xkv	29300000
 氶	xkv	1060000
 逮	xkw	9490000
@@ -11597,6 +11927,7 @@ encoder:
 迉	xmw	80100
 𡱏	xmz	0
 𦥖	xnb	0
+𫘩	xnc	0
 驯	xnd	3430000
 閥	xnh	2150000
 骓	xni	336000
@@ -11643,6 +11974,8 @@ encoder:
 𠮢	xsj	0
 昼	xsk	29200000
 甬	xsl	6570000
+𫘜	xso	0
+𪠥	xsq	0
 叉	xss	17700000
 𧦴	xss	0
 尽	xst	180000000
@@ -11676,6 +12009,7 @@ encoder:
 蝥	xxi	88700
 預	xxi	44500000
 预	xxi	117000000
+𫘟	xxi	0
 闢	xxj	1700000
 瞀	xxl	132000
 矛	xxm	8570000
@@ -11702,6 +12036,7 @@ encoder:
 孑	yaa	1550000
 𠄏	yaa	0
 𡤽	yaa	0
+𪪬	yad	0
 𨸦	yae	0
 𣏍	yaf	0
 䦺	yai	3470
@@ -11729,6 +12064,7 @@ encoder:
 陆	ybz	55100000
 𨻉	ybz	0
 弭	yce	1690000
+𫔾	yce	0
 张	ych	608000000
 彊	yck	990000
 䧞	ycu	3210
@@ -11752,6 +12088,7 @@ encoder:
 陻	yfb	25700
 𢌠	yfb	0
 𢌩	yfb	0
+𪪲	yfc	0
 孺	yfg	1200000
 䧈	yfj	3670
 廼	yfj	327000
@@ -11762,6 +12099,7 @@ encoder:
 隋	ygb	9530000
 𡏇	ygb	0
 𨻐	ygb	0
+𫔺	ygd	0
 陙	ygh	27200
 阫	ygi	22900
 𨹭	ygj	0
@@ -11813,6 +12151,7 @@ encoder:
 𨺁	ykf	0
 隈	ykh	1340000
 䧃	yki	3350
+𪪮	yki	0
 隙	ykk	7880000
 隅	ykl	8060000
 孙	yko	82600000
@@ -11832,6 +12171,7 @@ encoder:
 孟	ylk	30400000
 𡴺	yll	0
 𢌚	yll	0
+𫕄	ylo	0
 𨼅	ylp	0
 䧋	ylr	3480
 勐	yly	1120000
@@ -11850,6 +12190,7 @@ encoder:
 䧊	ymj	3460
 加	ymj	911000000
 尕	ymk	939000
+𪜌	ymk	0
 鼐	yml	643000
 办	ymo	418000000
 改	ymo	223000000
@@ -11865,6 +12206,7 @@ encoder:
 劜	ymz	101000
 孫	ymz	25800000
 隍	ync	371000
+𪪱	ync	0
 附	ynd	99900000
 陴	yne	187000
 𨻄	ynf	0
@@ -11927,6 +12269,7 @@ encoder:
 隌	ysk	34100
 障	ysk	15000000
 孩	yso	67200000
+𫔻	yso	0
 孓	ysv	1060000
 忍	ysw	117000000
 防	ysy	195000000
@@ -11957,6 +12300,7 @@ encoder:
 忌	ywz	22100000
 張韡武	yxa	26
 弪	yxb	97200
+𫔽	yxb	0
 𨼝	yxf	0
 陂	yxi	1480000
 限	yxo	317000000
@@ -12003,6 +12347,7 @@ encoder:
 𠙶	yzi	0
 𢎟	yzi	0
 𢎠	yzi	0
+𪪺	yzj	0
 𨹆	yzq	0
 𢐗	yzr	0
 弘	yzs	16300000
@@ -12039,6 +12384,7 @@ encoder:
 结	zbj	96100000
 妹	zbk	181000000
 絙	zbk	80300
+𫄠	zbk	0
 續	zbl	15900000
 緒	zbm	4630000
 緖	zbm	270000
@@ -12071,6 +12417,7 @@ encoder:
 巛	zda	709000
 𡿧	zda	0
 𥾒	zda	0
+𪱵	zdf	0
 䊷	zdm	3630
 䌶	zdm	4660
 紂	zds	194000
@@ -12129,11 +12476,13 @@ encoder:
 𦆕	zfz	0
 䋔	zga	3750
 綺	zga	6080000
+𫄞	zga	0
 绔	zgb	507000
 𦀰	zgb	0
 叁	zgc	9080000
 縟	zgd	60100
 缛	zgd	764000
+𫃫	zge	0
 娠	zgh	291000
 𦁄	zgh	0
 紑	zgi	928000
@@ -12148,6 +12497,7 @@ encoder:
 紌	zgr	37200
 𥾕	zgr	0
 紎	zgs	23900
+𫄤	zgw	0
 紱	zgx	489000
 姨	zgy	7660000
 紘	zgz	1430000
@@ -12179,6 +12529,7 @@ encoder:
 𡉟	zib	0
 𤯓	zib	0
 㞷	zic	4040
+𫃚	zid	0
 牀	zif	210000
 𦁲	zih	0
 䊼	zii	4170
@@ -12187,6 +12538,7 @@ encoder:
 綽	zik	719000
 绰	zik	1770000
 𠧡	zil	0
+𪺞	zis	0
 𥿓	zix	0
 𡳾	ziz	0
 娱	zja	22400000
@@ -12197,6 +12549,8 @@ encoder:
 絪	zjd	624000
 綑	zjf	690000
 繢	zji	52200
+𫃞	zji	0
+𫃥	zji	0
 絗	zjj	92000
 絽	zjj	910000
 绳	zjk	19000000
@@ -12264,6 +12618,7 @@ encoder:
 纲	zld	7140000
 𥿑	zld	0
 𦂴	zld	0
+𫄡	zld	0
 姍	zle	1780000
 緺	zlj	85600
 緲	zlk	748000
@@ -12296,11 +12651,13 @@ encoder:
 䋃	zmh	4000
 姫	zmh	42300000
 姬	zmh	21600000
+𫄜	zmh	0
 絬	zmi	115000
 如	zmj	638000000
 𦀽	zmj	0
 姝	zmk	3030000
 媞	zmk	679000
+𪥨	zmk	0
 姐	zml	89300000
 娥	zmm	8840000
 收	zmo	459000000
@@ -12330,11 +12687,13 @@ encoder:
 缎	znc	3870000
 紃	znd	44600
 𥾖	znd	0
+𫃺	znd	0
 婢	zne	3710000
 𦂖	zne	0
 䌖	znf	4290
 𦃨	znf	0
 𦈜	znf	0
+𫃢	znf	0
 𦃧	zng	0
 䗽	zni	3440
 維	zni	25100000
@@ -12419,6 +12778,7 @@ encoder:
 䊻	zro	3610
 妣	zrr	381000
 纔	zrr	2350000
+𪟨	zrr	0
 約	zrs	156000000
 约	zrs	180000000
 𥿄	zrs	0
@@ -12429,6 +12789,7 @@ encoder:
 絶	zry	5410000
 绝	zry	141000000
 𥾉	zry	0
+𫃠	zry	0
 鸞	zrz	964000
 𦃡	zrz	0
 𦄋	zrz	0
@@ -12457,6 +12818,7 @@ encoder:
 䏍	zsq	3290
 𦣏	zsq	0
 嫡	zsu	1460000
+𫃡	zsu	0
 娘	zsx	86000000
 𠁾	zsx	0
 紡	zsy	2580000
@@ -12537,6 +12899,7 @@ encoder:
 绿	zxk	140000000
 𦅘	zxk	0
 媚	zxl	39200000
+𫃷	zxl	0
 娓	zxm	5250000
 繡	zxn	4540000
 繝	zxq	2900000
@@ -12559,6 +12922,7 @@ encoder:
 紖	zyi	157000
 纼	zyi	23400
 𥾯	zyi	0
+𫄝	zyi	0
 紹	zyj	4040000
 绍	zyj	8910000
 𠰔	zyj	0
@@ -12632,10 +12996,12 @@ encoder:
 开赴	aebi	916000
 开来	aebk	16500000
 开埠	aebm	170000
+𪪁	aebn	0
 䵤	aebu	4490
 形声	aebx	400000
 刑场	aeby	1010000
 开动	aebz	3690000
+𪫊	aecb	0
 开球	aecd	745000
 开春	aeco	2180000
 干扰	aedg	21400000
@@ -12733,6 +13099,7 @@ encoder:
 开销	aepk	4420000
 型钢	aepl	2790000
 开盘	aepl	16800000
+𫌟	aepl	0
 开镰	aept	76800
 干脆	aeqr	23800000
 开脱	aequ	1330000
@@ -12740,6 +13107,7 @@ encoder:
 㰢	aero	4550
 鳱	aerz	27700
 鳽	aerz	35400
+𫛚	aerz	0
 𪚒	aesi	0
 干部	aesj	61600000
 开课	aesk	4590000
@@ -12842,6 +13210,7 @@ encoder:
 末端	afsl	4310000
 末	afvv	121000000
 末尾	afxm	4470000
+𪜑	afyd	0
 末了	afyv	2150000
 𣚺	afyz	0
 幵	agae	893000
@@ -13021,6 +13390,7 @@ encoder:
 无愧	agun	7850000
 𡚑	agun	0
 无益	aguo	3040000
+𪸓	aguo	0
 无恙	aguw	3190000
 无数	aguz	41400000
 无法	agvb	281000000
@@ -13043,6 +13413,7 @@ encoder:
 蚕桑	agxx	849000
 天子	agya	10300000
 无异	agye	6920000
+𪥉	agyi	0
 无力	agym	26400000
 天险	agyo	548000
 无限	agyx	107000000
@@ -13076,6 +13447,7 @@ encoder:
 𧹁	ahil	0
 鵡	ahir	180000
 鹉	ahir	183000
+𫛁	ahir	0
 武器	ahjj	67200000
 武鸣	ahjr	457000
 武昌	ahkk	7940000
@@ -13116,6 +13488,7 @@ encoder:
 下列	aiar	60600000
 𡕣	aiar	0
 𠾥	aiax	0
+𫑚	aiay	0
 𡿰	aiaz	0
 𡿴	aiaz	0
 正巧	aiba	2780000
@@ -13132,6 +13505,7 @@ encoder:
 下去	aibz	105000000
 𠳊	aibz	0
 𡿰	aibz	0
+𪴹	aibz	0
 𢧎	aich	0
 正职	aicj	730000
 𧶷	aicl	0
@@ -13193,6 +13567,7 @@ encoder:
 𢦪	aijh	0
 下颚	aijj	882000
 正品	aijj	32200000
+𪾌	aijl	0
 下跌	aijm	27500000
 𢼔	aijm	0
 㪼	aijp	3960
@@ -13203,6 +13578,7 @@ encoder:
 𥘱	aijr	0
 𪀉	aijr	0
 𪃿	aijr	0
+𫛌	aijr	0
 𧭳	aijs	0
 正中	aijv	6600000
 𠄙	aijx	0
@@ -13256,6 +13632,7 @@ encoder:
 𥙳	ainf	0
 𢧖	ainh	0
 𨾖	aini	0
+𪵿	aink	0
 𥘲	ainl	0
 𧹚	aino	0
 𣂘	ainp	0
@@ -13271,6 +13648,7 @@ encoder:
 𩳮	aion	0
 夒	aior	69700
 蘷	aior	25500
+𫁮	aios	0
 下令	aiow	14900000
 政令	aiow	3070000
 𠾥	aiow	0
@@ -13292,10 +13670,12 @@ encoder:
 𠶘	airk	0
 正负	airl	1250000
 𣀋	airm	0
+𪢦	airm	0
 𠀵	airo	0
 正比	airr	4290000
 𠀢	airr	0
 𠀲	airr	0
+𪤶	airr	0
 羐	airs	44700
 𣥛	airs	0
 政务	airy	67500000
@@ -13342,6 +13722,7 @@ encoder:
 𠃎	aivv	0
 下沉	aivw	3520000
 政治	aivz	321000000
+𪡑	aivz	0
 正宁	aiwa	107000
 正宗	aiwb	18900000
 正割	aiwc	28500
@@ -13474,12 +13855,14 @@ encoder:
 可口	ajja	6900000
 𧯱	ajja	0
 𡈧	ajjb	0
+𪡅	ajjb	0
 可因	ajjd	1180000
 可鄙	ajje	304000
 櫜	ajjf	73500
 𣟏	ajjf	0
 可贵	ajji	6990000
 𧏋	ajji	0
+𫙄	ajji	0
 副品	ajjj	47100
 㽬	ajjk	4650
 歌唱	ajjk	16200000
@@ -13510,6 +13893,7 @@ encoder:
 𩰼	ajkx	0
 𧰃	ajkz	0
 𧰗	ajla	0
+𫎄	ajla	0
 鬲	ajld	3230000
 𠀷	ajld	0
 𠁐	ajld	0
@@ -13520,8 +13904,10 @@ encoder:
 𩰭	ajlh	0
 融	ajli	55800000
 𧖓	ajli	0
+𫋊	ajli	0
 𧰏	ajlj	0
 䰝	ajlk	3750
+𫙅	ajll	0
 𩰫	ajlm	0
 可见	ajlr	69700000
 鷊	ajlr	27500
@@ -13564,6 +13950,7 @@ encoder:
 𠲀	ajoj	0
 𠀬	ajoo	0
 𧯲	ajoo	0
+𪫈	ajop	0
 鬷	ajor	34500
 𩰺	ajor	0
 𩱛	ajor	0
@@ -13665,6 +14052,7 @@ encoder:
 䜸	ajxm	3990
 𧰤	ajxx	0
 𩰸	ajxx	0
+𪜃	ajxz	0
 豆子	ajya	3820000
 䝀	ajyk	5010
 鬸	ajyk	17900
@@ -13771,6 +14159,7 @@ encoder:
 𣌼	akok	0
 㬲	akol	5960
 甦	akom	2340000
+𪯍	akom	0
 𩰽	akor	0
 更	akos	2310000000
 严令	akow	727000
@@ -13859,6 +14248,7 @@ encoder:
 𠕅	albd	0
 两项	albg	9600000
 再来	albk	34600000
+𪲬	albk	0
 两者	albm	25500000
 两地	albv	9180000
 再起	alby	7130000
@@ -13891,6 +14281,7 @@ encoder:
 䪟	alka	3200
 䪣	alka	3340
 𠚷	alkd	0
+𫜘	alko	0
 丽水	alkv	20000000
 两党	alkw	1550000
 丽	alld	115000000
@@ -13931,6 +14322,7 @@ encoder:
 丙	alod	47400000
 𠆴	alod	0
 𡗚	alod	0
+𪥇	alog	0
 𠛥	alok	0
 𩇽	alok	0
 𧶪	alol	0
@@ -14030,6 +14422,7 @@ encoder:
 𡕾	ankr	0
 夏县	anlz	294000
 夏种	anmj	155000
+𪡬	anmj	0
 百年	anmm	96800000
 𤾋	anmm	0
 百科	anmt	77800000
@@ -14043,9 +14436,11 @@ encoder:
 百余	anom	8680000
 𠀼	anos	0
 夏令	anow	816000
+𫑖	anow	0
 百分	anoy	32300000
 𠢊	anoy	0
 𠢨	anoy	0
+𪟊	anoy	0
 百般	anpq	8040000
 𡔀	anrb	0
 𩑋	anrd	0
@@ -14115,6 +14510,7 @@ encoder:
 𠀣	aqha	0
 𠁉	aqnc	0
 𠘲	aqqd	0
+𪜂	aqya	0
 死于	arad	7670000
 𣦿	arad	0
 死刑	arae	13000000
@@ -14125,6 +14521,7 @@ encoder:
 㱮	aral	18100
 殨	aral	70900
 	aral	0
+𪵅	aral	0
 𣩐	aran	0
 㱛	arar	4300
 殡殓	arar	43400
@@ -14272,6 +14669,7 @@ encoder:
 𣨵	arkr	0
 𣩜	arkr	0
 𣩹	arkr	0
+𫚓	arkr	0
 𣧖	arks	0
 𣨃	arks	0
 烈	arku	31900000
@@ -14302,6 +14700,8 @@ encoder:
 𣩑	arln	0
 𣧍	arlo	0
 𣧰	arlo	0
+𪵆	arlo	0
+𪵄	arlr	0
 残骸	arls	2270000
 𢤔	arlw	0
 𣨺	arlw	0
@@ -14364,6 +14764,7 @@ encoder:
 飱	arox	47800
 𣨳	aroy	0
 𣧑	aroz	0
+𪵂	aroz	0
 死后	arpa	10300000
 歽	arpd	22300
 𣧭	arpd	0
@@ -14396,6 +14797,7 @@ encoder:
 𣨍	arrl	0
 𣪁	arrl	0
 𧵲	arrl	0
+𪵇	arrl	0
 歾	arro	73000
 殤	arro	1170000
 𣧋	arro	0
@@ -14408,6 +14810,7 @@ encoder:
 𣧩	arrt	0
 㱝	arry	3690
 㱧	arry	4860
+𪵀	arry	0
 殦	arrz	37900
 𣧔	arrz	0
 死亡	arsh	90500000
@@ -14514,10 +14917,12 @@ encoder:
 𣩱	arzl	0
 𣩿	arzn	0
 𣨧	arzq	0
+𪵃	arzr	0
 裂纹	arzs	1870000
 𣩙	arzu	0
 𣩯	arzu	0
 裂缝	arzw	3940000
+𪵁	arzx	0
 𣧥	arzy	0
 列出	arzz	50200000
 𣦾	arzz	0
@@ -14557,6 +14962,7 @@ encoder:
 平昌	aukk	374000
 𣸞	aukk	0
 平常	aukw	35300000
+𪪅	aukz	0
 平山	aull	5090000
 平罗	aulr	346000
 平等	aumb	30500000
@@ -14585,6 +14991,7 @@ encoder:
 𡕢	aurs	0
 灭亡	aush	5840000
 平调	ausl	315000
+𪪄	ausw	0
 平方	ausy	69900000
 平装	autb	7850000
 平头	autg	1600000
@@ -14607,8 +15014,10 @@ encoder:
 𢂇	auwl	0
 平遥	auwp	1930000
 平房	auws	4980000
+𪪇	auws	0
 平通	auwx	72000
 平安	auwz	43700000
+𪪆	auxw	0
 平局	auxy	1810000
 平陆	auyb	371000
 平民	auyh	16900000
@@ -14795,6 +15204,9 @@ encoder:
 𠑺	awrd	0
 辷	awvv	439000
 𢄀	awwl	0
+𫅞	axej	0
+𫑱	axeq	0
+𫑯	axge	0
 𧰳	axgg	0
 𨳇	axhi	0
 疌	axii	17400
@@ -14802,6 +15214,7 @@ encoder:
 𧰳	axmg	0
 𧵹	axol	0
 妻儿	axrd	1640000
+𫅞	axuj	0
 妻子	axya	42900000
 㼮	axys	5870
 妻	axzm	57200000
@@ -14831,12 +15244,15 @@ encoder:
 万人	ayod	46400000
 万余	ayom	11400000
 𤽩	ayon	0
+𪜇	ayoo	0
 万个	ayov	18400000
 万分	ayoy	15800000
 万顷	ayrg	878000
 万象	ayrj	12500000
+𫔬	aytl	0
 万米	ayuf	1640000
 万源	ayvg	843000
+𪜁	ayvv	0
 万宁	aywa	1240000
 万家	aywg	8600000
 万户	aywm	5760000
@@ -14850,6 +15266,7 @@ encoder:
 万能	ayzq	22200000
 𢌱	azae	0
 𤮠	azag	0
+𪠜	azal	0
 𢪓	azam	0
 𢮠	azam	0
 瓸	azan	35900
@@ -14859,12 +15276,14 @@ encoder:
 𤬻	azax	0
 𡴃	azaz	0
 瓦工	azbi	592000
+𫀀	azbk	0
 𤮟	azbn	0
 𦤳	azci	0
 𦓩	azck	0
 与其	azec	52900000
 与共	azeo	2420000
 瓦斯	azep	5790000
+𪼹	azfa	0
 𤮍	azfd	0
 瓦楞	azfl	517000
 𢾣	azfm	0
@@ -14888,6 +15307,9 @@ encoder:
 𤮑	azkw	0
 𨚸	azky	0
 𤬲	azlo	0
+𪼻	azlo	0
+𫎣	azlq	0
+𪼿	azlz	0
 瓦特	azmb	1270000
 瓦罐	azme	443000
 𤭚	azmj	0
@@ -14902,6 +15324,7 @@ encoder:
 瓰	azoy	34000
 瓪	azpx	35500
 𤭷	azqk	0
+𪟆	azqk	0
 𨿾	azqn	0
 𣪟	azqq	0
 𨛼	azqy	0
@@ -14913,6 +15336,7 @@ encoder:
 𤮄	azsa	0
 𡊝	azsb	0
 𤭖	azsc	0
+𪼷	azsc	0
 瓧	azse	216000
 𤬧	azse	0
 𦓓	azsg	0
@@ -14923,12 +15347,15 @@ encoder:
 𤬸	azsm	0
 𤬨	azsq	0
 𩿺	azsr	0
+𪼸	azsu	0
 𤬯	azsx	0
 邷	azsy	24400
+𪼶	azsy	0
 𤮌	azsz	0
 瓦店	azti	125000
 𡋬	azub	0
 𤭅	azue	0
+𪼼	azun	0
 𢚎	azuw	0
 𤮒	azuz	0
 丂	azvv	116000
@@ -14942,6 +15369,7 @@ encoder:
 𤮂	azxj	0
 𦥼	azxo	0
 𠬣	azxs	0
+𪜆	azyb	0
 𤬫	azye	0
 𢏽	azyo	0
 瓦	azys	58500000
@@ -14981,14 +15409,17 @@ encoder:
 考核	bafs	37500000
 考研	baga	48800000
 𡐥	bagk	0
+𪢸	bagr	0
 𡍞	bagu	0
 赶车	bahe	671000
+𪣥	bahi	0
 土匪	bahk	3700000
 赶到	bahk	20000000
 圷	baid	216000
 𡊕	baii	0
 考点	baij	3920000
 赶点	baij	65300
+𪣴	baim	0
 赶上	baiv	10900000
 考虑	baiw	67400000
 𡎩	baix	0
@@ -15006,6 +15437,7 @@ encoder:
 垭	baku	643000
 𤎪	baku	0
 赶紧	bakx	41300000
+𪣃	balo	0
 𡔉	balt	0
 考生	bamc	26800000
 士气	bamy	4960000
@@ -15024,6 +15456,7 @@ encoder:
 赶脚	baqb	40300
 赶印	bara	39100
 𡊻	bark	0
+𪤐	barl	0
 考证	basa	10900000
 考评	basa	5380000
 考试	bash	163000000
@@ -15032,6 +15465,7 @@ encoder:
 土族	basm	403000
 土方	basy	3180000
 坪	baua	28800000
+𪤁	baud	0
 赶忙	baus	7580000
 赶快	baux	56000000
 考卷	bauy	2680000
@@ -15103,6 +15537,7 @@ encoder:
 堵车	bbhe	2830000
 𡓖	bbhy	0
 卦	bbid	8090000
+𫙌	bbin	0
 㪈	bbix	3910
 𢿣	bbix	0
 堵口	bbja	167000
@@ -15161,6 +15596,7 @@ encoder:
 𡒡	bbux	0
 圭	bbvv	9360000
 𡎓	bbvv	0
+𪢴	bbvv	0
 堵塞	bbwe	14300000
 𦥂	bbwh	0
 𡐉	bbwi	0
@@ -15170,6 +15606,7 @@ encoder:
 恚	bbwz	1280000
 封皮	bbxi	1660000
 𧎹	bbxi	0
+𪣔	bbxj	0
 隷	bbxk	441000
 𡊋	bbxs	0
 款子	bbya	361000
@@ -15197,6 +15634,7 @@ encoder:
 壃	bckk	83800
 𤣪	bcrd	0
 趣闻	bctc	6550000
+𪤚	bcug	0
 𡉠	bcvv	0
 𡔐	bcyi	0
 𡏼	bcym	0
@@ -15214,6 +15652,8 @@ encoder:
 𠒺	bdal	0
 二百	bdan	12000000
 二列	bdar	332000
+𪲅	bdau	0
+𪱼	bdax	0
 二万	bday	4520000
 𠃻	bday	0
 亖	bdbd	246000
@@ -15228,6 +15668,7 @@ encoder:
 𪒨	bdbu	0
 𠄥	bdbz	0
 𠝆	bdck	0
+𪜞	bdcm	0
 𩇖	bdcq	0
 𠃻	bdcy	0
 𠄽	bddk	0
@@ -15240,6 +15681,7 @@ encoder:
 𦈱	bdez	0
 𠄯	bdfa	0
 𨎑	bdff	0
+𪳭	bdfk	0
 二楼	bdfu	14200000
 鄻	bdfy	24500
 𣠕	bdgb	0
@@ -15255,6 +15697,7 @@ encoder:
 𩺸	bdgr	0
 𪅗	bdgr	0
 𣁟	bdgs	0
+𪺽	bdgs	0
 𥼋	bdgu	0
 𢟤	bdgw	0
 𢡷	bdgw	0
@@ -15279,6 +15722,7 @@ encoder:
 𢤏	bdiw	0
 𢻳	bdix	0
 𢿍	bdix	0
+𪯋	bdix	0
 𠢷	bdjf	0
 𠁩	bdji	0
 𠄸	bdjj	0
@@ -15307,7 +15751,10 @@ encoder:
 𩒢	bdkg	0
 𩓋	bdkg	0
 𩕗	bdkg	0
+𪥊	bdkg	0
 戩	bdkh	164000
+𪟾	bdki	0
+𫋉	bdki	0
 刯	bdkk	23500
 神	bdkk	0
 𠄵	bdkk	0
@@ -15367,6 +15814,7 @@ encoder:
 𠩺	bdmg	0
 𪘻	bdmi	0
 𣸗	bdmk	0
+𫎜	bdml	0
 㲠	bdmm	9120
 㹈	bdmm	4560
 𠄦	bdms	0
@@ -15375,9 +15823,11 @@ encoder:
 𡟋	bdmz	0
 坓	bdnb	33600
 𡉝	bdnb	0
+𪧷	bdnb	0
 亓	bdnd	1420000
 井	bdnd	45100000
 𠦈	bdne	0
+𪱶	bdnf	0
 㓝	bdnk	3880
 汬	bdnk	35000
 𣲜	bdnk	0
@@ -15396,15 +15846,20 @@ encoder:
 𠒞	bdnz	0
 𥾟	bdnz	0
 𩰿	bdoa	0
+𪥃	bdoa	0
 夫	bdod	92500000
 輦	bdof	211000
 𩖀	bdog	0
 辇	bdoh	613000
 𠴅	bdoj	0
+𫎁	bdoj	0
 替	bdok	60900000
+𪞾	bdok	0
 規	bdol	20900000
 规	bdol	46000000
 賛	bdol	608000
+𫌡	bdol	0
+𪯈	bdom	0
 𤾞	bdon	0
 𨾚	bdon	0
 斄	bdoo	33700
@@ -15466,7 +15921,9 @@ encoder:
 二话	bdsm	6540000
 㣋	bdsp	3850
 慭	bdsw	44300
+𪱼	bdsx	0
 𨚢	bdsy	0
+𫑘	bdsy	0
 㪴	bdte	3790
 𣂐	bdte	0
 寺庙	bdtk	4340000
@@ -15478,10 +15935,12 @@ encoder:
 刾	bduk	33300
 夹	bduo	84700000
 𦣓	bduq	0
+𫛥	bdur	0
 郏	bduy	668000
 𣜾	bdvb	0
 二流	bdvs	2750000
 𡌋	bdvs	0
+𫏼	bdwf	0
 𣘾	bdwq	0
 二心	bdwz	531000
 忈	bdwz	113000
@@ -15501,6 +15960,7 @@ encoder:
 𠎶	bdyo	0
 𠛝	bdys	0
 寺院	bdyw	9120000
+𫅣	bdyy	0
 亐	bdza	84600
 𠦊	bdze	0
 𣐂	bdzf	0
@@ -15513,6 +15973,7 @@ encoder:
 𧴳	bdzl	0
 互	bdzm	96000000
 𡚬	bdzm	0
+𪵣	bdzm	0
 䰟	bdzn	5340
 二维	bdzn	3110000
 魂	bdzn	74500000
@@ -15565,7 +16026,9 @@ encoder:
 壦	bejn	32600
 𡎁	bejq	0
 𡕁	bejr	0
+𪣕	bejr	0
 塻	bekg	41400
+𪣲	beki	0
 𡐋	bekk	0
 墴	beko	232000
 𡑪	bekr	0
@@ -15627,19 +16090,24 @@ encoder:
 壩	bfeq	1210000
 𡑲	bffb	0
 𡑓	bfff	0
+𪤰	bfff	0
 壖	bfgl	60900
 墰	bfke	217000
 𡐧	bfke	0
+𪤠	bfki	0
 𡒫	bflb	0
 堜	bflk	717000
 𢽓	bfmo	0
 𡓘	bfni	0
+𪤦	bfok	0
 𡐛	bfpd	0
+𪤙	bfuo	0
 𡉿	bfvv	0
 𣏅	bfvv	0
 𡐅	bfxb	0
 𡓒	bfyl	0
 㙘	bfzm	4390
+𪣄	bgae	0
 埼	bgaj	1300000
 㙽	bgan	3800
 坏死	bgar	7450000
@@ -15650,12 +16118,14 @@ encoder:
 𡍲	bgce	0
 垮掉	bgdi	958000
 𡏌	bgds	0
+𪣳	bgds	0
 𡍋	bgee	0
 堧	bggd	157000
 𡊘	bggd	0
 𡓃	bggg	0
 坯布	bggl	4450000
 𡑂	bggl	0
+𪣋	bgiy	0
 𡒜	bgjk	0
 㙩	bgkk	3800
 𡎋	bgky	0
@@ -15663,6 +16133,7 @@ encoder:
 𡍿	bgkz	0
 项目	bgla	534000000
 坏账	bglc	1700000
+𪢹	bgld	0
 㘵	bgli	7950
 壢	bgmi	5590000
 塬	bgnk	484000
@@ -15709,6 +16180,7 @@ encoder:
 城里	bhkb	15000000
 越野	bhkb	23500000
 越界	bhko	1030000
+𪣆	bhko	0
 越是	bhkv	13000000
 堰	bhkz	5350000
 𡔑	bhll	0
@@ -15730,6 +16202,7 @@ encoder:
 𡐖	bhxb	0
 越剧	bhxe	1320000
 墭	bhyl	123000
+𪾓	bhyl	0
 城防	bhys	810000
 城建	bhyx	9680000
 𡒤	bhzh	0
@@ -15819,9 +16292,11 @@ encoder:
 𩒾	bijg	0
 敔	bijm	114000
 𥞣	bijm	0
+𫖌	bijm	0
 塷	bijo	30800
 𣣄	bijr	0
 𪁙	bijr	0
+𫖖	biju	0
 逜	bijw	81400
 𢙢	bijw	0
 㐚	bijy	4240
@@ -15846,6 +16321,7 @@ encoder:
 工党	bikw	760000
 埱	bikx	43400
 𠄲	bikz	0
+𫖕	bilb	0
 𥊾	bilg	0
 𡎍	bili	0
 盐	bilk	37400000
@@ -15866,6 +16342,7 @@ encoder:
 工种	bimj	5610000
 工程	bimj	468000000
 𧖬	biml	0
+𫖔	biml	0
 攻	bimo	49300000
 工科	bimt	4140000
 㙤	bimu	4300
@@ -15874,6 +16351,7 @@ encoder:
 𠄋	bimy	0
 工段	binc	436000
 𢀘	bind	0
+𫖓	bine	0
 工休	binf	65300
 𨾊	bini	0
 工作	binm	542000000
@@ -15929,6 +16407,7 @@ encoder:
 𧦬	biqs	0
 䊄	biqu	4370
 恐	biqw	57900000
+𫖒	bire	0
 𡍥	birf	0
 𡎵	birg	0
 𧠱	birl	0
@@ -15942,6 +16421,7 @@ encoder:
 𧝣	bisr	0
 𪀛	bisr	0
 工商	bisu	117000000
+𫖑	bisx	0
 工头	bitg	1870000
 𧋳	biti	0
 工间	bitk	221000
@@ -15964,6 +16444,7 @@ encoder:
 𢖶	biwz	0
 垇	bixa	38100
 𩏽	bixb	0
+𫔙	bixd	0
 𧷱	bixf	0
 𠁰	bixh	0
 吾	bixj	34000000
@@ -15972,6 +16453,7 @@ encoder:
 垆	bixm	256000
 𢀞	bixm	0
 韨	bixs	35600
+𪢺	bixs	0
 忢	bixw	38700
 𢛤	bixw	0
 𩐀	bixx	0
@@ -16047,6 +16529,7 @@ encoder:
 喜鹊	bjek	2690000
 𪔭	bjel	0
 𪔵	bjel	0
+𪞉	bjeo	0
 喜获	bjeq	2310000
 𤋔	bjeu	0
 鼓	bjex	46300000
@@ -16075,10 +16558,12 @@ encoder:
 鼔	bjix	47800
 𢼣	bjix	0
 𧰒	bjja	0
+𪤑	bjja	0
 鼞	bjjb	25200
 𡅤	bjjb	0
 𡅸	bjjc	0
 𪔪	bjjc	0
+𪤢	bjjf	0
 𡀆	bjjg	0
 鼓足	bjji	1990000
 𧑭	bjji	0
@@ -16102,6 +16587,7 @@ encoder:
 𧰘	bjke	0
 䶁	bjkk	3670
 𣻅	bjkm	0
+𪢣	bjkq	0
 彭水	bjkv	1080000
 鼓掌	bjkw	17900000
 𥀽	bjkw	0
@@ -16184,6 +16670,7 @@ encoder:
 喜	bjuj	98600000
 囍	bjuj	1900000
 吉普	bjuk	6070000
+𪟌	bjuk	0
 𤈂	bjuo	0
 彭	bjup	37800000
 㰻	bjur	666
@@ -16208,6 +16695,7 @@ encoder:
 嘉定	bjwd	6270000
 吉达	bjwg	383000
 臺	bjwh	32600000
+𪢢	bjwl	0
 嘉宾	bjwp	24500000
 𡔧	bjwq	0
 吉它	bjwr	2150000
@@ -16240,6 +16728,7 @@ encoder:
 鼘	bjxn	28800
 𩟚	bjxo	0
 䥢	bjxp	4310
+𫓖	bjxp	0
 𩙏	bjxq	0
 喜欢	bjxr	383000000
 𪇀	bjxr	0
@@ -16258,6 +16747,7 @@ encoder:
 翓	bjyy	22600
 𡔼	bjzb	0
 𡔣	bjzg	0
+𪣘	bjzg	0
 𠚌	bjzi	0
 𪔮	bjzl	0
 𡜩	bjzm	0
@@ -16265,6 +16755,7 @@ encoder:
 𡔷	bjzx	0
 喜好	bjzy	15900000
 垾	bkae	226000
+𪣨	bkae	0
 堤	bkai	23000000
 𠟜	bkak	0
 𡏶	bkal	0
@@ -16276,9 +16767,11 @@ encoder:
 祘	bkbk	255000
 堤坝	bkbl	1240000
 来者	bkbm	5400000
+𫀏	bkbr	0
 壜	bkbz	155000
 来去	bkbz	6150000
 𥜪	bkci	0
+𫀤	bkcm	0
 来势	bkdq	2660000
 埘	bkds	834000
 未接	bkds	2560000
@@ -16308,6 +16801,8 @@ encoder:
 𡐹	bkjk	0
 𡑄	bkjm	0
 来路	bkjr	4770000
+𪤅	bkju	0
+𪤡	bkju	0
 示踪	bkjw	203000
 𡐃	bkjz	0
 来日	bkka	6020000
@@ -16349,6 +16844,7 @@ encoder:
 𥜦	bkob	0
 𥜬	bkoc	0
 来人	bkod	16100000
+𫀟	bkom	0
 堺	bkon	7670000
 示众	bkoo	1280000
 𪇚	bkor	0
@@ -16357,11 +16853,13 @@ encoder:
 坦然	bkrg	8200000
 𥘖	bkrh	0
 未免	bkrj	7470000
+𫀙	bkrm	0
 埸	bkro	3410000
 場	bkro	230000000
 堒	bkrr	37900
 埋怨	bkry	8260000
 堨	bkry	191000
+𫀆	bkry	0
 𩿷	bkrz	0
 来讲	bksb	17700000
 坦诚	bksh	4520000
@@ -16378,6 +16876,7 @@ encoder:
 𥜟	bktg	0
 未准	bktn	324000
 未决	bktx	1480000
+𪣙	bkua	0
 𥘽	bkub	0
 墣	bkuc	812000
 埋单	bkuk	1860000
@@ -16395,6 +16894,7 @@ encoder:
 未被	bkwx	7040000
 未退	bkwx	377000
 来安	bkwz	860000
+𪤃	bkwz	0
 垱	bkxb	371000
 来劲	bkxb	1050000
 坦承	bkxk	3380000
@@ -16402,6 +16902,7 @@ encoder:
 未尽	bkxs	5050000
 未加	bkyj	1350000
 𡎣	bkyj	0
+𪣍	bkym	0
 塌陷	bkyr	1640000
 堤防	bkys	3930000
 示弱	bkyt	4210000
@@ -16410,6 +16911,8 @@ encoder:
 𥜸	bkzi	0
 𧊢	bkzi	0
 塿	bkzm	47400
+𪣚	bkzm	0
+𫀁	bkzm	0
 未能	bkzq	29900000
 未婚	bkzr	27300000
 㙷	bkzu	3970
@@ -16422,6 +16925,7 @@ encoder:
 𡉱	blbd	0
 坝址	blbi	172000
 墿	blbu	693000
+𪤄	blbz	0
 坝基	bleb	134000
 夁	blej	26800
 贡献	blel	95500000
@@ -16437,6 +16941,7 @@ encoder:
 𢤶	bljw	0
 𡍫	blkd	0
 𡊢	blla	0
+𪤂	bllk	0
 覿	blll	68900
 贡山	blll	226000
 𩴺	blln	0
@@ -16480,6 +16985,7 @@ encoder:
 㙮	bmaj	4080
 𦒽	bmaj	0
 考	bmaz	223000000
+𪥟	bmbg	0
 𦒳	bmbi	0
 𦓃	bmbj	0
 䎜	bmbr	3820
@@ -16522,14 +17028,18 @@ encoder:
 墧	bmjl	34100
 𥂁	bmjl	0
 㗯	bmjr	3800
+𫅳	bmjr	0
 𦒺	bmjx	0
 𨚻	bmjy	0
 𨜞	bmjy	0
 𡒁	bmka	0
 堹	bmkb	31400
 𩥞	bmkc	0
+𪟈	bmkd	0
+𪣛	bmkd	0
 𧡺	bmkl	0
 𣯆	bmkm	0
+𪣎	bmko	0
 㙏	bmkr	4140
 𪄖	bmkr	0
 攻坚	bmkx	2810000
@@ -16542,6 +17052,7 @@ encoder:
 𡋂	bmmb	0
 𦒷	bmmh	0
 𠺛	bmmj	0
+𪤛	bmmm	0
 䬡	bmmn	3960
 𢠛	bmmw	0
 𡍪	bmnb	0
@@ -16557,10 +17068,12 @@ encoder:
 䀋	bmol	6210
 𪉹	bmol	0
 𦙩	bmoo	0
+𫗍	bmox	0
 𡎫	bmoz	0
 斱	bmpd	20100
 𡌖	bmqb	0
 殾	bmqx	90100
+𫅶	bmrb	0
 耋	bmrh	1410000
 㖈	bmrj	3940
 䎛	bmrj	3480
@@ -16586,10 +17099,12 @@ encoder:
 𡗀	bmrr	0
 𪀧	bmrr	0
 𡦳	bmru	0
+𪸦	bmru	0
 㐗	bmry	4120
 𪃙	bmrz	0
 𦒼	bmsc	0
 攻读	bmse	4520000
+𫅵	bmsm	0
 𦒹	bmso	0
 都	bmsy	0
 𣂃	bmte	0
@@ -16600,6 +17115,7 @@ encoder:
 煑	bmuo	98000
 煮	bmuo	49600000
 𤆯	bmuo	0
+𫅸	bmux	0
 𡓕	bmuy	0
 攻守	bmwd	2340000
 𡒺	bmwl	0
@@ -16614,7 +17130,9 @@ encoder:
 𦓁	bmyj	0
 㘯	bmym	4650
 教	bmym	250000000
+𪣜	bmym	0
 𩳔	bmyn	0
+𪵋	bmyq	0
 攻陷	bmyr	1460000
 㼥	bmys	4650
 塠	bmyw	35100
@@ -16623,13 +17141,16 @@ encoder:
 𡦊	bmyy	0
 𨛨	bmyy	0
 耉	bmzj	53700
+𪤓	bmzm	0
 𡦲	bmzu	0
+𫅴	bmzx	0
 㙁	bmzy	4920
 攻丝	bmzz	328000
 井下	bnai	2050000
 赤豆	bnaj	312000
 𧹪	bnal	0
 𧹡	bnan	0
+𪤨	bnan	0
 𡐟	bnaz	0
 𧹻	bnbb	0
 赤城	bnbh	1900000
@@ -16643,6 +17164,7 @@ encoder:
 坿	bnds	78100
 塮	bnds	49100
 埤	bned	1220000
+𫎯	bnek	0
 𧹛	bnex	0
 𧹱	bnez	0
 𧹥	bnfb	0
@@ -16658,11 +17180,13 @@ encoder:
 垘	bngs	29300
 𡏣	bngs	0
 䞓	bnhb	3590
+𪣝	bnhd	0
 𧹹	bnhk	0
 㘺	bnhm	4520
 𡏲	bnhr	0
 赪	bnil	81000
 赬	bnil	34200
+𪤧	bnio	0
 井口	bnja	2460000
 井喷	bnje	2810000
 堢	bnjf	816000
@@ -16685,6 +17209,7 @@ encoder:
 堆积	bnmj	8880000
 𧹰	bnmk	0
 𧹺	bnmm	0
+𫛿	bnmr	0
 𧹜	bnms	0
 𢟻	bnmw	0
 𠭷	bnmx	0
@@ -16694,6 +17219,7 @@ encoder:
 赭	bnob	1680000
 頳	bnog	31700
 𡘥	bnog	0
+𫎮	bnoh	0
 赨	bnoi	23200
 𧹢	bnoj	0
 𧹤	bnoj	0
@@ -16724,6 +17250,7 @@ encoder:
 𥏷	bnrm	0
 𡒠	bnro	0
 𡓻	bnrr	0
+𪢼	bnrr	0
 𡌠	bnrs	0
 𧹝	bnrt	0
 赩	bnry	78100
@@ -16742,6 +17269,7 @@ encoder:
 𡒳	bnws	0
 赤道	bnwu	3560000
 赤字	bnwy	10900000
+𫎭	bnxb	0
 赤壁	bnxj	3780000
 赯	bnxj	113000
 𧹣	bnxj	0
@@ -16759,8 +17287,10 @@ encoder:
 𠢂	bnyy	0
 井台	bnzj	153000
 𧹴	bnzk	0
+𫎰	bnzk	0
 𧹽	bnzu	0
 𡐙	boad	0
+𫎹	boad	0
 走开	boae	8870000
 赶	boae	82800000
 趕	boae	12100000
@@ -16794,6 +17324,8 @@ encoder:
 趌	bobj	36300
 𧻇	bobk	0
 𧻚	bobk	0
+𫎲	bobk	0
+𫎶	bobk	0
 𧼉	bobl	0
 𢴸	bobm	0
 𧽭	bobn	0
@@ -16868,6 +17400,7 @@ encoder:
 𧾁	bogk	0
 𧻶	bogl	0
 𧼵	bogm	0
+𫎺	bogp	0
 䞥	bogq	3400
 𧼡	bogq	0
 𧼙	bogs	0
@@ -16877,6 +17410,8 @@ encoder:
 𧽔	bogx	0
 𧻑	bogy	0
 𧻜	bogy	0
+𫎱	bogy	0
+𫎾	bogy	0
 𧻗	boha	0
 𧻔	bohc	0
 𧻪	bohg	0
@@ -16886,6 +17421,7 @@ encoder:
 𧺱	bohm	0
 䟇	boho	3150
 䞪	bohp	3300
+𫎸	bohp	0
 走软	bohr	979000
 䞖	bohs	3240
 𧺹	bohx	0
@@ -16925,6 +17461,7 @@ encoder:
 䟑	bojl	3580
 趫	bojl	97100
 𧽛	bojl	0
+𪤒	bojl	0
 𡓎	bojm	0
 𧼐	bojm	0
 𧾦	bojm	0
@@ -16935,6 +17472,7 @@ encoder:
 𧽓	bojr	0
 𧽚	bojr	0
 𧾎	bojr	0
+𫎵	bojr	0
 𧾑	bojs	0
 𧯣	boju	0
 𧻿	boju	0
@@ -16952,6 +17490,7 @@ encoder:
 𧼩	bokb	0
 𧽆	bokb	0
 𧽿	bokb	0
+𫎷	bokb	0
 𧺈	bokd	0
 趁早	boke	2330000
 趠	boke	50300
@@ -16965,6 +17504,7 @@ encoder:
 𧾃	bokk	0
 趟	bokl	29000000
 赻	bokm	722000
+𫎻	bokm	0
 𧽟	bokn	0
 趪	boko	22400
 𡊒	boko	0
@@ -16986,6 +17526,7 @@ encoder:
 趄	bolc	1070000
 𧾖	bolc	0
 𧺸	bold	0
+𫎴	bold	0
 𧼴	bolg	0
 𧼽	bolj	0
 规则	bolk	136000000
@@ -17097,6 +17638,7 @@ encoder:
 𧻵	booo	0
 𧼛	booo	0
 𧾏	booo	0
+𫎿	booo	0
 䟃	boop	3380
 趁	boop	32700000
 䞭	boor	3470
@@ -17151,6 +17693,7 @@ encoder:
 𧺎	boqy	0
 𡠦	boqz	0
 𧾡	borb	0
+𫎳	bore	0
 赿	borh	43600
 𡏜	borh	0
 䟉	bori	3200
@@ -17175,6 +17718,7 @@ encoder:
 𡑨	boro	0
 𧼮	boro	0
 𧺤	borq	0
+𫆢	borq	0
 趍	borr	43800
 𡒇	borr	0
 𣣋	borr	0
@@ -17183,6 +17727,7 @@ encoder:
 𧻌	borr	0
 𧼔	borr	0
 𧼬	borr	0
+𪤽	borr	0
 夌	bors	1360000
 趆	bors	24300
 𧺓	bors	0
@@ -17275,6 +17820,7 @@ encoder:
 䞽	bowz	3470
 𧺨	bowz	0
 𧽉	bowz	0
+𫎼	bowz	0
 𧻡	boxb	0
 𧽡	boxb	0
 赽	boxg	735000
@@ -17283,6 +17829,7 @@ encoder:
 䞫	boxj	3180
 𡌢	boxj	0
 𧽜	boxj	0
+𪤇	boxj	0
 趢	boxk	20200
 𧻹	boxl	0
 趘	boxm	18900
@@ -17332,12 +17879,14 @@ encoder:
 𧽅	bozf	0
 䞼	bozg	3540
 赳	bozi	641000
+𫎽	bozl	0
 𧺜	bozm	0
 𧻭	bozm	0
 𧽈	bozm	0
 𡏓	bozr	0
 𧽸	bozr	0
 𧽞	bozu	0
+𪤣	bozw	0
 夫妇	bozx	17500000
 䞛	bozy	3000
 䞷	bozz	3440
@@ -17367,6 +17916,7 @@ encoder:
 𡐮	bpyu	0
 𡏛	bpzg	0
 坍塌	bqbk	3240000
+𪢵	bqda	0
 𡉻	bqed	0
 𡕀	bqfu	0
 𢀃	bqfz	0
@@ -17383,6 +17933,7 @@ encoder:
 恐怖	bqug	125000000
 恐惧	bqul	29300000
 恐怕	bqun	48200000
+𪢻	bqvv	0
 𡉕	bqya	0
 趋于	brad	9760000
 𦧄	brae	0
@@ -17435,11 +17986,13 @@ encoder:
 坎昆	brkr	142000
 埆	brld	724000
 趋同	brld	1160000
+𪣷	brlg	0
 元山	brll	431000
 𧷏	brll	0
 𧸇	brll	0
 元贝	brlo	85700
 塡	brlo	106000
+𪤩	brlr	0
 老手	brmd	3500000
 𡏝	brmf	0
 𡓡	brmg	0
@@ -17556,6 +18109,7 @@ encoder:
 坑木	bsfa	73200
 培植	bsfe	2950000
 𡌮	bsgj	0
+𪤕	bsgm	0
 𩓁	bsgo	0
 𡑌	bshk	0
 𡔋	bsix	0
@@ -17568,6 +18122,7 @@ encoder:
 壈	bsjm	478000
 𡐴	bsjq	0
 㙥	bsjr	4690
+𪤯	bsju	0
 埻	bsjy	139000
 𡏿	bsjy	0
 壇	bska	11600000
@@ -17578,11 +18133,13 @@ encoder:
 境界	bsko	34200000
 境	bskr	96300000
 壞	bskr	24300000
+𪤥	bskw	0
 𡏡	bskz	0
 㙵	bslb	3920
 𡌾	bslb	0
 𡊔	bsli	0
 境内	bslo	23900000
+𪤋	bslz	0
 𣘢	bsmf	0
 𢧴	bsmh	0
 𨅚	bsmj	0
@@ -17595,11 +18152,16 @@ encoder:
 𠢕	bsmy	0
 坑人	bsod	704000
 埣	bsoe	471000
+𪣼	bsog	0
+𪣫	bsok	0
 𡋟	bsoo	0
 𡌧	bsot	0
 垴	bsoz	170000
 坑	bsqd	29500000
 境外	bsri	15600000
+𪣱	bsri	0
+𪤪	bsrn	0
+𪣠	bssj	0
 培训	bssn	243000000
 培育	bssz	29600000
 境况	bstj	2270000
@@ -17610,6 +18172,7 @@ encoder:
 壕沟	bsvr	331000
 圡	bsvv	79600
 𡈽	bsvv	0
+𪣹	bswa	0
 坑害	bswc	830000
 壕	bswg	2840000
 境遇	bswk	3670000
@@ -17642,6 +18205,7 @@ encoder:
 𡎻	btob	0
 𡒷	btpk	0
 𡍓	btra	0
+𪣵	btrq	0
 𡍓	btrs	0
 𡔙	bttt	0
 𡍔	btub	0
@@ -17657,6 +18221,7 @@ encoder:
 𡓊	btyq	0
 增刊	buae	1260000
 增开	buae	1030000
+𪣺	buaj	0
 增殖	buar	2300000
 𡒶	buax	0
 增城	bubh	1940000
@@ -17700,6 +18265,7 @@ encoder:
 増	bukk	16700000
 𡐭	bukk	0
 𡌶	buku	0
+𪤉	bukv	0
 增幅	bula	13300000
 𡋁	buli	0
 增	bulk	288000000
@@ -17711,6 +18277,7 @@ encoder:
 𣮾	bumh	0
 增重	bumk	1250000
 盩	buml	71500
+𪯎	bumo	0
 𡓏	bumy	0
 𡏆	bund	0
 增值	bune	62600000
@@ -17810,11 +18377,15 @@ encoder:
 𥃁	buzl	0
 增收	buzm	10300000
 𡓌	buzm	0
+𪣻	buzm	0
+𪪉	buzm	0
 夹缝	buzw	1710000
+𪤫	buzx	0
 幸好	buzy	15200000
 地形	bvae	13300000
 地丁	bvai	426000
 地下	bvai	62900000
+𪣢	bvao	0
 地平	bvau	1490000
 𡐵	bvau	0
 地坛	bvbb	694000
@@ -17858,11 +18429,13 @@ encoder:
 地委	bvmz	770000
 𡐘	bvnb	0
 地段	bvnc	16600000
+𪣏	bvnd	0
 地堡	bvnj	131000
 地价	bvno	3850000
 地位	bvns	90200000
 墚	bvof	55700
 塉	bvoq	35400
+𪣢	bvos	0
 地质	bvpe	18000000
 地铺	bvpf	1800000
 地盘	bvpl	17000000
@@ -17878,6 +18451,7 @@ encoder:
 地主	bvsc	9170000
 地市	bvsl	5860000
 地产	bvsm	260000000
+𪣢	bvso	0
 地衣	bvsr	558000
 地方	bvsy	364000000
 地头	bvtg	1820000
@@ -17892,9 +18466,11 @@ encoder:
 地心	bvwz	2240000
 地层	bvxb	1430000
 地皮	bvxi	2300000
+𪣮	bvxr	0
 地线	bvzh	750000
 地级	bvzy	6520000
 㘾	bwad	4820
+𪣟	bwae	0
 塜	bwag	91900
 𡔿	bwag	0
 坾	bwai	22300
@@ -17920,14 +18496,17 @@ encoder:
 壼	bwbz	325000
 㲄	bwcq	4150
 瑴	bwcq	47400
+𫜕	bwcr	0
 壹拾	bwdo	236000
 垨	bwds	302000
 𩌊	bweq	0
 𡄜	bwer	0
+𪤔	bwfb	0
 𣝝	bwfj	0
 𧥆	bwfj	0
 堚	bwfk	191000
 𡍦	bwfk	0
+𪤎	bwfk	0
 𤜕	bwfl	0
 𥢉	bwfl	0
 榖	bwfq	452000
@@ -17949,6 +18528,8 @@ encoder:
 𢦁	bwgw	0
 㙆	bwgz	4660
 𦤼	bwhb	0
+𪣞	bwhd	0
+𪣒	bwhe	0
 毂	bwhq	510000
 壺	bwia	6800000
 𡔳	bwia	0
@@ -17976,13 +18557,16 @@ encoder:
 𡔹	bwju	0
 壷	bwka	3190000
 𡔱	bwkg	0
+𪤮	bwkk	0
 𡒨	bwkl	0
 𡐔	bwko	0
 𣹬	bwkq	0
 壶	bwku	22100000
+𪭁	bwkw	0
 𡏉	bwkz	0
 𡔩	bwkz	0
 𡔻	bwkz	0
+𪣯	bwlc	0
 𡎚	bwld	0
 𡑟	bwlj	0
 𣫪	bwlk	0
@@ -18014,6 +18598,7 @@ encoder:
 𡑮	bwob	0
 堔	bwof	163000
 塎	bwoj	25500
+𪤴	bwol	0
 𧹲	bwoq	0
 𪏙	bwoq	0
 𪍠	bwor	0
@@ -18026,6 +18611,7 @@ encoder:
 𨢋	bwqf	0
 𥔼	bwqg	0
 𧲇	bwqg	0
+𫖡	bwqg	0
 螜	bwqi	30700
 𧐜	bwqi	0
 𣪥	bwqj	0
@@ -18057,6 +18643,8 @@ encoder:
 𡔸	bwrb	0
 塳	bwrc	23100
 売	bwrd	27800000
+𪣑	bwrh	0
+𪣞	bwrh	0
 𡄻	bwrj	0
 𧰝	bwrl	0
 𧹌	bwrl	0
@@ -18105,6 +18693,7 @@ encoder:
 𥗣	bwxg	0
 㚄	bwxi	4120
 𡐡	bwxk	0
+𪤤	bwxk	0
 𣰺	bwxm	0
 𥀎	bwxq	0
 𪈞	bwxr	0
@@ -18117,6 +18706,7 @@ encoder:
 𣫌	bwyq	0
 𪄽	bwyr	0
 𦐼	bwyy	0
+𪤆	bwyy	0
 𡔵	bwyz	0
 𣙲	bwzf	0
 𥃕	bwzl	0
@@ -18141,6 +18731,7 @@ encoder:
 五万	bxay	8060000
 垏	bxbd	91100
 墛	bxbd	306000
+𪤳	bxbd	0
 𡕐	bxbj	0
 块规	bxbo	53800
 𡋶	bxbs	0
@@ -18162,6 +18753,7 @@ encoder:
 𨞪	bxdy	0
 五十	bxed	63800000
 𡉜	bxed	0
+𪤍	bxeh	0
 𡍄	bxej	0
 𣫊	bxej	0
 声带	bxew	912000
@@ -18173,6 +18765,7 @@ encoder:
 块根	bxfx	286000
 块	bxgd	186000000
 五原	bxgn	348000
+𪵑	bxgn	0
 𡎔	bxhb	0
 𣫒	bxhb	0
 声区	bxho	1230000
@@ -18218,6 +18811,7 @@ encoder:
 𡎹	bxlx	0
 五千	bxme	12000000
 𥗚	bxmg	0
+𪣓	bxmh	0
 𠭐	bxmi	0
 𡄈	bxmj	0
 馨	bxmk	38600000
@@ -18250,9 +18844,11 @@ encoder:
 磬	bxqg	2870000
 𧏌	bxqi	0
 𧐡	bxqi	0
+𪡹	bxqj	0
 漀	bxqk	31900
 𣍆	bxqk	0
 𥊧	bxql	0
+𫌤	bxql	0
 䅽	bxqm	4090
 撀	bxqm	75100
 𤛗	bxqm	0
@@ -18270,6 +18866,7 @@ encoder:
 㘲	bxqy	8860
 𢐙	bxqy	0
 𣪤	bxqy	0
+𪤲	bxri	0
 声象	bxrj	168000
 𡄒	bxrj	0
 声乐	bxrk	3780000
@@ -18307,6 +18904,7 @@ encoder:
 坡道	bxwu	632000
 埐	bxwx	49100
 五官	bxwy	10100000
+𪤌	bxxf	0
 㘧	bxxi	4260
 𤍌	bxxu	0
 㙍	bxxx	3980
@@ -18336,6 +18934,7 @@ encoder:
 𡑏	bybj	0
 起来	bybk	252000000
 都未	bybk	6020000
+𪤞	bybm	0
 𡕋	bybn	0
 功夫	bybo	41600000
 教规	bybo	355000
@@ -18379,6 +18978,7 @@ encoder:
 起到	byhk	24600000
 教区	byho	686000
 都督	byia	1400000
+𪣀	byia	0
 起点	byij	36600000
 起步	byik	18500000
 教龄	byio	727000
@@ -18435,6 +19035,7 @@ encoder:
 场	byod	584000000
 功德	byoe	4740000
 教父	byoo	10300000
+𪤗	byop	0
 场馆	byow	7040000
 教令	byow	209000
 起锚	bype	317000
@@ -18521,6 +19122,7 @@ encoder:
 𡒔	byyn	0
 㙝	byyq	4070
 起飞	byyt	8210000
+𫅢	byyt	0
 场院	byyw	215000
 超限	byyx	1710000
 𡒘	byzb	0
@@ -18712,6 +19314,8 @@ encoder:
 击键	bzpy	113000
 动脉	bzqs	14200000
 劫狱	bzqs	276000
+𪣁	bzrd	0
+𪤖	bzrd	0
 𡊮	bzrh	0
 𡋡	bzrh	0
 𣱌	bzrh	0
@@ -18725,9 +19329,11 @@ encoder:
 击毙	bzrr	3170000
 𠫾	bzrr	0
 𡕮	bzrr	0
+𪣾	bzrr	0
 去留	bzrs	4060000
 逺	bzrw	340000
 𪚸	bzrw	0
+𫇤	bzry	0
 鵶	bzrz	50500
 𩿟	bzrz	0
 𩿹	bzrz	0
@@ -18743,6 +19349,7 @@ encoder:
 却说	bzsv	12700000
 专讯	bzsy	431000
 动词	bzsy	2720000
+𪠢	bztg	0
 专门	bztl	91200000
 动情	bzuc	4420000
 云烟	bzuj	1900000
@@ -18778,6 +19385,7 @@ encoder:
 云层	bzxb	2150000
 𤿜	bzxi	0
 劫难	bzxn	2040000
+𪠝	bzxr	0
 坶	bzya	102000
 刧	bzyd	66400
 䂲	bzyg	5150
@@ -18814,6 +19422,7 @@ encoder:
 𤥗	cahx	0
 王国	cajc	27200000
 奏响	cajn	1620000
+𪻡	caju	0
 𤧮	cakf	0
 瑨	cakk	298000
 𤨁	cakk	0
@@ -18859,6 +19468,7 @@ encoder:
 玒	cbia	135000
 璹	cbjd	64700
 𤩖	cbjk	0
+𪼄	cbjr	0
 耕田	cbki	1050000
 𤩾	cbki	0
 玩赏	cbkw	499000
@@ -18884,6 +19494,8 @@ encoder:
 奉令	cbow	214000
 耕翻	cbpk	152000
 𤤲	cbqd	0
+𪳈	cbqf	0
+𪻧	cbrb	0
 玩	cbrd	372000000
 𤦿	cbrj	0
 珯	cbrr	399000
@@ -18930,10 +19542,12 @@ encoder:
 𩰟	ccgu	0
 𩰎	cchm	0
 𩰒	ccju	0
+𪼡	cckk	0
 𩰗	cckl	0
 𩰝	cckl	0
 彗星	cckm	5120000
 𤦗	cckv	0
+𪼃	cckv	0
 䰗	cckz	3880
 𩰘	cckz	0
 慧黠	cclb	378000
@@ -18951,6 +19565,7 @@ encoder:
 𤦠	ccon	0
 𩰞	ccoo	0
 䰘	ccop	3950
+𪻴	ccop	0
 𤧂	ccow	0
 𤧲	ccoy	0
 𩰏	ccoy	0
@@ -18961,6 +19576,7 @@ encoder:
 𤪵	ccrr	0
 𩰍	ccsi	0
 鬧	ccsl	8930000
+𪯥	ccso	0
 琴	ccsx	51300000
 鬦	ccte	56700
 琴头	cctg	90500
@@ -19035,6 +19651,7 @@ encoder:
 三倍	cdns	5890000
 寿命	cdoa	28700000
 三分	cdoy	29600000
+𪻢	cdpd	0
 三月	cdqv	58400000
 三九	cdqy	6400000
 𪎍	cdri	0
@@ -19084,6 +19701,7 @@ encoder:
 𦖿	ceaj	0
 𦗞	ceaj	0
 𦗧	ceaj	0
+𪻸	ceaj	0
 䎾	ceal	3500
 聩	ceal	210000
 聵	ceal	54600
@@ -19106,11 +19724,13 @@ encoder:
 𦕜	cebk	0
 𦕝	cebk	0
 𦕷	cebk	0
+𪼘	cebk	0
 䎴	cebn	3600
 𤨢	cebo	0
 𦔾	cebo	0
 𤧳	cebr	0
 𦕳	cebr	0
+𪼒	cebr	0
 𦗣	cebu	0
 𦗩	cebu	0
 耺	cebz	26600
@@ -19137,11 +19757,14 @@ encoder:
 𦕐	ceeb	0
 𦖋	ceeb	0
 𦗉	ceeb	0
+𪣿	ceeb	0
 𦗫	ceef	0
 𦖱	ceej	0
 𤩳	ceel	0
 𦕠	ceeo	0
 𦖌	ceeo	0
+𫆓	ceer	0
+𪪩	ceeu	0
 𪔠	ceex	0
 䏇	cefb	3770
 𤨳	cefb	0
@@ -19157,6 +19780,7 @@ encoder:
 𨝮	cefy	0
 𡒍	cegb	0
 耳聋	cegc	1620000
+𪻷	cegj	0
 㔌	cegk	4550
 聏	cegl	37100
 𦖁	cegl	0
@@ -19185,6 +19809,7 @@ encoder:
 𣀒	ceix	0
 𦔼	ceix	0
 𦖐	ceiy	0
+𫆄	ceiz	0
 聝	ceja	44200
 瑾	cejc	5880000
 聖	cejc	39400000
@@ -19196,6 +19821,7 @@ encoder:
 䏀	cejk	4190
 𦗴	cejk	0
 𦘆	cejl	0
+𫆋	cejl	0
 璥	cejm	61800
 𦗇	cejm	0
 瓘	cejn	488000
@@ -19213,6 +19839,7 @@ encoder:
 𦖕	cekc	0
 刵	cekd	26600
 𦗡	ceke	0
+𫆐	ceke	0
 𦖍	cekf	0
 𦗔	cekf	0
 耳光	cekg	6740000
@@ -19222,12 +19849,14 @@ encoder:
 䎶	ceki	3470
 𤲌	ceki	0
 䏆	cekk	3710
+𫆑	cekk	0
 𦕈	cekm	0
 𦖤	cekm	0
 璜	ceko	5940000
 𤩲	cekr	0
 弄堂	cekw	1260000
 𦖻	cekw	0
+𪟤	ceky	0
 𦖈	cekz	0
 𦖧	cekz	0
 𦗆	cekz	0
@@ -19239,6 +19868,7 @@ encoder:
 𦕘	celb	0
 𦕋	celd	0
 𦖉	celd	0
+𪻳	celd	0
 瑛	celg	5980000
 𦗘	celg	0
 䎺	celk	3520
@@ -19253,6 +19883,7 @@ encoder:
 珙县	celz	230000
 聅	cema	63200
 𦔽	cemb	0
+𫆅	cemb	0
 𤯩	cemc	0
 耳垂	ceme	1300000
 毦	cemh	113000
@@ -19281,6 +19912,7 @@ encoder:
 䏂	cenx	3600
 瓁	cenx	119000
 𦖚	cenx	0
+𫆂	ceoc	0
 𦖒	ceoe	0
 𤨓	ceof	0
 𦖣	ceof	0
@@ -19292,6 +19924,7 @@ encoder:
 𦗋	ceoj	0
 𤨶	ceok	0
 𦘋	ceol	0
+𫆌	ceol	0
 瑹	ceom	510000
 𦖘	ceom	0
 璊	ceoo	117000
@@ -19300,16 +19933,19 @@ encoder:
 𦖏	ceoo	0
 𦗹	ceoo	0
 𦘎	ceoo	0
+𫆊	ceoo	0
 聄	ceop	57500
 𦗖	ceop	0
 𦡠	ceoq	0
 𦖸	ceor	0
 聸	ceos	41500
 𦕻	ceos	0
+𪻚	ceos	0
 𤧴	ceou	0
 聆	ceow	7690000
 𤧍	ceow	0
 𦖟	ceow	0
+𫆒	ceow	0
 𦖪	ceox	0
 聁	ceoy	33600
 𤦈	ceoy	0
@@ -19318,6 +19954,7 @@ encoder:
 𤩐	cepd	0
 𦕄	cepd	0
 弄错	cepe	2550000
+𫆇	cepf	0
 𦗌	cepn	0
 𥪻	ceps	0
 𦖀	cepy	0
@@ -19340,6 +19977,7 @@ encoder:
 𦗈	cerm	0
 𦗲	cerm	0
 𦗸	cerm	0
+𫆁	cero	0
 𦕑	cers	0
 𦖡	cers	0
 𦗽	cers	0
@@ -19372,11 +20010,13 @@ encoder:
 耳闻	cetc	2580000
 𢌌	cetg	0
 𦘅	cetg	0
+𪻨	cetg	0
 𦗓	cetx	0
 𤪣	ceub	0
 弄懂	ceue	1370000
 聠	ceue	35800
 𦖣	ceuf	0
+𪳎	ceuf	0
 联	ceug	265000000
 𦗢	ceuj	0
 𥉔	ceul	0
@@ -19410,6 +20050,7 @@ encoder:
 𨟡	cewy	0
 恥	cewz	9040000
 𢚸	cewz	0
+𪫵	cewz	0
 埾	cexb	29800
 𤦟	cexc	0
 𦘁	cexc	0
@@ -19420,6 +20061,7 @@ encoder:
 𦘀	cexi	0
 𪘸	cexi	0
 䎸	cexj	4050
+𪼧	cexj	0
 䎼	cexk	3890
 𣷗	cexk	0
 𦗬	cexk	0
@@ -19427,6 +20069,7 @@ encoder:
 𤚉	cexm	0
 𦕨	cexo	0
 𤔛	cexp	0
+𫆍	cexq	0
 取	cexs	423000000
 𦔹	cexs	0
 𧩞	cexs	0
@@ -19449,10 +20092,12 @@ encoder:
 𦔳	ceym	0
 𦕚	ceyn	0
 𦗗	ceyn	0
+𫛉	ceyr	0
 𤭗	ceys	0
 𤭡	ceys	0
 𤭿	ceys	0
 𤮱	ceys	0
+𪠱	ceys	0
 𦖯	ceyu	0
 𦖹	ceyu	0
 聬	ceyy	44000
@@ -19468,6 +20113,7 @@ encoder:
 𪚁	cezi	0
 瓂	cezl	65800
 𦖬	cezl	0
+𫆆	cezm	0
 𩀳	cezn	0
 𦖶	cezs	0
 䏉	cezu	3490
@@ -19488,6 +20134,7 @@ encoder:
 瑼	cfds	50800
 𤧵	cfds	0
 𤫦	cfeq	0
+𪼬	cfff	0
 㻷	cffl	6360
 瓀	cfgl	25300
 㻝	cfjk	4040
@@ -19497,9 +20144,11 @@ encoder:
 瑓	cflk	37200
 琜	cfoo	72900
 𤫩	cfoo	0
+𪻩	cfpd	0
 𤫢	cfrj	0
 瓎	cfrl	29300
 璷	cfsm	26100
+𪼗	cfso	0
 𤩗	cfuf	0
 璤	cfwz	23900
 璴	cfxi	31700
@@ -19510,9 +20159,11 @@ encoder:
 环形	cgae	2410000
 琦	cgaj	13900000
 𤨯	cgaj	0
+𪼩	cgan	0
 𤦐	cgbb	0
 𤧊	cgbb	0
 环城	cgbh	2800000
+𪻦	cgbk	0
 㻟	cgbq	4220
 环境	cgbs	265000000
 环球	cgcd	39300000
@@ -19522,8 +20173,10 @@ encoder:
 环顾	cggy	2990000
 珔	cgiy	505000
 𤨀	cgka	0
+𪻵	cgkb	0
 璙	cgkk	23400
 𤪃	cgku	0
+𪻶	cgky	0
 𤤰	cgli	0
 𤩵	cgll	0
 环县	cglz	1160000
@@ -19531,8 +20184,10 @@ encoder:
 𤪾	cgmc	0
 瓑	cgmi	224000
 环保	cgnj	99500000
+𪼆	cgnk	0
 环行	cgoi	521000
 𤥵	cgoo	0
+𪼐	cgoo	0
 𤤒	cgos	0
 环岛	cgrl	1670000
 琢磨	cgtf	17600000
@@ -19578,6 +20233,7 @@ encoder:
 𩰈	chbg	0
 长城	chbh	33900000
 长工	chbi	1320000
+𪻙	chbi	0
 䯾	chbj	3400
 髻	chbj	2810000
 𨱻	chbj	0
@@ -19599,6 +20255,7 @@ encoder:
 𨲑	chbz	0
 𩬨	chbz	0
 𩭯	chbz	0
+𫘽	chbz	0
 𩯻	chcc	0
 𩰆	chcc	0
 长寿	chcd	9360000
@@ -19665,6 +20322,7 @@ encoder:
 长大	chgd	42100000
 𩬴	chge	0
 𩯹	chgg	0
+𫘾	chgh	0
 䯱	chgi	3640
 长存	chgi	1790000
 𩭍	chgj	0
@@ -19685,6 +20343,7 @@ encoder:
 𩭐	chgq	0
 髡	chgr	865000
 𩬇	chgs	0
+𫔗	chgu	0
 长在	chgv	8560000
 髪	chgx	22100000
 𨱾	chgy	0
@@ -19735,6 +20394,7 @@ encoder:
 𩮶	chjr	0
 𩯯	chjr	0
 𩯴	chjr	0
+𫙁	chjr	0
 𩮖	chju	0
 𩯇	chju	0
 长叹	chjx	4930000
@@ -19756,6 +20416,7 @@ encoder:
 𩭂	chkg	0
 长辈	chkh	6260000
 𩯈	chkh	0
+𫘼	chki	0
 𩭸	chkj	0
 镽	chkk	30900
 髷	chkk	237000
@@ -19774,6 +20435,7 @@ encoder:
 𩮂	chkr	0
 𩯝	chkr	0
 𩯏	chku	0
+𪶰	chkv	0
 䰄	chkw	5360
 𩯵	chkw	0
 𨲄	chkx	0
@@ -19808,6 +20470,7 @@ encoder:
 𨲩	chlx	0
 长眠	chly	2220000
 𩮺	chly	0
+𫙃	chly	0
 𨲴	chlz	0
 𩮐	chlz	0
 𩮻	chlz	0
@@ -19909,6 +20572,7 @@ encoder:
 鬛	choz	34100
 鬣	choz	1120000
 𨱛	choz	0
+𫙀	chpb	0
 𩬡	chpd	0
 䰂	chpf	4750
 鬚	chpg	2260000
@@ -19974,6 +20638,7 @@ encoder:
 𨳂	chrs	0
 𩭲	chrs	0
 𩰃	chrs	0
+𫘹	chrs	0
 鬇	chrx	29300
 髱	chry	98600
 𩮼	chry	0
@@ -20026,6 +20691,7 @@ encoder:
 鬈	chuy	813000
 𨲏	chuy	0
 𩬸	chuz	0
+𫙂	chuz	0
 长兴	chva	3350000
 长汀	chva	986000
 长河	chva	5450000
@@ -20056,7 +20722,9 @@ encoder:
 长途	chwo	21200000
 𨱤	chwq	0
 𩭠	chwq	0
+𫘻	chwq	0
 髧	chwr	28200
+𫔖	chwr	0
 䰓	chws	3910
 𨲾	chws	0
 𨳅	chws	0
@@ -20076,6 +20744,7 @@ encoder:
 𩬣	chxb	0
 𩬶	chxb	0
 𩮢	chxb	0
+𪼑	chxb	0
 𩬋	chxe	0
 𤦲	chxf	0
 𩮧	chxf	0
@@ -20083,6 +20752,7 @@ encoder:
 髲	chxi	43700
 𨱢	chxi	0
 𩮩	chxj	0
+𫘿	chxj	0
 䰁	chxk	5860
 鬝	chxk	20400
 𨲒	chxk	0
@@ -20101,6 +20771,7 @@ encoder:
 𩭮	chxw	0
 𨱣	chxx	0
 长子	chya	3210000
+𫘸	chyd	0
 𩬰	chyg	0
 𩮁	chyg	0
 䯲	chyi	3420
@@ -20136,6 +20807,7 @@ encoder:
 长女	chzm	998000
 𨱽	chzm	0
 𩬲	chzm	0
+𫘺	chzm	0
 𩯕	chzn	0
 𩮉	chzo	0
 𩬌	chzr	0
@@ -20167,12 +20839,14 @@ encoder:
 𠁳	cicl	0
 𣮝	cicm	0
 琥珀	cicn	9970000
+𫕻	cicq	0
 𢜎	cicw	0
 彗	cicx	1250000
 𦑓	cicy	0
 蠢事	cidj	1240000
 寿	cids	26600000
 焘	cidu	416000
+𪫷	cidw	0
 丰茂	cieh	415000
 丰南	ciel	377000
 𩇡	cies	0
@@ -20198,9 +20872,11 @@ encoder:
 𧑨	ciii	0
 𧔄	ciii	0
 𪎋	ciij	0
+𫑢	ciji	0
 麺	cijk	18200000
 𩱏	cijl	0
 𩇢	cijm	0
+𫜓	cijq	0
 𠓆	cijr	0
 𤋒	ciju	0
 𧯮	ciju	0
@@ -20218,11 +20894,13 @@ encoder:
 瓐	cikl	25400
 𪎊	cikm	0
 㻉	ciko	3930
+𫕼	cikr	0
 𣍈	ciku	0
 琡	cikx	62000
 𠡾	ciky	0
 𤩡	cild	0
 𩔳	cilg	0
+𫖴	cilg	0
 䚍	cill	4150
 𥡯	cilm	0
 責	cilo	5750000
@@ -20232,7 +20910,9 @@ encoder:
 𣤈	cilr	0
 𪄸	cilr	0
 𠂴	cilu	0
+𪬿	cilw	0
 勣	cily	227000
+𪟝	cily	0
 丰县	cilz	3480000
 𩱏	cima	0
 聱	cimc	170000
@@ -20277,6 +20957,7 @@ encoder:
 𠢕	cimy	0
 嫯	cimz	101000
 纛	cimz	869000
+𫜔	cine	0
 丰顺	cing	517000
 幚	cinl	67600
 䨼	cinx	3780
@@ -20289,6 +20970,7 @@ encoder:
 𤪻	ciol	0
 𤪽	ciol	0
 𦚨	cioo	0
+𫆰	cioo	0
 䵅	cior	7360
 𤩁	cios	0
 𩇙	ciow	0
@@ -20303,17 +20985,22 @@ encoder:
 靚	ciql	15300000
 靔	ciqm	20000
 靝	ciqm	33200
+𫕹	ciqm	0
 丰腴	ciqn	1120000
 𨿬	ciqn	0
 𩇕	ciqp	0
 䴖	ciqr	19800
 鶄	ciqr	71200
 	ciqr	0
+𫕺	ciqu	0
 靛	ciqw	7380000
+𪬿	ciqw	0
 郬	ciqy	58500
+𫜑	circ	0
 𩓳	cirg	0
 表	cirh	1050000000
 𪎈	cirh	0
+𫕸	ciri	0
 㗉	cirj	3830
 𠲱	cirj	0
 𦃅	cirj	0
@@ -20350,7 +21037,9 @@ encoder:
 𦤿	ciwh	0
 𪎐	ciwl	0
 𩇣	ciwm	0
+𪬇	ciwm	0
 丰裕	ciwo	370000
+𫜒	ciwr	0
 𢗣	ciwz	0
 𢑹	cixb	0
 𤥷	cixb	0
@@ -20360,7 +21049,9 @@ encoder:
 𡘱	cixg	0
 𦥆	cixh	0
 𤥩	cixi	0
+𪼧	cixj	0
 𣊄	cixk	0
+𪽂	cixm	0
 㺳	cixs	4630
 𤪨	cixs	0
 熭	cixu	23000
@@ -20380,6 +21071,7 @@ encoder:
 𩓁	ciyg	0
 蛪	ciyi	28600
 齧	ciyi	279000
+𫜩	ciyi	0
 洯	ciyk	666000
 帮	ciyl	227000000
 㸷	ciym	4750
@@ -20407,6 +21099,7 @@ encoder:
 豔	cizl	4870000
 𩇠	cizl	0
 丰收	cizm	7770000
+𪯑	cizm	0
 𩇤	cizq	0
 𪅸	cizr	0
 𠫢	cizs	0
@@ -20414,6 +21107,7 @@ encoder:
 毒	cizy	93600000
 㻍	cjag	3960
 璝	cjal	76900
+𪻺	cjal	0
 职工	cjbi	47000000
 𤥪	cjbn	0
 职责	cjcl	34700000
@@ -20422,6 +21116,7 @@ encoder:
 噩梦	cjff	2750000
 职权	cjfx	9140000
 𤩩	cjia	0
+𪼓	cjja	0
 璪	cjjf	62400
 䫷	cjjg	3340
 噩	cjjj	1320000
@@ -20459,12 +21154,15 @@ encoder:
 䎯	ckbo	3490
 理塘	ckbt	288000
 𦔥	ckbu	0
+𪼲	ckbu	0
 䎬	ckbz	17700
 理亏	ckbz	705000
 耘	ckbz	2500000
 	ckbz	0
 𦓷	ckbz	0
 耫	ckcl	26600
+𫅽	ckco	0
+𪱟	ckcq	0
 𤩛	ckcx	0
 理事	ckdj	49000000
 琐事	ckdj	4850000
@@ -20483,6 +21181,7 @@ encoder:
 理想	ckfl	111000000
 耨	ckgd	642000
 𦓶	ckgh	0
+𫅺	ckgl	0
 頛	ckgo	48200
 珖	ckgr	525000
 琐碎	ckgs	3900000
@@ -20506,6 +21205,7 @@ encoder:
 𦔐	ckjl	0
 𦓾	ckjm	0
 理喻	ckjo	1540000
+𪼚	ckjr	0
 𦔪	ckjz	0
 𦓵	ckkb	0
 𦔉	ckkb	0
@@ -20513,8 +21213,10 @@ encoder:
 𠛨	ckkd	0
 𤨆	ckkg	0
 理由	ckki	155000000
+𫅹	ckki	0
 瓃	ckkk	124000
 𤩜	ckkk	0
+𫅻	ckkk	0
 耥	ckkl	99500
 耖	ckkm	219000
 𦔈	ckkm	0
@@ -20558,6 +21260,7 @@ encoder:
 理智	ckmj	27700000
 𤥮	ckmj	0
 𦔄	ckml	0
+𪻻	ckml	0
 𢼡	ckmo	0
 𤥟	ckms	0
 理科	ckmt	25400000
@@ -20567,6 +21270,7 @@ encoder:
 𦔠	ckne	0
 理顺	ckng	3960000
 𦔑	cknj	0
+𫅿	cknl	0
 聘任	cknm	4310000
 理化	cknr	4790000
 𦓮	ckns	0
@@ -20625,6 +21329,7 @@ encoder:
 𣅨	ckvv	0
 泰宁	ckwa	511000
 𦔖	ckwf	0
+𫅼	ckwh	0
 耰	ckwr	53400
 耪	ckws	76900
 耢	ckwy	93600
@@ -20641,6 +21346,7 @@ encoder:
 耙	ckyi	2310000
 䎤	ckyj	3980
 耞	ckyj	108000
+𫅾	ckyk	0
 𦔤	ckyl	0
 𦓨	ckyy	0
 𦔣	ckyz	0
@@ -20660,6 +21366,7 @@ encoder:
 瑞丽	clal	5320000
 瑞士	clba	36900000
 琱	clbj	97800
+𪼢	clbu	0
 琠	cleo	83800
 𤫡	clez	0
 𦉦	clez	0
@@ -20689,6 +21396,7 @@ encoder:
 珼	cloa	117000
 责令	clow	9460000
 瑞金	clpa	2460000
+𪼇	clrc	0
 㻿	clri	5450
 责备	clrk	3830000
 𤨉	clrm	0
@@ -20738,6 +21446,7 @@ encoder:
 耗电	cmkz	1790000
 秦岭	cmlo	1650000
 𤩏	cmmb	0
+𪼋	cmmh	0
 珠算	cmml	635000
 𤤥	cmod	0
 瓈	cmok	51100
@@ -20799,10 +21508,12 @@ encoder:
 𤫅	cnnj	0
 𤧙	cnod	0
 𤪒	cnof	0
+𪼰	cnom	0
 𤧯	cnor	0
 𤨌	cnow	0
 𤥱	cnox	0
 𤦑	cnox	0
+𪼣	cnpg	0
 𤥰	cnrd	0
 𤦤	cnrd	0
 璁	cnrw	3170000
@@ -20815,6 +21526,7 @@ encoder:
 瑰宝	cnwc	1860000
 𤧝	cnxm	0
 𤤱	cnxs	0
+𪼌	cnxs	0
 㻪	cnym	4060
 𤦥	cnzm	0
 𢦋	cnzw	0
@@ -20831,9 +21543,12 @@ encoder:
 奉	cobi	23400000
 𦦺	cobj	0
 𥘿	cobk	0
+𪼊	cobo	0
 䳞	cobr	3190
 𠒏	cobr	0
+𫛍	cobr	0
 㻅	cobz	4030
+𪻖	cobz	0
 春耕	cocb	1840000
 𣋕	cocb	0
 𣌠	cocc	0
@@ -20872,11 +21587,13 @@ encoder:
 璯	colk	69700
 𧡲	colr	0
 𡏑	comb	0
+𫀜	comb	0
 㻌	comf	4980
 秦	comf	89600000
 𤦜	comi	0
 𦦜	comi	0
 珍重	comk	3790000
+𫋫	coml	0
 𥠼	comm	0
 𦦱	comn	0
 珍稀	como	3680000
@@ -20894,6 +21611,7 @@ encoder:
 𪆊	conr	0
 憃	conw	35800
 瑜伽	cony	22300000
+𪻐	cood	0
 𡙹	cooe	0
 㻜	cooi	3860
 瑽	cooi	44000
@@ -20906,6 +21624,7 @@ encoder:
 珍爱	copw	4230000
 瑜	coqk	16400000
 春风	coqo	14700000
+𪼔	coqq	0
 𤥞	coqx	0
 𤫄	corg	0
 𤪀	corr	0
@@ -20914,6 +21633,7 @@ encoder:
 𪂹	corz	0
 𪃣	corz	0
 春意	cosk	7370000
+𪥐	cosl	0
 𣁤	coss	0
 玪	cosx	83600
 春装	cotb	2520000
@@ -20938,7 +21658,10 @@ encoder:
 玢	coyd	265000
 𤧒	coyl	0
 𦒰	coyn	0
+𪼜	coyo	0
 玱	coyy	69500
+𪩫	coyy	0
+𪼜	coyy	0
 𤦴	cozk	0
 玜	cozs	53700
 𤥼	cozw	0
@@ -20949,10 +21672,12 @@ encoder:
 瑗	cpgx	1180000
 瑷	cpgx	635000
 璠	cpki	292000
+𪻬	cpll	0
 𤪞	cplr	0
 瑫	cpnb	50500
 𤪊	cpow	0
 瓆	cppl	49500
+𪼪	cpqg	0
 𤩥	cprm	0
 瑶族	cpsm	2190000
 琻	cpvv	65400
@@ -21029,6 +21754,7 @@ encoder:
 𤦶	cram	0
 玖万	cray	36700
 𤥋	cray	0
+𪻎	crbd	0
 聊城	crbh	7770000
 㻮	crbk	4140
 表示	crbk	1340000000
@@ -21081,6 +21807,7 @@ encoder:
 玭	crrr	182000
 𤩞	crrr	0
 𤥀	crrs	0
+𪼤	crrs	0
 麦冬	crrt	850000
 𤧔	crry	0
 表彰	crsk	19500000
@@ -21090,6 +21817,7 @@ encoder:
 表率	crsv	4840000
 𤧚	crsw	0
 𤤮	crtd	0
+𪻎	crtd	0
 表决	crtx	6540000
 表情	cruc	232000000
 表弟	cruy	2180000
@@ -21125,19 +21853,25 @@ encoder:
 玉树	csfx	3530000
 玉石	csga	9590000
 𤧿	csgl	0
+𪻾	csgp	0
 玣	csid	24000
 斑点	csij	8890000
+𪼱	csil	0
 玉器	csjj	11500000
 琼	csjk	23100000
 𤧼	csjl	0
 琼中	csjv	428000
+𪻥	csjy	0
 璮	cska	31200
 𤩔	cskb	0
 璋	cske	3490000
 𤨼	cske	0
+𪼝	cskg	0
+𪼞	cskh	0
 玉田	cski	2690000
 璄	cskr	62200
 瓌	cskr	52000
+𪼦	cskw	0
 玉雕	cslb	1340000
 斑岩	cslg	114000
 玉山	csll	4700000
@@ -21146,6 +21880,9 @@ encoder:
 瓋	cslw	25100
 璃	cslz	5100000
 𤩺	csmh	0
+𪼕	csmm	0
+𪻯	csmo	0
+𪼂	csmo	0
 𤧦	csmu	0
 㻢	csmy	3600
 𤦽	csmy	0
@@ -21157,9 +21894,11 @@ encoder:
 𤥿	csnr	0
 𤪿	csnr	0
 琗	csoe	31300
+𪼁	csog	0
 珓	csoo	85400
 𤥽	csot	0
 珳	cspd	38300
+𪻑	csqd	0
 斑鸠	csqr	481000
 琼脂	csqr	595000
 玉玺	csrk	783000
@@ -21182,6 +21921,7 @@ encoder:
 𤧟	cswa	0
 𤪗	cswg	0
 𤧛	cswl	0
+𪼀	cswl	0
 𤦻	cswr	0
 𤧭	csws	0
 斑马	csxa	2770000
@@ -21196,16 +21936,19 @@ encoder:
 𤥑	cszm	0
 琉	cszn	4450000
 𤫚	cszn	0
+𪻞	cszo	0
 㻙	cszq	3970
 珫	cszr	65100
 玹	cszz	683000
 𤥦	ctbs	0
 㺶	cted	3870
+𪻿	ctex	0
 𤧻	ctmb	0
 𤪮	ctob	0
 𤪮	ctrb	0
 𤦿	ctrj	0
 𤦾	ctrz	0
+𪼥	ctux	0
 瑭	ctxj	556000
 𤨭	ctxl	0
 𤨫	ctxw	0
@@ -21236,6 +21979,7 @@ encoder:
 䭶	cuan	4230
 𩢷	cuan	0
 𩥿	cuan	0
+𫘙	cuar	0
 駍	cuau	24300
 騁	cuaz	227000
 𩢆	cuaz	0
@@ -21255,6 +21999,7 @@ encoder:
 䭼	cubn	4610
 𩤻	cubo	0
 𩥲	cubo	0
+𫘆	cubo	0
 𩢄	cubr	0
 𩧝	cubr	0
 驛	cubu	1250000
@@ -21280,11 +22025,13 @@ encoder:
 𩦤	cuch	0
 𧕸	cuci	0
 𩥌	cucj	0
+𫘋	cucl	0
 𥤡	cucm	0
 𩥚	cucm	0
 𩥫	cucn	0
 䮞	cuco	3260
 𩤣	cucq	0
+𪱟	cucq	0
 𩤕	cucr	0
 𪄕	cucr	0
 𪉒	cucr	0
@@ -21318,6 +22065,7 @@ encoder:
 𩣲	cueo	0
 𩦖	cueo	0
 𩦸	cueo	0
+𫘚	cueo	0
 驤	cuer	161000
 𩦪	cuer	0
 联营	cuew	4350000
@@ -21330,8 +22078,10 @@ encoder:
 驃	cufb	57200
 㻥	cufd	3600
 𩧜	cufd	0
+𫘒	cufd	0
 𩧅	cufg	0
 駷	cufj	54200
+𫘊	cufj	0
 𩣳	cufk	0
 联想	cufl	51400000
 驦	cufl	24700
@@ -21363,6 +22113,7 @@ encoder:
 璲	cugw	66500
 𩢚	cugx	0
 䮊	cugy	3530
+𪼫	cugy	0
 𩣊	cuha	0
 駤	cuhb	24500
 𩣪	cuhb	0
@@ -21378,6 +22129,7 @@ encoder:
 駆	cuho	4370000
 𩦋	cuho	0
 𩣕	cuhp	0
+𫘇	cuhr	0
 駏	cuhx	32400
 駵	cuhx	25800
 䮅	cuhz	3420
@@ -21386,6 +22138,7 @@ encoder:
 𩢩	cuia	0
 𩡭	cuid	0
 𩤋	cuif	0
+𫘌	cuih	0
 𩤎	cuij	0
 驉	cuik	39000
 𩣝	cuik	0
@@ -21415,10 +22168,12 @@ encoder:
 䮠	cujk	6390
 𩤲	cujk	0
 𩥺	cujk	0
+𫘏	cujk	0
 䮥	cujl	6060
 䮦	cujl	3500
 驕	cujl	1740000
 𩤬	cujl	0
+𫘍	cujl	0
 𩤁	cujm	0
 𩤮	cujm	0
 𩥹	cujm	0
@@ -21440,6 +22195,7 @@ encoder:
 䣖	cujy	3160
 驙	cuka	23000
 䮵	cukb	4140
+𫘐	cukb	0
 騑	cukc	93000
 䮓	cuke	3460
 騨	cuke	102000
@@ -21519,6 +22275,7 @@ encoder:
 馲	cumh	30600
 騀	cumh	30800
 𩢵	cumh	0
+𪼯	cumh	0
 駳	cumi	18700
 𩢐	cumi	0
 𩣜	cumi	0
@@ -21583,6 +22340,7 @@ encoder:
 𩤏	cuoe	0
 𩦗	cuoe	0
 𩤞	cuof	0
+𫘔	cuoi	0
 䮿	cuoj	4030
 𩣥	cuoj	0
 𩢜	cuok	0
@@ -21592,6 +22350,7 @@ encoder:
 駼	cuom	33800
 騇	cuom	28300
 𩥽	cuom	0
+𫘓	cuom	0
 𩡺	cuon	0
 𩢯	cuon	0
 𩥒	cuon	0
@@ -21605,6 +22364,7 @@ encoder:
 𩥗	cuoo	0
 𩥾	cuoo	0
 𩧁	cuoo	0
+𫘗	cuoo	0
 駗	cuop	28800
 驂	cuop	57700
 䮚	cuor	3510
@@ -21641,6 +22401,7 @@ encoder:
 騚	cuqk	42400
 騟	cuqk	22800
 班风	cuqo	322000
+𫘈	cuqx	0
 𩣱	curb	0
 𩧇	curb	0
 𩥪	curc	0
@@ -21685,6 +22446,7 @@ encoder:
 𩥎	cury	0
 騶	curz	69900
 𩣛	curz	0
+𪼎	curz	0
 𩤑	cusb	0
 駐	cusc	11600000
 騂	cuse	38500
@@ -21715,6 +22477,7 @@ encoder:
 驣	cuuc	47500
 𩣆	cuuc	0
 駢	cuue	158000
+𫘑	cuug	0
 𤩕	cuuj	0
 𩦇	cuuj	0
 𩦐	cuuj	0
@@ -21725,11 +22488,13 @@ encoder:
 𩥍	cuum	0
 琰	cuuo	1660000
 𤊇	cuuo	0
+𫘉	cuuo	0
 䯁	cuuq	3310
 𤫙	cuuu	0
 𩧟	cuuu	0
 䮟	cuux	3380
 𤫉	cuux	0
+𫘕	cuux	0
 𩢣	cuuz	0
 駲	cuvn	43200
 駣	cuvr	53700
@@ -21794,14 +22559,17 @@ encoder:
 馭	cuxs	814000
 駅	cuxs	116000000
 𤥎	cuxs	0
+𫘅	cuxs	0
 騐	cuxw	24700
 䮕	cuxx	3480
 騢	cuxx	25500
 𩢃	cuxx	0
+𪦠	cuxz	0
 班子	cuya	15100000
 𩧣	cuyb	0
 𩡰	cuye	0
 𩣸	cuye	0
+𪼯	cuyh	0
 馳	cuyi	3220000
 駋	cuyj	27500
 駶	cuyj	35400
@@ -21810,6 +22578,7 @@ encoder:
 𩦝	cuyl	0
 䮯	cuym	3540
 驐	cuym	22600
+𪼯	cuym	0
 騽	cuyn	30000
 联队	cuyo	2500000
 𩥩	cuyo	0
@@ -21892,10 +22661,12 @@ encoder:
 𤦮	cvzj	0
 珱	cvzm	62200
 现出	cvzz	3670000
+𪻝	cwad	0
 𤧽	cwag	0
 𤨥	cwaj	0
 琮	cwbk	1550000
 瑄	cwbk	5620000
+𪻭	cwbk	0
 𤧺	cwbl	0
 琎	cwbn	345000
 𤩼	cwbq	0
@@ -21918,7 +22689,10 @@ encoder:
 琏	cwhe	936000
 瑏	cwhi	146000
 𤫐	cwjr	0
+𪼨	cwjr	0
+𪼮	cwjr	0
 𤨖	cwjy	0
+𪼍	cwka	0
 㻘	cwki	3870
 璸	cwkl	146000
 𤫞	cwkl	0
@@ -21927,10 +22701,12 @@ encoder:
 𤦌	cwlc	0
 㻞	cwld	4130
 𤤚	cwli	0
+𪼭	cwlw	0
 𤨚	cwmi	0
 𤩻	cwmm	0
 𤧫	cwmy	0
 璡	cwni	68300
+𪼖	cwno	0
 𤧫	cwnx	0
 琛	cwof	5860000
 瑢	cwoj	218000
@@ -21941,6 +22717,8 @@ encoder:
 瑸	cwpo	40600
 𤤌	cwqd	0
 㻱	cwrc	3810
+𪻔	cwrd	0
+𪻽	cwrj	0
 鬓角	cwrl	492000
 𤨺	cwrp	0
 琬	cwry	1750000
@@ -21981,10 +22759,12 @@ encoder:
 瑋	cxjm	7720000
 璒	cxju	26200
 玛曲	cxkk	210000
+𪼟	cxkm	0
 取暖	cxkp	14300000
 取景	cxks	4210000
 㻖	cxkv	4830
 琭	cxkv	82600
+𪻱	cxkz	0
 聚赌	cxlb	207000
 𤧱	cxld	0
 𤥈	cxli	0
@@ -22038,9 +22818,11 @@ encoder:
 玛沁	cxvw	124000
 取道	cxwu	818000
 聚居	cxxe	3100000
+𪼏	cxxf	0
 𤤂	cxxi	0
 𤤏	cxxs	0
 瑕	cxxx	4330000
+𪼠	cxyq	0
 㻵	cxyy	4350
 𤪆	cxzm	0
 𤪍	cxzm	0
@@ -22058,6 +22840,8 @@ encoder:
 𤣲	cyed	0
 𤩄	cyeo	0
 契机	cyfq	9920000
+𪻟	cygl	0
+𪼅	cygq	0
 珉	cyhd	1510000
 瑉	cyhk	60500
 帮困	cyjf	953000
@@ -22067,12 +22851,14 @@ encoder:
 珽	cymb	199000
 帮手	cymd	11400000
 𤥻	cymi	0
+𪻏	cyms	0
 𤦆	cynb	0
 𤤖	cynd	0
 契合	cyoa	2920000
 帮会	cyob	2420000
 玚	cyod	59800
 璻	cyoe	26100
+𪲠	cyof	0
 璆	cyop	132000
 帮凶	cyoz	1310000
 帮腔	cyqw	420000
@@ -22120,6 +22906,7 @@ encoder:
 瑻	czlo	36500
 𤨏	czlo	0
 𤪫	czlo	0
+𪻲	czlo	0
 毒贩	czlp	989000
 𤪫	czls	0
 毒手	czmd	2770000
@@ -22139,6 +22926,7 @@ encoder:
 𤨿	czrd	0
 毒枭	czrf	719000
 瑙鲁	czrk	620000
+𪻰	czrm	0
 毒计	czse	407000
 毒辣	czsf	2400000
 毒剂	czsn	436000
@@ -22177,6 +22965,7 @@ encoder:
 捷报	dady	1270000
 扞	daed	134000
 捷克	daej	17200000
+𪮵	daeo	0
 攮	daer	133000
 𢭅	daeu	0
 打雷	dafk	2110000
@@ -22195,6 +22984,7 @@ encoder:
 𢯞	dahi	0
 打卡	daia	3100000
 𢩹	daid	0
+𪭤	daii	0
 𢯬	daix	0
 𢪪	daiz	0
 打嗝	daja	743000
@@ -22234,6 +23024,7 @@ encoder:
 𢷡	daof	0
 掚	daoo	26600
 擟	daoo	48200
+𪭵	daoo	0
 𢺕	daor	0
 扙	daos	63100
 𢰯	daot	0
@@ -22244,6 +23035,7 @@ encoder:
 𢪁	daqd	0
 打猎	daqe	2440000
 打杂	daqf	1450000
+𪮌	daqk	0
 打印	dara	687000000
 𢳗	darf	0
 𢵍	darf	0
@@ -22254,11 +23046,13 @@ encoder:
 𢲀	darw	0
 抹煞	darx	818000
 打颤	dasj	730000
+𪭫	dasy	0
 抚育	dasz	953000
 抨	daua	304000
 𢸸	daug	0
 抚恤	daum	2480000
 抚养	daun	5450000
+𪮂	dauy	0
 打消	davk	4160000
 抚州	davn	3790000
 抚宁	dawa	172000
@@ -22352,6 +23146,7 @@ encoder:
 𢴇	dbqs	0
 抏	dbrd	45700
 搘	dbrk	73600
+𪮭	dbrk	0
 㧯	dbrr	5030
 持久	dbrs	19600000
 𢫮	dbrs	0
@@ -22360,6 +23155,7 @@ encoder:
 𢹤	dbrz	0
 𢳆	dbsm	0
 𢭷	dbso	0
+𪮬	dbuj	0
 扶养	dbun	702000
 挟	dbuo	5500000
 𢵓	dbup	0
@@ -22446,6 +23242,7 @@ encoder:
 𢯨	deal	0
 撕裂	dear	5530000
 𢮻	deax	0
+𪯃	deax	0
 技巧	deba	271000000
 技工	debi	8220000
 擆	debm	50100
@@ -22460,6 +23257,7 @@ encoder:
 撕扯	dedi	1500000
 摸排	dedk	339000
 撒播	dedp	770000
+𪮣	dedp	0
 搭救	dedv	1030000
 撶	deeb	939000
 𢱴	deef	0
@@ -22469,6 +23267,7 @@ encoder:
 𢱗	deej	0
 𢴢	deel	0
 𢵕	deem	0
+𪮙	deeo	0
 𢴿	deeq	0
 𢵎	dees	0
 摸索	deew	9510000
@@ -22502,6 +23301,7 @@ encoder:
 描图	dejr	183000
 𢭪	dejr	0
 𢵖	dejr	0
+𫛒	dejr	0
 㩥	deka	10300
 技师	deka	5350000
 撒旦	deka	1370000
@@ -22510,6 +23310,7 @@ encoder:
 摸	dekg	56600000
 描	deki	7280000
 𢲵	dekk	0
+𪮫	dekm	0
 撗	deko	500000
 擖	dekr	67900
 𢶭	dekr	0
@@ -22537,6 +23338,7 @@ encoder:
 𢶤	denr	0
 𢸺	denu	0
 擭	denx	148000
+𪯄	deny	0
 𢹕	deoe	0
 搽	deof	2740000
 攧	deog	79500
@@ -22570,6 +23372,7 @@ encoder:
 𢶰	desw	0
 𢮻	desx	0
 𢳑	desx	0
+𪯃	desx	0
 𢮷	desy	0
 摸底	detr	3350000
 𢴯	deuj	0
@@ -22584,6 +23387,7 @@ encoder:
 𢱢	dewz	0
 𢶬	dexc	0
 𢷟	dexi	0
+𪨵	dexl	0
 𢸳	dexn	0
 技	dexs	93600000
 𢳌	dexz	0
@@ -22606,6 +23410,7 @@ encoder:
 𢲧	dezo	0
 技能	dezq	62600000
 𢱝	dezz	0
+𪮎	dezz	0
 搟	dfae	55000
 𢰁	dfaz	0
 𢷋	dfbd	0
@@ -22646,6 +23451,7 @@ encoder:
 𢺁	dfkr	0
 拺	dfld	544000
 揀	dflk	2860000
+𪮁	dflk	0
 𢲆	dflm	0
 𢺓	dfmb	0
 𢱼	dfme	0
@@ -22658,9 +23464,11 @@ encoder:
 㩕	dfow	3870
 捕食	dfox	2840000
 摲	dfpd	111000
+𪮻	dfpk	0
 𢮴	dfqy	0
 捕鱼	dfra	2490000
 攋	dfrl	60000
+𪮶	dfrl	0
 𢺴	dfrp	0
 𢷛	dfrr	0
 𢶉	dfry	0
@@ -22672,6 +23480,7 @@ encoder:
 𢳬	dfxb	0
 𣡮	dfxd	0
 𢲭	dfyy	0
+𪮸	dfyy	0
 𢰳	dfzm	0
 𢱿	dfzo	0
 𢮨	dfzs	0
@@ -22682,6 +23491,7 @@ encoder:
 𢫲	dgax	0
 㨒	dgbb	4280
 捱	dgbb	2850000
+𪭥	dgbi	0
 捺	dgbk	1570000
 掩埋	dgbk	2540000
 撦	dgbm	84400
@@ -22720,6 +23530,7 @@ encoder:
 𢲅	dgkz	0
 振幅	dgla	2440000
 抪	dgli	45100
+𪭬	dgli	0
 𢴓	dglr	0
 拔罐	dgme	352000
 𢫳	dgme	0
@@ -22728,6 +23539,7 @@ encoder:
 扼制	dgml	659000
 扰乱	dgmz	8590000
 掩体	dgnf	734000
+𪮢	dgnk	0
 振作	dgnm	4140000
 拓片	dgnx	307000
 扼杀	dgof	6470000
@@ -22776,6 +23588,7 @@ encoder:
 揻	dhaz	56100
 拭	dhbi	6260000
 挳	dhbi	587000
+𪮗	dhbk	0
 𢴧	dhbl	0
 撼动	dhbz	2310000
 𢸩	dhcm	0
@@ -22835,6 +23648,7 @@ encoder:
 𢺂	dibu	0
 掉换	didr	292000
 扑救	didv	1560000
+𪮮	dieh	0
 扑克	diej	7220000
 𢵎	dies	0
 據	digq	19300000
@@ -22883,6 +23697,7 @@ encoder:
 𢪊	dixs	0
 𢷂	dixu	0
 𢳌	dixz	0
+𪮄	dixz	0
 𢫋	diya	0
 掳	diym	2820000
 掉队	diyo	792000
@@ -22923,6 +23738,8 @@ encoder:
 摑	djja	663000
 𢰊	djjd	0
 操	djjf	45300000
+𪭶	djji	0
+𪮐	djjj	0
 攌	djjr	50200
 撣	djke	163000
 事由	djki	4110000
@@ -22956,13 +23773,16 @@ encoder:
 𢹡	djpn	0
 事儿	djrd	9510000
 拀	djrd	22900
+𪮯	djri	0
 𢷅	djrj	0
 𢭻	djro	0
 扣留	djrs	3710000
 事务	djry	152000000
+𪭦	djry	0
 事端	djsl	1630000
 事变	djsx	3350000
 拐弯	djsy	2430000
+𪭸	djte	0
 捐资	djtr	2900000
 事情	djuc	214000000
 损益	djuo	3440000
@@ -23005,6 +23825,7 @@ encoder:
 捑	dkas	48800
 押款	dkbb	74800
 提款	dkbb	2340000
+𪮛	dkbd	0
 提示	dkbk	393000000
 揭示	dkbk	16000000
 攩	dkbu	62000
@@ -23268,7 +24089,9 @@ encoder:
 𢫭	dloo	0
 𢳕	dloq	0
 𢴔	dlpx	0
+𪮤	dlqq	0
 摆脱	dlqu	23900000
+𪮘	dlrc	0
 擉	dlri	59300
 擺	dlrr	12300000
 摆放	dlsm	7810000
@@ -23293,6 +24116,7 @@ encoder:
 才干	dmae	2610000
 撬开	dmae	1220000
 𢭉	dmai	0
+𪭻	dmai	0
 撘	dmaj	879000
 𢭡	dmak	0
 𢲐	dmal	0
@@ -23302,11 +24126,14 @@ encoder:
 𢳾	dmby	0
 拖动	dmbz	4940000
 𢫻	dmbz	0
+𪮹	dmcb	0
 插班	dmcu	773000
 插拔	dmdg	2110000
 插播	dmdp	2300000
 挺	dmdy	96600000
 捶	dmeb	4880000
+𪭟	dmed	0
+𪮓	dmee	0
 𢭉	dmei	0
 插花	dmen	3930000
 𢹢	dmeo	0
@@ -23337,6 +24164,7 @@ encoder:
 拃	dmid	104000
 𢭉	dmii	0
 𧎆	dmii	0
+𪭻	dmii	0
 𢯺	dmil	0
 𢜉	dmiw	0
 挻	dmiy	999000
@@ -23346,6 +24174,7 @@ encoder:
 插足	dmji	750000
 撟	dmjl	183000
 𢹣	dmjl	0
+𪮝	dmjl	0
 𢰈	dmjn	0
 插图	dmjr	16300000
 𢹀	dmjr	0
@@ -23353,6 +24182,7 @@ encoder:
 𢴈	dmka	0
 揰	dmkb	61900
 𢯔	dmkd	0
+𪭼	dmkd	0
 𢹺	dmke	0
 插曲	dmkk	7820000
 𢶌	dmkm	0
@@ -23379,6 +24209,7 @@ encoder:
 𢺮	dmml	0
 撬	dmmm	5670000
 𢵜	dmmm	0
+𪮞	dmmo	0
 托管	dmmw	22000000
 才气	dmmy	2050000
 㩯	dmmz	6690
@@ -23404,6 +24235,7 @@ encoder:
 托盘	dmpl	4850000
 拖船	dmpq	307000
 擶	dmqk	56500
+𪮜	dmrb	0
 𢸕	dmrc	0
 𢸽	dmrc	0
 㧥	dmrd	5460
@@ -23456,6 +24288,7 @@ encoder:
 𢭆	dmym	0
 𢺜	dmyn	0
 插队	dmyo	1090000
+𪮼	dmyu	0
 搥	dmyw	732000
 逰	dmyw	77800
 𢰛	dmzg	0
@@ -23469,12 +24302,14 @@ encoder:
 𢩻	dmzs	0
 挴	dmzy	106000
 𢯃	dmzy	0
+𪭞	dmzz	0
 推开	dnae	11400000
 𢬲	dnaj	0
 𢲐	dnal	0
 擤	dnan	730000
 𢰻	dnaz	0
 揑	dnbi	150000
+𪮆	dnbi	0
 𢶙	dnbq	0
 推动	dnbz	127000000
 𢹻	dncg	0
@@ -23490,6 +24325,7 @@ encoder:
 捭	dned	250000
 𢮒	dned	0
 𢲜	dned	0
+𪭡	dned	0
 推荐	dneg	956000000
 搜索	dnew	1070000000
 携带	dnew	23000000
@@ -23510,6 +24346,7 @@ encoder:
 𢷣	dnio	0
 擕	dniy	93500
 㨐	dnjf	4630
+𪮈	dnjo	0
 𢭱	dnka	0
 𢷏	dnku	0
 拍照	dnky	24900000
@@ -23594,6 +24431,7 @@ encoder:
 推断	dnzu	9050000
 𢸂	dnzu	0
 推出	dnzz	296000000
+𪮦	doad	0
 扒开	doae	852000
 拾	doaj	30600000
 𤁙	doaj	0
@@ -23608,6 +24446,7 @@ encoder:
 捡	dobv	19900000
 拾起	doby	3760000
 抢劫	dobz	22400000
+𪭯	dobz	0
 𢷸	docm	0
 扖	doda	41400
 挫折	dodp	16800000
@@ -23627,6 +24466,7 @@ encoder:
 𢲡	dojm	0
 𢮦	dojo	0
 挩	dojr	92800
+𪮷	dojs	0
 掵	dojy	321000
 攕	doka	52500
 𢶒	dolk	0
@@ -23647,11 +24487,13 @@ encoder:
 擒拿	dooa	1170000
 挫	doob	7420000
 𢬕	doob	0
+𪭢	dood	0
 㧿	dooi	5250
 摐	dooi	169000
 𢵄	dook	0
 𢯧	doom	0
 撿	dooo	4340000
+𪭮	dooo	0
 𢯋	doop	0
 㨑	door	4200
 𢹦	door	0
@@ -23659,6 +24501,7 @@ encoder:
 抮	dopd	110000
 揄	doqk	341000
 抡	dorr	3020000
+𪮟	dorr	0
 摿	dosk	59900
 搇	dosr	75600
 扲	dosx	512000
@@ -23749,6 +24592,7 @@ encoder:
 㩊	dpld	4120
 𢂼	dpli	0
 捳	dpll	23200
+𫎘	dplo	0
 援助	dply	25800000
 拆卸	dpma	5150000
 𢳸	dpmi	0
@@ -23771,12 +24615,15 @@ encoder:
 拆分	dpoy	1900000
 㩫	dppl	3930
 𢸖	dppp	0
+𪴒	dppp	0
 𢶎	dpps	0
+𪮥	dpqj	0
 𢸔	dpql	0
 折腾	dpqu	9510000
 搬	dpqx	42400000
 折服	dpqy	5130000
 挀	dprh	520000
+𪭭	dprh	0
 援外	dpri	411000
 𧣯	dprl	0
 掀	dpro	19800000
@@ -23874,6 +24721,7 @@ encoder:
 投奔	dqge	2430000
 抛在	dqgv	1880000
 执友	dqgx	18500
+𫐋	dqhe	0
 热切	dqhy	4240000
 热轧	dqhz	2620000
 热点	dqij	491000000
@@ -23915,9 +24763,11 @@ encoder:
 抛盘	dqpl	899000
 热爱	dqpw	24600000
 热键	dqpy	3150000
+𪭪	dqqa	0
 热风	dqqo	2300000
 𢲰	dqrk	0
 𢵁	dqru	0
+𪭹	dqry	0
 鸷	dqrz	383000
 垫	dqsb	38000000
 𢬋	dqsb	0
@@ -23993,6 +24843,7 @@ encoder:
 抵押	drdk	10900000
 抵挡	drdk	7700000
 抵抗	drds	29500000
+𪭺	drds	0
 挽救	drdv	7910000
 指挥	drdw	36000000
 指控	drdw	7870000
@@ -24018,6 +24869,7 @@ encoder:
 𢭌	drii	0
 指点	drij	23700000
 揝	drik	68600
+𪮱	drjg	0
 挽回	drjj	11700000
 挽	drjr	11000000
 𢛑	drjw	0
@@ -24026,11 +24878,13 @@ encoder:
 㩩	drkg	4430
 指甲	drki	22900000
 㧰	drko	4040
+𪭧	drko	0
 指明	drkq	5040000
 抵账	drlc	45900
 捔	drld	57400
 换	drlg	192000000
 換	drlg	44600000
+𪾑	drlk	0
 捣	drll	6870000
 搗	drll	1850000
 𢳷	drll	0
@@ -24073,6 +24927,7 @@ encoder:
 换位	drns	2240000
 搀假	drnx	51900
 𢪱	drod	0
+𪭠	drod	0
 抵御	drom	6790000
 擔	dros	2280000
 𢪣	dros	0
@@ -24177,6 +25032,7 @@ encoder:
 撞球	dscd	2160000
 拉长	dsch	3510000
 擅长	dsch	13800000
+𪮉	dsci	0
 撤职	dscj	2500000
 𢴶	dscr	0
 𢸣	dscr	0
@@ -24273,6 +25129,7 @@ encoder:
 接待	dsob	43900000
 接入	dsod	23100000
 捽	dsoe	146000
+𪮊	dsoe	0
 𢭒	dsof	0
 搞得	dsok	14700000
 𢮰	dsok	0
@@ -24280,6 +25137,7 @@ encoder:
 挍	dsoo	102000
 抗衡	dsor	10700000
 𢮁	dsot	0
+𪮠	dsow	0
 搞错	dspe	5610000
 撤销	dspk	10700000
 撤兵	dspo	474000
@@ -24341,6 +25199,7 @@ encoder:
 摘录	dsxk	4800000
 𢬠	dsxk	0
 𢭗	dsxo	0
+𪮡	dsxq	0
 𢲲	dsxy	0
 拉力	dsym	3670000
 接力	dsym	5660000
@@ -24368,6 +25227,7 @@ encoder:
 搞好	dszy	15700000
 撤出	dszz	3870000
 𢫔	dszz	0
+𪭽	dtbs	0
 抖动	dtbz	4660000
 抖擞	dtdu	1710000
 扩招	dtdy	2580000
@@ -24391,6 +25251,7 @@ encoder:
 𢵹	dtmz	0
 捬	dtnd	67700
 𢳋	dtne	0
+𪯂	dtnw	0
 𢷹	dtob	0
 𢱅	dtoz	0
 扩印	dtra	232000
@@ -24410,12 +25271,15 @@ encoder:
 搪塞	dtwe	1580000
 扩军	dtwh	661000
 扩容	dtwo	5150000
+𪮿	dtwr	0
 扩展	dtxe	45000000
+𪭱	dtxg	0
 𢭸	dtxi	0
 𢳿	dtxi	0
 搪	dtxj	1840000
 𢹲	dtxj	0
 𢳧	dtxk	0
+𪮧	dtxl	0
 掶	dtxo	66100
 扩张	dtyc	22200000
 𢺠	dtyn	0
@@ -24478,6 +25342,7 @@ encoder:
 拼音	dusk	26300000
 攁	dusx	58100
 拼凑	dutc	2270000
+𪮲	dutr	0
 𢵈	duuj	0
 掞	duuo	305000
 𢴵	duuu	0
@@ -24560,12 +25425,15 @@ encoder:
 求爱	dvpw	4340000
 𠂃	dvqs	0
 挑	dvrd	60700000
+𪮨	dvrf	0
 𢹅	dvri	0
+𪮔	dvrj	0
 𣰐	dvrm	0
 求证	dvsa	3040000
 𡌊	dvsb	0
 𤥲	dvsc	0
 𩣗	dvsc	0
+𪪵	dvse	0
 𩒮	dvsg	0
 𧋛	dvsi	0
 𨁛	dvsj	0
@@ -24813,6 +25681,7 @@ encoder:
 揵	dxby	125000
 扭动	dxbz	3280000
 𢰰	dxci	0
+𪭲	dxci	0
 撖	dxcm	147000
 扫毒	dxcz	284000
 扫描	dxde	46900000
@@ -24833,6 +25702,7 @@ encoder:
 扫雷	dxfk	3620000
 摊档	dxfk	188000
 攔	dxfl	1720000
+𪮪	dxfv	0
 抉	dxgd	1180000
 𢷧	dxgo	0
 扭转	dxhb	9010000
@@ -24845,6 +25715,7 @@ encoder:
 摊点	dxij	2150000
 揟	dxiq	71500
 据此	dxir	12600000
+𪭣	dxis	0
 撏	dxjd	70000
 𢶝	dxji	0
 𢯷	dxjm	0
@@ -24869,6 +25740,7 @@ encoder:
 摊贩	dxlp	787000
 𢱥	dxlx	0
 𢰭	dxly	0
+𪯁	dxlz	0
 𢲕	dxma	0
 握手	dxmd	13100000
 𢰱	dxmd	0
@@ -24884,6 +25756,7 @@ encoder:
 摊	dxni	23500000
 择偶	dxnk	2070000
 摊牌	dxnn	2030000
+𪮋	dxno	0
 握住	dxns	8850000
 㨛	dxod	3950
 㩔	dxoq	4620
@@ -24911,8 +25784,10 @@ encoder:
 摒	dxue	1140000
 𢷚	dxuk	0
 披着	dxul	6810000
+𪮺	dxul	0
 𢺟	dxuu	0
 𢸞	dxuy	0
+𪮴	dxuz	0
 扫清	dxvc	1030000
 摊派	dxvp	2150000
 𢳲	dxvx	0
@@ -24923,6 +25798,7 @@ encoder:
 扫房	dxws	45100
 扭送	dxwu	376000
 𢬶	dxwx	0
+𪮰	dxwz	0
 𢬞	dxxb	0
 𢬟	dxxe	0
 𢮢	dxxe	0
@@ -24978,6 +25854,7 @@ encoder:
 𢴟	dyfk	0
 报检	dyfo	2550000
 报酬	dyfv	12900000
+𪮸	dygy	0
 挪威	dyha	25000000
 抿	dyhd	4840000
 㨉	dyhk	4170
@@ -24985,6 +25862,7 @@ encoder:
 招致	dyhm	3230000
 把	dyia	771000000
 报国	dyjc	2910000
+𪯀	dyjc	0
 𢱌	dyjf	0
 摾	dyji	74800
 招呼	dyjm	19600000
@@ -25009,6 +25887,7 @@ encoder:
 挻	dymi	999000
 报告	dymj	232000000
 报复	dymk	14100000
+𪮕	dymn	0
 报答	dymo	4340000
 𢭮	dymo	0
 扱	dyms	5850000
@@ -25163,6 +26042,7 @@ encoder:
 𢰹	dzrs	0
 𢴋	dzrt	0
 撧	dzry	162000
+𪮖	dzry	0
 拟订	dzsa	1910000
 拟请	dzsc	127000
 扎襄	dzsj	717
@@ -25240,6 +26120,7 @@ encoder:
 𪏂	eabu	0
 𦫒	eabx	0
 𦮆	eabx	0
+𪟥	eaby	0
 𦻠	eace	0
 𠞱	eack	0
 苛责	eacl	408000
@@ -25272,6 +26153,7 @@ encoder:
 𢻎	eaex	0
 𪏫	eafb	0
 𩔑	eafg	0
+𫖷	eafg	0
 𠝚	eafk	0
 𠝝	eafk	0
 荆棘	eafl	4350000
@@ -25299,6 +26181,7 @@ encoder:
 𪏅	eahb	0
 𦺐	eahh	0
 𪏊	eahh	0
+𫈓	eahi	0
 𢦫	eahm	0
 𦯄	eahx	0
 𪎶	eahz	0
@@ -25328,9 +26211,12 @@ encoder:
 𦮉	eajn	0
 𩁂	eajn	0
 𦭮	eajo	0
+𫖆	eajo	0
+𫉸	eajr	0
 荳	eaju	1560000
 𪏄	eaju	0
 𪏨	eaju	0
+𪤱	eaju	0
 䢽	eajy	3590
 䵍	eajy	5460
 𣋄	eajy	0
@@ -25358,7 +26244,10 @@ encoder:
 鵲	eakr	532000
 鹊	eakr	2890000
 𣤬	eakr	0
+𪴮	eakr	0
+𫈶	eakr	0
 𦶣	eaku	0
+𫊌	eaku	0
 逪	eakw	26300
 皵	eakx	725000
 𦮆	eakx	0
@@ -25367,6 +26256,7 @@ encoder:
 𨛳	eaky	0
 𤲅	eakz	0
 𦁬	eakz	0
+𫇶	ealb	0
 𤰍	ealf	0
 𧁡	ealf	0
 䵎	ealg	4980
@@ -25383,6 +26273,7 @@ encoder:
 虉	ealr	20300
 𣣐	ealr	0
 𥌵	ealr	0
+𫜱	eals	0
 䕻	ealt	3600
 慸	ealw	26800
 遰	ealw	62700
@@ -25421,6 +26312,7 @@ encoder:
 𪎿	eaog	0
 𪏔	eaog	0
 𪏀	eaoh	0
+𪭍	eaoh	0
 蛬	eaoi	36500
 𠍳	eaoi	0
 𪏐	eaoi	0
@@ -25467,12 +26359,14 @@ encoder:
 𢙄	eaow	0
 𢟮	eaow	0
 𪏉	eaow	0
+𫈡	eaow	0
 艱	eaox	1400000
 𪎳	eaox	0
 䢼	eaoy	3400
 巷	eaoy	44900000
 𢀼	eaoy	0
 𨝴	eaoy	0
+𪯗	eaoy	0
 𦭯	eaoz	0
 𪎺	eaps	0
 𦹡	eapy	0
@@ -25514,6 +26408,7 @@ encoder:
 苛刻	easz	5410000
 斢	eate	29200
 𪏡	eate	0
+𪪫	eatf	0
 芋头	eatg	1450000
 荆门	eatl	5140000
 苹	eaua	3020000
@@ -25537,6 +26432,7 @@ encoder:
 酀	eauy	36800
 𡤈	eauz	0
 芜湖	eave	9390000
+𪯝	eavf	0
 荆州	eavn	12200000
 𠥻	eavv	0
 𪏕	eawf	0
@@ -25556,6 +26452,7 @@ encoder:
 𤴟	eaxi	0
 𦱥	eaxi	0
 𪏢	eaxk	0
+𫈤	eaxk	0
 𠕯	eaxs	0
 萋	eaxz	1300000
 𪏖	eayg	0
@@ -25599,6 +26496,7 @@ encoder:
 𤯅	ebai	0
 𥂯	ebal	0
 𦏡	ebaz	0
+𫇷	ebaz	0
 𧁞	ebbb	0
 葑	ebbd	803000
 蕘	ebbg	55900
@@ -25685,6 +26583,8 @@ encoder:
 蘾	ebkr	158000
 𦿋	ebkr	0
 基业	ebku	2980000
+𫊌	ebku	0
+𫊔	ebku	0
 莱	ebkv	118000000
 甘当	ebkx	742000
 冓	eblb	68500
@@ -25703,6 +26603,7 @@ encoder:
 𧂣	ebmq	0
 著称	ebmr	6180000
 𢎌	ebnh	0
+𫉊	ebni	0
 甘泉	ebnk	2120000
 著作	ebnm	130000000
 䓇	ebno	5190
@@ -25721,6 +26622,7 @@ encoder:
 𦶐	ebow	0
 基金	ebpa	96000000
 𣃈	ebpd	0
+𫉷	ebqb	0
 茿	ebqd	36400
 𦵶	ebqf	0
 𧁈	ebqf	0
@@ -25729,6 +26631,7 @@ encoder:
 爇	ebqu	118000
 𦶐	ebqw	0
 基肥	ebqy	901000
+𫉥	ebqy	0
 蒆	ebqz	26700
 芫	ebrd	1270000
 𠒌	ebrd	0
@@ -25736,6 +26639,7 @@ encoder:
 𤯄	ebrh	0
 𠨊	ebri	0
 𪙐	ebri	0
+𪲣	ebri	0
 著名	ebrj	95300000
 𦰶	ebrj	0
 𦴆	ebrj	0
@@ -25761,6 +26665,7 @@ encoder:
 𦹷	ebsj	0
 基调	ebsl	3490000
 𧃳	ebsr	0
+𫉵	ebsr	0
 爇	ebsu	118000
 𤑔	ebsu	0
 𢤍	ebsw	0
@@ -25770,6 +26675,7 @@ encoder:
 基准	ebtn	9240000
 𦿖	ebtx	0
 𦱾	ebua	0
+𫈐	ebub	0
 𦵶	ebuf	0
 甘美	ebug	1420000
 𧅩	ebum	0
@@ -25833,6 +26739,7 @@ encoder:
 𦻙	ecce	0
 𧂖	eccp	0
 𦿰	eccu	0
+𫉝	eccw	0
 蔧	eccx	24300
 𦹙	eccx	0
 𧅞	eccx	0
@@ -25847,11 +26754,13 @@ encoder:
 䫏	ecgo	3420
 𤯉	ecgp	0
 𦥄	echb	0
+𫊕	echs	0
 𧕷	ecii	0
 㪛	ecix	3770
 蘁	ecjj	33000
 𧂬	ecjl	0
 𤯑	ecjm	0
+𫉦	ecjm	0
 其中	ecjv	359000000
 㫷	ecka	4230
 䒹	ecka	4480
@@ -25868,6 +26777,7 @@ encoder:
 𦶈	eclb	0
 𧂻	eclh	0
 𧒤	ecli	0
+𫊇	eclj	0
 蔶	eclo	19200
 𠔶	eclo	0
 𧂺	eclw	0
@@ -25877,6 +26787,7 @@ encoder:
 㲨	ecmh	5030
 𦶇	ecmh	0
 𠔫	ecmi	0
+𫉋	ecmk	0
 𦺹	ecmy	0
 𨿣	ecni	0
 𧀐	ecnj	0
@@ -25900,6 +26811,7 @@ encoder:
 𣃄	ecqp	0
 𡠧	ecqz	0
 𦼆	ecrc	0
+𫈒	ecrh	0
 欺	ecro	12500000
 夦	ecrr	24200
 𪅾	ecrr	0
@@ -25907,6 +26819,8 @@ encoder:
 𦫡	ecry	0
 䳢	ecrz	3960
 𫜶	ecrz	0
+𫛰	ecrz	0
+𫈑	ecso	0
 䔷	ecsx	4110
 𦲖	ecsx	0
 𡠧	ecsz	0
@@ -25962,6 +26876,7 @@ encoder:
 䓯	eczy	3320
 勘	eczy	11100000
 幹	edae	18500000
+𪪂	edae	0
 𦺕	edag	0
 䔶	edai	4730
 𧶚	edal	0
@@ -25980,6 +26895,7 @@ encoder:
 十堰	edbh	4820000
 𥈷	edbl	0
 荴	edbo	25300
+𫈌	edbo	0
 𠒈	edbr	0
 𠒖	edbr	0
 蘀	edbu	47200
@@ -25998,6 +26914,7 @@ encoder:
 卋	edea	500000
 𠦔	edea	0
 𧂽	edeb	0
+𪯆	edeb	0
 𠥼	eded	0
 𠦃	edee	0
 𠦄	edee	0
@@ -26018,6 +26935,7 @@ encoder:
 𠐱	edeo	0
 𥽤	edeo	0
 朝	edeq	183000000
+𪟵	edeq	0
 𩿜	eder	0
 𪂂	eder	0
 𣁖	edes	0
@@ -26051,6 +26969,7 @@ encoder:
 𠒲	edhh	0
 𦣰	edhi	0
 𦯙	edhi	0
+𫛑	edhr	0
 十成	edhv	1060000
 㢤	edhy	4250
 𠦾	edii	0
@@ -26081,6 +27000,7 @@ encoder:
 𠧂	edjm	0
 𢪿	edjm	0
 𩏑	edjm	0
+𫖐	edjm	0
 䧸	edjn	3420
 㼋	edjp	4360
 胡	edjq	103000000
@@ -26092,6 +27012,7 @@ encoder:
 鴣	edjr	85100
 鸪	edjr	956000
 𠷫	edjr	0
+𪡜	edjr	0
 辜	edjs	4010000
 𨐒	edjs	0
 𨑀	edjs	0
@@ -26157,6 +27078,7 @@ encoder:
 亁	edmy	74600
 𠄊	edmy	0
 𠢇	edmy	0
+𪟴	edmy	0
 𠒭	edmz	0
 𠦠	edna	0
 十佳	ednb	7310000
@@ -26169,6 +27091,7 @@ encoder:
 十亿	edny	7870000
 𪕮	ednz	0
 十八	edoa	59200000
+𫀂	edob	0
 䮧	edoc	31600
 𦴽	edoc	0
 𠦵	edoe	0
@@ -26198,14 +27121,17 @@ encoder:
 𩹼	edor	0
 𠓏	edos	0
 栆	edot	44000
+𪞟	edot	0
 𤌹	edou	0
 㥲	edow	4320
+𪟹	edow	0
 𥀐	edox	0
 兝	edoy	25400
 十分	edoy	191000000
 𡥇	edoy	0
 𢺺	edoy	0
 𨝊	edoy	0
+𪦵	edoz	0
 䓆	edpd	3570
 𠦉	edpd	0
 𦷀	edpf	0
@@ -26215,6 +27141,7 @@ encoder:
 𨡷	edqf	0
 𧍵	edqi	0
 𩖘	edqi	0
+𪟺	edqk	0
 𡹹	edql	0
 𩀉	edqn	0
 䭌	edqo	4120
@@ -26225,6 +27152,7 @@ encoder:
 鹕	edqr	294000
 𪆘	edqr	0
 𫜽	edqr	0
+𫛷	edqr	0
 𤒒	edqu	0
 𦶟	edqu	0
 十月	edqv	49800000
@@ -26250,6 +27178,8 @@ encoder:
 菢	edry	130000
 𦫛	edry	0
 𡒙	edsb	0
+𪤟	edsb	0
+𫜰	edsi	0
 𨆕	edsj	0
 十六	edso	61800000
 𦽲	edsr	0
@@ -26274,6 +27204,7 @@ encoder:
 赍	edwl	547000
 𢄬	edwl	0
 𦾣	edwn	0
+𪞱	edwq	0
 十字	edwy	22500000
 孛	edwy	1040000
 索	edwz	148000000
@@ -26293,8 +27224,10 @@ encoder:
 𦜚	edxq	0
 鳷	edxr	53000
 𣤳	edxr	0
+𫛛	edxr	0
 支	edxs	230000000
 菝	edxs	177000
+𫑆	edxw	0
 嘏	edxx	250000
 攰	edxy	352000
 𨙸	edxy	0
@@ -26372,12 +27305,14 @@ encoder:
 𩊘	eean	0
 𩎋	eear	0
 𩊂	eeax	0
+𫊍	eeax	0
 䪈	eeay	3450
 𩊕	eeay	0
 蘳	eebb	20800
 鞋	eebb	125000000
 𩋔	eebb	0
 𩋮	eebd	0
+𫊐	eebg	0
 鞐	eebi	204000
 鞊	eebj	415000
 𩋙	eebj	0
@@ -26458,6 +27393,7 @@ encoder:
 𦴈	eegj	0
 𩊵	eegk	0
 𩊽	eegl	0
+𫖅	eegm	0
 鞒	eegn	268000
 𩔈	eego	0
 靰	eegr	50200
@@ -26545,9 +27481,11 @@ encoder:
 𩍕	eeka	0
 𩍅	eekb	0
 𩋂	eekc	0
+𪟋	eekd	0
 𦿩	eeke	0
 𩌬	eeke	0
 𩍍	eeke	0
+𫖊	eeke	0
 𩋗	eekf	0
 𩍀	eekf	0
 𩊠	eekg	0
@@ -26568,6 +27506,7 @@ encoder:
 䪄	eeko	3820
 鞕	eeko	92500
 鞭	eeko	18700000
+𫉉	eeko	0
 鞘	eekq	7620000
 𩋤	eekq	0
 𩍋	eekq	0
@@ -26575,6 +27514,7 @@ encoder:
 𩋟	eekr	0
 𩋲	eekr	0
 𩍛	eekr	0
+𫈶	eekr	0
 䪁	eeku	3790
 𩍩	eeku	0
 𩍖	eekw	0
@@ -26608,6 +27548,7 @@ encoder:
 𩎉	eelt	0
 𧀱	eelw	0
 𩍹	eelw	0
+𪭅	eelw	0
 䩠	eemb	4280
 𩍮	eeme	0
 鞂	eemf	37700
@@ -26668,10 +27609,12 @@ encoder:
 𩍲	eeoo	0
 𩌭	eeop	0
 𩌰	eeop	0
+𫖋	eeoq	0
 䕿	eeor	4100
 𩊻	eeor	0
 𩋯	eeor	0
 𩍔	eeor	0
+𫉍	eeor	0
 韂	eeos	53000
 𩍎	eeot	0
 𦷧	eeou	0
@@ -26708,6 +27651,7 @@ encoder:
 䩼	eerc	3380
 𩊩	eerc	0
 𧆚	eere	0
+𫖇	eere	0
 𩌜	eerf	0
 𩍘	eerf	0
 𩉬	eerh	0
@@ -26722,6 +27666,7 @@ encoder:
 𩊺	eerl	0
 𩍁	eerl	0
 𩎈	eerl	0
+𫖉	eerl	0
 𩋧	eern	0
 𩉢	eero	0
 𩋌	eero	0
@@ -26915,6 +27860,7 @@ encoder:
 䩙	eezz	3620
 𩋎	eezz	0
 蓒	efae	83200
+𫈥	efaj	0
 博士	efba	69300000
 蓕	efbb	28400
 蔈	efbk	24600
@@ -26969,6 +27915,7 @@ encoder:
 𧂼	efjl	0
 𧃗	efjl	0
 䔩	efjm	3980
+𫉈	efjp	0
 𦿓	efjq	0
 蔌	efjr	168000
 𦳘	efka	0
@@ -26988,6 +27935,7 @@ encoder:
 𧃬	efku	0
 𦳏	eflc	0
 茦	efld	25700
+𫈷	efld	0
 莿	eflk	578000
 萰	eflk	29100
 𠞁	eflk	0
@@ -27003,6 +27951,7 @@ encoder:
 𦲲	efmo	0
 𦵂	efmy	0
 䔦	efmz	3910
+𫉹	efne	0
 藿	efni	2840000
 𧃝	efnj	0
 博白	efnk	652000
@@ -27018,6 +27967,7 @@ encoder:
 𦽨	efoo	0
 𦼊	efor	0
 𦾹	efor	0
+𫉍	efor	0
 某个	efov	50000000
 蕶	efow	273000
 𧀾	efoy	0
@@ -27064,6 +28014,7 @@ encoder:
 𦷢	efwz	0
 𦾄	efwz	0
 𦽯	efxa	0
+𫉎	efxj	0
 𦶠	efxo	0
 𦴡	efxs	0
 𧄁	efxx	0
@@ -27071,8 +28022,10 @@ encoder:
 博导	efyd	1250000
 薽	efys	38200
 蓜	efyy	447000
+𫈣	efyy	0
 𦼋	efzk	0
 葽	efzm	455000
+𫈺	efzo	0
 𦼷	efzq	0
 若干	egae	59800000
 𦰃	egae	0
@@ -27092,6 +28045,7 @@ encoder:
 𦷔	egel	0
 𣯬	egem	0
 若需	egfg	2350000
+𫈹	egfk	0
 𧂾	egfu	0
 若要	egfv	19700000
 䓴	eggd	3700
@@ -27110,13 +28064,16 @@ encoder:
 𧍷	egji	0
 𦵀	egjk	0
 𧃦	egjn	0
+𪴰	egjr	0
 𤎗	egju	0
 惹	egjw	63300000
 逽	egjw	26700
 鄀	egjy	71600
 𦼔	egkk	0
 若是	egkv	26800000
+𫈢	egky	0
 菴	egkz	1010000
+𫈸	egkz	0
 𦯞	egld	0
 蕤	egmc	937000
 𦷃	egmc	0
@@ -27129,6 +28086,7 @@ encoder:
 䔪	egoo	4180
 莢	egoo	571000
 𦳵	egpd	0
+𫊑	egpk	0
 𦵁	egqy	0
 𦰘	egra	0
 𦱯	egra	0
@@ -27162,10 +28120,12 @@ encoder:
 荑	egyz	924000
 𦰅	egzj	0
 𦵘	egzm	0
+𫈻	egzp	0
 若能	egzq	6080000
 蕨	egzr	4100000
 𦲘	egzr	0
 𦾀	egzr	0
+𫉌	egzr	0
 𦮈	egzz	0
 	ehaa	0
 𢦏	ehaa	0
@@ -27217,6 +28177,7 @@ encoder:
 𦽫	ehjw	0
 𥅤	ehjx	0
 𨚵	ehjy	0
+𫉏	ehjy	0
 韯	ehka	45400
 𦿱	ehka	0
 𦷁	ehkc	0
@@ -27227,6 +28188,7 @@ encoder:
 𢨆	ehkz	0
 𦭧	ehli	0
 𦶻	ehlk	0
+𫊗	ehll	0
 蒇	ehlo	87100
 蕆	ehlo	39000
 𪈭	ehlr	0
@@ -27253,6 +28215,7 @@ encoder:
 𢧇	ehor	0
 𦴉	ehps	0
 𢦼	ehpv	0
+𪭒	ehpy	0
 藏胞	ehqr	143000
 苉	ehrd	13800
 茂名	ehrj	5600000
@@ -27276,8 +28239,11 @@ encoder:
 茂密	ehww	2960000
 𦸃	ehxb	0
 藖	ehxl	24800
+𫉶	ehxl	0
 菣	ehxs	24200
 藏书	ehxy	7780000
+𫉺	ehxz	0
+𪭋	ehya	0
 苆	ehyd	367000
 藏民	ehyh	775000
 𦼦	ehyl	0
@@ -27301,6 +28267,7 @@ encoder:
 𦴁	eiao	0
 𧃷	eibz	0
 𦺩	eieh	0
+𪡻	eiej	0
 𧃢	eieo	0
 𦸺	eifl	0
 𦿥	eige	0
@@ -27371,6 +28338,7 @@ encoder:
 勤于	ejad	1830000
 𡭆	ejad	0
 𦮣	ejad	0
+𫉞	ejad	0
 茣	ejag	38000
 𦱕	ejaj	0
 𦳬	ejaj	0
@@ -27379,8 +28347,10 @@ encoder:
 蒉	ejal	109000
 蕢	ejal	46300
 𦹛	ejaz	0
+𫇯	ejaz	0
 古城	ejbh	17600000
 菋	ejbk	1430000
+𫈁	ejbn	0
 𦰩	ejbo	0
 古老	ejbr	20400000
 故地	ejbv	1070000
@@ -27421,6 +28391,7 @@ encoder:
 𦳩	ejgq	0
 𦵣	ejgq	0
 𩙤	ejgq	0
+𫊛	ejgy	0
 𢨖	ejhh	0
 克东	ejhk	295000
 𦯁	ejhz	0
@@ -27477,6 +28448,7 @@ encoder:
 𥍊	ejnl	0
 𣰻	ejnm	0
 勤俭	ejno	5150000
+𫈽	ejno	0
 飌	ejnq	28600
 歡	ejnr	10300000
 鸛	ejnr	170000
@@ -27518,8 +28490,10 @@ encoder:
 蕗	ejrj	1080000
 辜负	ejrl	7610000
 𦮶	ejro	0
+𫈀	ejro	0
 𦵇	ejrw	0
 勤务	ejry	515000
+𫉩	ejrz	0
 古诗	ejsb	9710000
 故意	ejsk	38800000
 古文	ejso	7760000
@@ -27536,6 +28510,7 @@ encoder:
 胡涂	ejvo	958000
 𦬅	ejvv	0
 勤学	ejvw	1590000
+𫈕	ejvy	0
 𣓝	ejwf	0
 故宫	ejwj	5450000
 𧀰	ejwl	0
@@ -27597,6 +28572,7 @@ encoder:
 草地	ekbv	12500000
 草场	ekby	1730000
 𠢽	ekby	0
+𫈩	ekby	0
 䕺	ekcx	3780
 蕞	ekcx	1260000
 募捐	ekdj	2730000
@@ -27613,6 +28589,7 @@ encoder:
 𦹵	ekej	0
 𦹸	ekek	0
 黄南	ekel	604000
+𫊘	ekel	0
 草莓	ekem	20800000
 𢾳	ekem	0
 黄花	eken	9330000
@@ -27623,6 +28600,7 @@ encoder:
 菲薄	ekev	646000
 草药	ekez	6130000
 苗木	ekfa	10500000
+𫉻	ekfc	0
 𨠷	ekfd	0
 菲林	ekff	1650000
 𧅲	ekff	0
@@ -27648,6 +28626,7 @@ encoder:
 蟇	ekgi	137000
 𠻚	ekgj	0
 暮	ekgk	9920000
+𪷂	ekgk	0
 幕	ekgl	46500000
 𦷤	ekgl	0
 摹	ekgm	2380000
@@ -27678,12 +28657,14 @@ encoder:
 𧕐	ekii	0
 𧁎	ekim	0
 𦸿	ekir	0
+𫉧	ekiu	0
 韩国	ekjc	114000000
 苗圃	ekjf	4670000
 𦼕	ekjf	0
 𦼲	ekjk	0
 𦿹	ekjk	0
 𧄳	ekjl	0
+𫉒	ekjl	0
 𦺡	ekjm	0
 𦾛	ekjm	0
 𧀞	ekjo	0
@@ -27704,8 +28685,10 @@ encoder:
 蕌	ekkk	27200
 藟	ekkk	115000
 𣊛	ekkk	0
+𫈳	ekkk	0
 𡿉	ekkl	0
 𡮦	ekkm	0
+𪯓	ekkm	0
 𧅒	ekkp	0
 𨬛	ekkp	0
 䖁	ekkw	3960
@@ -27729,6 +28712,7 @@ encoder:
 乾县	eklz	275000
 曹县	eklz	488000
 萬	eklz	79400000
+𫈧	eklz	0
 黄牛	ekmb	3140000
 蓝筹	ekmc	2760000
 𦿔	ekme	0
@@ -27751,6 +28735,7 @@ encoder:
 黄牌	eknn	3910000
 摹仿	ekns	407000
 𦾠	ekob	0
+𫈨	ekon	0
 草丛	ekoo	6620000
 𦺏	ekoo	0
 茰	ekos	18600
@@ -27762,6 +28747,7 @@ encoder:
 萷	ekqk	36200
 募股	ekqq	648000
 𢡗	ekqw	0
+𫈔	ekrb	0
 苗条	ekrf	4680000
 黄昏	ekrk	28000000
 𣰌	ekrm	0
@@ -27808,6 +28794,7 @@ encoder:
 䒤	ekvv	4260
 𦾥	ekwf	0
 黄连	ekwh	1330000
+𫊜	ekwl	0
 墓穴	ekwo	1630000
 乾安	ekwz	173000
 草案	ekwz	21100000
@@ -27829,6 +28816,7 @@ encoder:
 黄陂	ekyx	1330000
 𦶑	ekyy	0
 𨟔	ekyy	0
+𫊅	ekzc	0
 𧄴	ekzg	0
 蠆	ekzi	53600
 躉	ekzj	342000
@@ -27838,12 +28826,14 @@ encoder:
 𦰇	ekzm	0
 𦽍	ekzn	0
 𧁾	ekzp	0
+𪵒	ekzq	0
 草纸	ekzr	322000
 𦿌	ekzu	0
 萌发	ekzv	4210000
 邁	ekzw	6200000
 𦽳	ekzw	0
 𧄌	ekzw	0
+𫉨	ekzx	0
 勱	ekzy	75000
 𨝥	ekzy	0
 𦰲	elad	0
@@ -27914,6 +28904,8 @@ encoder:
 直到	elhk	82000000
 𥋚	elhl	0
 𧀅	elhm	0
+𫈦	elhm	0
+𫈼	elhm	0
 南欧	elho	758000
 𪈛	elhr	0
 蔑	elhs	1110000
@@ -28013,6 +29005,7 @@ encoder:
 𧲎	elrg	0
 𩖎	elrg	0
 薥	elri	25000
+𫉼	elri	0
 真象	elrj	2170000
 𦶔	elrj	0
 南乐	elrk	293000
@@ -28106,6 +29099,7 @@ encoder:
 夢	elwr	121000000
 𪅇	elwr	0
 真迹	elws	1250000
+𫉐	elws	0
 真实	elwt	304000000
 南通	elwx	25100000
 直通	elwx	39100000
@@ -28233,6 +29227,7 @@ encoder:
 䔉	emmf	4440
 蔾	emmf	33900
 𦳁	emmh	0
+𫇸	emmi	0
 𧗘	emml	0
 𦺙	emmm	0
 𦱒	emmo	0
@@ -28253,6 +29248,7 @@ encoder:
 𧁩	emnj	0
 䕴	emnu	4430
 𧄄	emnw	0
+𫊆	emnx	0
 𦽂	emob	0
 苵	emod	23400
 𦸸	emof	0
@@ -28265,6 +29261,7 @@ encoder:
 𦸈	emps	0
 蘈	emqg	75400
 萟	emqs	18500
+𫉽	emqw	0
 萟	emqy	18500
 𦽂	emrb	0
 𦭶	emrd	0
@@ -28273,15 +29270,18 @@ encoder:
 菞	emrm	22400
 𦳫	emro	0
 𦴙	emro	0
+𫈫	emro	0
 䔟	emrr	3840
 莵	emrs	94500
 𦱜	emrs	0
 𦲦	emrs	0
+𫊎	emsb	0
 蘖	emsf	447000
 𩕸	emsg	0
 𦱐	emsh	0
 𧕏	emsi	0
 躠	emsj	27300
+𪺶	emsm	0
 𪈟	emsr	0
 糵	emsu	85200
 𦷏	emsu	0
@@ -28304,6 +29304,8 @@ encoder:
 𦱮	emxb	0
 蒛	emxg	119000
 𦬐	emxs	0
+𫈿	emxx	0
+𫉀	emya	0
 䒗	emyd	3940
 𦰺	emye	0
 𦭥	emyi	0
@@ -28323,6 +29325,7 @@ encoder:
 萎缩	emzw	12000000
 莓	emzy	6030000
 𦵛	emzz	0
+𫈪	enaf	0
 荷	enaj	32900000
 𦷌	enaj	0
 𦷉	enal	0
@@ -28372,6 +29375,7 @@ encoder:
 𦽻	enge	0
 𧁗	enge	0
 截面	engj	2090000
+𫈈	engj	0
 花布	engl	1060000
 茯	engs	702000
 截至	enhb	28000000
@@ -28382,6 +29386,7 @@ encoder:
 䒫	enhs	4000
 𦬙	enid	0
 截止	enii	40300000
+𫈾	enii	0
 𦾔	enik	0
 莜	enim	768000
 藇	enio	28600
@@ -28395,6 +29400,7 @@ encoder:
 茽	enji	121000
 𦵋	enji	0
 𦽌	enjk	0
+𫉔	enjm	0
 𦲺	enjo	0
 截听	enjp	77700
 㗡	enjr	3730
@@ -28427,6 +29433,7 @@ encoder:
 𦭛	enme	0
 鞭策	enmf	2110000
 莋	enmi	295000
+𫉢	enmj	0
 荷重	enmk	1750000
 花簇	enms	128000
 花季	enmy	6740000
@@ -28468,6 +29475,7 @@ encoder:
 蓧	enrf	60700
 截然	enrg	8600000
 𠝐	enrk	0
+𫇹	enro	0
 蓚	enrp	67100
 蓨	enrq	43500
 花	enrr	598000000
@@ -28477,6 +29485,7 @@ encoder:
 𦶰	enrr	0
 𦹿	enrr	0
 𧄷	enrr	0
+𫈇	enrr	0
 截留	enrs	1900000
 菂	enrs	685000
 𦯎	enrs	0
@@ -28490,6 +29499,7 @@ encoder:
 花鸟	enrz	6470000
 𦺰	enrz	0
 𧄔	ensb	0
+𫈘	ensh	0
 𧕏	ensi	0
 蓓	ensj	5620000
 花市	ensl	1600000
@@ -28526,15 +29536,18 @@ encoder:
 𦭽	enxm	0
 𣤨	enxr	0
 𪇡	enxr	0
+𪴳	enxr	0
 蒦	enxs	57800
 蓃	enxs	21800
 𦲪	enxs	0
 𦹜	enxx	0
 靴子	enya	3520000
 鞭子	enya	1950000
+𫇱	enya	0
 葩	enyi	1190000
 𦭟	enyi	0
 𦯐	enyj	0
+𫈆	enyj	0
 芿	enym	46500
 花费	enyn	42300000
 蘤	enyu	39900
@@ -28543,6 +29556,7 @@ encoder:
 𦺯	enzf	0
 花絮	enzj	16400000
 𦴞	enzm	0
+𫈄	enzo	0
 𦲮	enzr	0
 花纹	enzs	5410000
 截断	enzu	1900000
@@ -28559,6 +29573,8 @@ encoder:
 蓗	eobo	22200
 苍老	eobr	3950000
 蓌	eobr	30200
+𫅷	eobr	0
+𫊏	eobu	0
 莶	eobv	158000
 茶壶	eobw	2040000
 遳	eobw	27100
@@ -28566,6 +29582,7 @@ encoder:
 荟	eobz	11800000
 𦻏	eobz	0
 藢	eocm	26100
+𫈙	eocs	0
 共事	eodj	4020000
 苍南	eoel	2880000
 恭敬	eoer	10100000
@@ -28590,6 +29607,7 @@ encoder:
 茶碗	eogw	2340000
 共感	eoha	8810000
 共轭	eohg	371000
+𫇳	eoia	0
 蓰	eoii	75400
 𦮳	eoii	0
 苍蝇	eoij	12700000
@@ -28650,6 +29668,7 @@ encoder:
 𦶎	eooe	0
 𦹬	eoog	0
 蓯	eooi	98900
+𫈅	eooj	0
 𦮓	eook	0
 𧁴	eook	0
 葅	eool	35600
@@ -28664,6 +29683,7 @@ encoder:
 葼	eoor	23100
 蘝	eoor	26900
 䒝	eoos	3960
+𫇫	eoos	0
 茶馆	eoow	28600000
 共创	eooy	11700000
 𦭏	eopd	0
@@ -28718,6 +29738,7 @@ encoder:
 棻	eoyf	795000
 𦯲	eoyg	0
 恭贺	eoyj	2690000
+𫉕	eoyj	0
 葐	eoyl	39900
 𧆀	eoyn	0
 𧂆	eoys	0
@@ -28730,6 +29751,7 @@ encoder:
 𧀈	eozk	0
 𧅔	eozl	0
 𧃸	eozm	0
+𫉪	eozm	0
 恭维	eozn	4220000
 𦹟	eozq	0
 𦮀	eozr	0
@@ -28745,6 +29767,7 @@ encoder:
 芹菜	epep	7580000
 菜蔬	epex	672000
 䔄	epez	5250
+𫊙	epfd	0
 𦹮	epfp	0
 𧂵	epge	0
 𧄭	epgl	0
@@ -28753,6 +29776,7 @@ encoder:
 𧂀	epgo	0
 𧀔	epgp	0
 萲	epgx	55400
+𫉁	epgx	0
 𧂂	ephh	0
 菜园	epjb	4580000
 𧀷	epjd	0
@@ -28777,6 +29801,7 @@ encoder:
 𦼎	eppy	0
 蒰	epqx	21800
 𦽮	epqz	0
+𫉟	eprb	0
 𦽋	eprj	0
 蕣	eprm	116000
 𦲽	epro	0
@@ -28855,7 +29880,9 @@ encoder:
 散射	eqnd	1560000
 散件	eqnm	1980000
 期货	eqnr	34400000
+𫉬	eqnx	0
 期待	eqob	149000000
+𫉡	eqoe	0
 获得	eqok	209000000
 𧀬	eqok	0
 𦷈	eqoo	0
@@ -28872,6 +29899,7 @@ encoder:
 获胜	eqqm	7870000
 𧁿	eqri	0
 葋	eqrj	23500
+𫊖	eqrn	0
 𦼳	eqro	0
 𦱔	eqrr	0
 𦺎	eqsj	0
@@ -28896,6 +29924,7 @@ encoder:
 散漫	eqvk	2600000
 期房	eqws	5090000
 𧂿	eqww	0
+𫉖	eqwy	0
 𦽇	eqxb	0
 𦘃	eqxc	0
 莥	eqxe	28500
@@ -28913,6 +29942,7 @@ encoder:
 散发	eqzv	22100000
 𪃖	erar	0
 茚	eray	295000
+𫊒	erbb	0
 蘏	erbg	23300
 𢨝	erbh	0
 𦮧	erbi	0
@@ -28931,6 +29961,7 @@ encoder:
 葡萄	erer	22100000
 萄	erez	1320000
 𦮍	erez	0
+𫄿	erez	0
 葡	erfb	6030000
 𢣋	erfw	0
 欺压	ergb	1280000
@@ -29004,6 +30035,7 @@ encoder:
 𦲇	eroe	0
 茐	eros	30500
 薝	eros	48000
+𫇬	eros	0
 䓤	erow	5260
 蕵	erox	27300
 𦭪	eroz	0
@@ -29060,6 +30092,7 @@ encoder:
 苟安	erwz	86500
 𦮤	erwz	0
 𦱩	erxa	0
+𫇴	erxb	0
 𦿙	erxg	0
 薿	erxi	44800
 蔸	erxr	632000
@@ -29068,6 +30101,7 @@ encoder:
 𦳌	erxw	0
 𦺄	erxy	0
 警卫	erya	6620000
+𫊈	eryb	0
 警民	eryh	1410000
 蒥	eryk	56700
 𦺲	eryl	0
@@ -29087,6 +30121,7 @@ encoder:
 𧅱	esbk	0
 𧆐	esbl	0
 藷	esbm	389000
+𫉄	esbm	0
 𦽡	esbr	0
 𧂕	esbr	0
 荒地	esbv	2310000
@@ -29112,6 +30147,7 @@ encoder:
 𦸰	esgm	0
 荒原	esgn	2840000
 𩓜	esgo	0
+𫈱	esgp	0
 藙	esgq	35000
 𧄘	esgq	0
 蘐	esgx	29000
@@ -29132,6 +30168,7 @@ encoder:
 蔉	esjr	50700
 𦯇	esjr	0
 𦳆	esjr	0
+𫈮	esjr	0
 蔀	esjy	457000
 䕊	eska	4110
 虀	eska	66300
@@ -29139,6 +30176,7 @@ encoder:
 𧆂	eska	0
 𧆌	eska	0
 蕫	eskb	70100
+𫉿	eskb	0
 蔁	eske	26100
 𦿤	eske	0
 芒果	eskf	5870000
@@ -29150,6 +30188,7 @@ encoder:
 蓑	eskr	1770000
 蔼	eskr	1500000
 藹	eskr	438000
+𫉮	eskr	0
 蓄水	eskv	1890000
 薪水	eskv	13200000
 薏	eskw	3750000
@@ -29174,6 +30213,7 @@ encoder:
 芳香	esmk	13100000
 裁制	esml	251000
 蔟	esmm	321000
+𫈚	esmo	0
 𦹭	esmp	0
 𧆍	esms	0
 葹	esmy	71300
@@ -29239,6 +30279,7 @@ encoder:
 裁军	eswh	554000
 蒂	eswl	44700000
 𦹾	eswm	0
+𫉚	eswm	0
 蒡	esws	490000
 莣	eswz	827000
 蔙	esxi	62600
@@ -29287,6 +30328,7 @@ encoder:
 蘑菇	etez	7660000
 𧂷	etfb	0
 蔴	etff	208000
+𫉭	etff	0
 蘑	etfg	1340000
 蘼	etfk	2090000
 藦	etfm	149000
@@ -29296,6 +30338,7 @@ encoder:
 𦶉	etir	0
 䕲	etjb	3890
 𦾰	etjm	0
+𫉾	etjy	0
 𦳅	etko	0
 蓭	etkz	27600
 燕山	etll	6780000
@@ -29316,6 +30359,7 @@ encoder:
 薋	etrl	50700
 茨	etro	24100000
 苝	etrr	326000
+𫈋	etrr	0
 菧	etrs	78700
 𦿵	etrs	0
 𦿬	etrz	0
@@ -29332,14 +30376,17 @@ encoder:
 燕窝	etwj	1770000
 𦯅	etxi	0
 蓎	etxj	52000
+𫉘	etxl	0
 菮	etxo	24500
 燕子	etya	9640000
 䕠	etyq	4070
 薦	etzu	3100000
 蔊	euae	38200
 𧁙	euax	0
+𫉱	euax	0
 蒫	eubi	31500
 𦵕	eubr	0
+𫉠	euce	0
 𧀘	eucl	0
 蕲春	euco	457000
 𦾿	eucq	0
@@ -29357,6 +30404,7 @@ encoder:
 蕿	eugx	21400
 𧀿	eugy	0
 啬	eujj	742000
+𫊊	eujq	0
 莌	eujr	25100
 𦻐	euke	0
 𦽗	eukm	0
@@ -29386,10 +30434,12 @@ encoder:
 𧀜	eupn	0
 葥	euqk	55700
 𧆇	euri	0
+𫉫	eurl	0
 𦺸	eurm	0
 𧃮	eurm	0
 𦿯	euro	0
 䓎	eurs	4170
+𫈯	eurs	0
 蘱	eusg	41700
 𦮝	eush	0
 𧁙	eusx	0
@@ -29410,6 +30460,7 @@ encoder:
 𦽓	euye	0
 𦽽	euyg	0
 𧅛	euyn	0
+𫇭	euys	0
 蒍	euyu	265000
 菤	euyy	39000
 𦯔	euyz	0
@@ -29426,6 +30477,7 @@ encoder:
 菏	evaj	1330000
 𦶒	evaj	0
 𦺘	evaj	0
+𫈰	evaj	0
 𦽘	eval	0
 萍	evau	24200000
 𧁛	evau	0
@@ -29438,6 +30490,7 @@ encoder:
 𦼥	evbm	0
 蒲圻	evbp	134000
 𦻄	evbp	0
+𫊓	evbr	0
 䕪	evbu	3780
 落地	evbv	15300000
 薄壳	evbw	229000
@@ -29446,6 +30499,7 @@ encoder:
 𦴵	evcz	0
 𦺇	evcz	0
 𧁕	evee	0
+𫉰	evee	0
 落幕	evek	7710000
 菠萝	evel	13600000
 薄荷	even	8390000
@@ -29461,12 +30515,14 @@ encoder:
 𧄩	evfe	0
 𦽼	evff	0
 𦵜	evfj	0
+𫊚	evfj	0
 𧁔	evfl	0
 薄板	evfp	4040000
 𦾶	evfp	0
 薄雾	evfr	1570000
 落榜	evfs	1980000
 𦱈	evfs	0
+𫉗	evfv	0
 𦻈	evfx	0
 𦴮	evge	0
 𦹈	evge	0
@@ -29484,6 +30540,7 @@ encoder:
 蕖	evhh	221000
 落成	evhv	5180000
 菃	evhx	34500
+𫊉	evii	0
 𦶵	evik	0
 𦶼	evik	0
 𦴢	evir	0
@@ -29495,6 +30552,7 @@ encoder:
 𦶶	evji	0
 薃	evjl	30200
 𦰪	evjo	0
+𫉣	evjq	0
 𧀌	evjr	0
 萍踪	evjw	932000
 虃	evka	27100
@@ -29505,6 +30563,7 @@ encoder:
 藫	evke	24200
 𦴝	evke	0
 薻	evkf	27400
+𫈜	evki	0
 𧀪	evkk	0
 蕰	evkl	75000
 莎	evkm	40800000
@@ -29536,6 +30595,7 @@ encoder:
 𧄻	evmi	0
 𦶡	evmj	0
 薄利	evmk	2250000
+𫉃	evmk	0
 蘫	evml	87800
 𧗎	evml	0
 落笔	evmm	1350000
@@ -29548,6 +30608,7 @@ encoder:
 𦭴	evnd	0
 薬	evnf	25000000
 𧃡	evnf	0
+𫊋	evnf	0
 世代	evnh	38300000
 𦹏	evni	0
 萡	evnk	36100
@@ -29556,6 +30617,7 @@ encoder:
 蒞	evns	424000
 𧀡	evnu	0
 薄片	evnx	2020000
+𫉯	evnx	0
 世人	evod	17400000
 落入	evod	8300000
 𦸂	evof	0
@@ -29581,6 +30643,7 @@ encoder:
 𦷰	evpy	0
 𦷪	evpz	0
 落脚	evqb	4140000
+𫇼	evqd	0
 薄膜	evqe	16900000
 蒅	evqf	50000
 蕍	evqk	28800
@@ -29599,6 +30662,7 @@ encoder:
 世贸	evrs	8420000
 𦮛	evrs	0
 𧂙	evru	0
+𫉙	evru	0
 𦿞	evrw	0
 萢	evry	266000
 茫	evsh	3140000
@@ -29609,8 +30673,10 @@ encoder:
 𦯻	evso	0
 𦲷	evsu	0
 蒗	evsx	648000
+𫈊	evsy	0
 薄冰	evtk	1590000
 薄情	evuc	878000
+𫈭	evuc	0
 蓱	evue	432000
 𦲍	evuo	0
 𦸁	evuu	0
@@ -29632,6 +30698,7 @@ encoder:
 𦴴	evwz	0
 葏	evxb	19500
 蕖	evxf	221000
+𫊁	evxf	0
 菠	evxi	1770000
 落难	evxn	1200000
 𦯊	evxo	0
@@ -29640,8 +30707,10 @@ encoder:
 蔢	evxz	41100
 𦻭	evxz	0
 𡎊	evyb	0
+𫈲	evyb	0
 𦴮	evye	0
 𧍙	evyi	0
+𫇻	evyi	0
 菬	evyj	33100
 𦽾	evyk	0
 荡	evyo	29700000
@@ -29657,6 +30726,7 @@ encoder:
 世纪	evzy	166000000
 萍乡	evzz	7610000
 𦯫	evzz	0
+𫈞	evzz	0
 荢	ewad	48400
 𦭨	ewad	0
 𦯼	ewae	0
@@ -29762,9 +30832,11 @@ encoder:
 蔰	ewjy	26600
 𧅉	ewjy	0
 蒙昧	ewkb	617000
+𫉂	ewkf	0
 荣耀	ewkg	20800000
 荧光	ewkg	6790000
 𦶺	ewkg	0
+𫈛	ewki	0
 荣昌	ewkk	2170000
 藔	ewkk	25000
 𧂏	ewkk	0
@@ -29777,6 +30849,7 @@ encoder:
 带电	ewkz	1520000
 𦶳	ewkz	0
 𧂜	ewkz	0
+𫈬	ewkz	0
 薴	ewla	42900
 𦾼	ewlb	0
 䔃	ewlc	5060
@@ -29824,6 +30897,7 @@ encoder:
 芯片	ewnx	36500000
 藭	ewny	41100
 𦹇	ewob	0
+𫉲	ewob	0
 带入	ewod	4220000
 蓉	ewoj	17300000
 𧃕	ewoj	0
@@ -29849,7 +30923,9 @@ encoder:
 𦬮	ewrd	0
 𦵤	ewrd	0
 勃然	ewrg	2480000
+𫇽	ewrh	0
 𦴦	ewrj	0
+𫊀	ewrl	0
 蔲	ewrm	41900
 𦲋	ewrm	0
 𧁽	ewrm	0
@@ -29895,6 +30971,7 @@ encoder:
 蒙混	ewvk	1160000
 蓬溪	ewvp	349000
 芝	ewvv	45100000
+𫇦	ewwa	0
 营运	ewwb	9270000
 𧁚	ewwb	0
 带宽	ewwe	39600000
@@ -29909,6 +30986,7 @@ encoder:
 蕊	ewww	7750000
 蓬安	ewwz	146000
 𧄜	ewwz	0
+𫈝	ewwz	0
 鞍马	ewxa	357000
 带劲	ewxb	693000
 蓪	ewxl	59800
@@ -29932,6 +31010,7 @@ encoder:
 𦽜	ewyn	0
 带队	ewyo	3460000
 𦴎	ewyq	0
+𫉽	ewyq	0
 营建	ewyx	1240000
 𦶋	ewyy	0
 𦲄	ewyz	0
@@ -29946,6 +31025,8 @@ encoder:
 𦹎	ewzw	0
 荥经	ewzx	174000
 𦼠	exae	0
+𫈴	exae	0
+𫉑	exae	0
 葵	exag	19200000
 𦽅	exaj	0
 𦲙	exak	0
@@ -29959,6 +31040,7 @@ encoder:
 𦼘	exbu	0
 𦵥	exbx	0
 卖场	exby	21100000
+𫈎	exby	0
 萧瑟	excc	1850000
 𦻛	excu	0
 支持	exdb	656000000
@@ -30002,6 +31084,7 @@ encoder:
 蕁	exjd	1190000
 𧃭	exjf	0
 𧄋	exjf	0
+𫉴	exji	0
 䕡	exjj	3890
 卖唱	exjk	465000
 葦	exjm	1990000
@@ -30028,6 +31111,7 @@ encoder:
 菡	exkz	1450000
 𧀓	exkz	0
 𦱲	exlb	0
+𫈏	exld	0
 𦹧	exlk	0
 萧山	exll	6380000
 蓪	exlw	59800
@@ -30088,6 +31172,7 @@ encoder:
 𦳒	exuo	0
 蒸汽	exvm	9190000
 支流	exvs	2660000
+𪜀	exvv	0
 卖家	exwg	41000000
 菷	exwl	29400
 𦲅	exwl	0
@@ -30172,6 +31257,7 @@ encoder:
 𦳉	eygq	0
 苠	eyhd	102000
 𦳜	eyhk	0
+𫈟	eyhk	0
 𩀔	eyhn	0
 苏区	eyho	507000
 𪃔	eyhr	0
@@ -30183,6 +31269,7 @@ encoder:
 节点	eyij	13000000
 𦬌	eyim	0
 𧁅	eyip	0
+𫈠	eyjb	0
 𦴰	eyje	0
 蔃	eyji	55200
 艺员	eyjl	631000
@@ -30220,6 +31307,7 @@ encoder:
 𧃯	eymy	0
 蓀	eymz	318000
 𦶽	eymz	0
+𫉛	eymz	0
 茀	eynd	104000
 𦱖	eynd	0
 𦹽	eyne	0
@@ -30247,6 +31335,7 @@ encoder:
 苏丹	eyqs	3430000
 𦸐	eyrb	0
 𦰴	eyrk	0
+𫉤	eyro	0
 𦶬	eyrr	0
 𦵮	eyse	0
 䔼	eysi	4060
@@ -30298,6 +31387,7 @@ encoder:
 协力	eyym	5550000
 藋	eyyn	37800
 𦸚	eyyn	0
+𫉆	eyyq	0
 蒻	eyyt	206000
 𦭳	eyyt	0
 茘	eyyy	70300
@@ -30324,6 +31414,7 @@ encoder:
 葒	ezbi	925000
 𦮨	ezbi	0
 𦺢	ezbj	0
+𫊃	ezbj	0
 𦳀	ezbk	0
 𦿎	ezbm	0
 䔴	ezbx	4600
@@ -30372,6 +31463,7 @@ encoder:
 𧀒	ezjm	0
 𦱫	ezjq	0
 𦲭	ezjq	0
+𫉅	ezjw	0
 𦸖	ezjx	0
 蕠	ezjz	39700
 𧃒	ezjz	0
@@ -30394,6 +31486,7 @@ encoder:
 蒳	ezlo	73700
 𦭯	ezlo	0
 𦴁	ezlo	0
+𫉜	ezlo	0
 药用	ezlv	5460000
 蘰	ezlx	206000
 𦷵	ezly	0
@@ -30432,6 +31525,7 @@ encoder:
 𧁯	ezqi	0
 药膳	ezqu	2590000
 𦯏	ezqy	0
+𫉳	ezqy	0
 蘕	ezrc	21200
 蔣	ezrd	6440000
 𦱭	ezre	0
@@ -30448,11 +31542,13 @@ encoder:
 葯	ezrs	1050000
 𦳹	ezrs	0
 蔠	ezrt	387000
+𫈍	ezrt	0
 𧀛	ezru	0
 𧄉	ezrw	0
 蕝	ezry	182000
 𦰾	ezry	0
 𦹅	ezry	0
+𫈵	ezry	0
 𧂩	ezsi	0
 勘误	ezsj	893000
 𦽠	ezsm	0
@@ -30486,7 +31582,9 @@ encoder:
 𦵚	ezxw	0
 薌	ezxy	90600
 䒵	ezya	3980
+𫉇	ezyi	0
 𦹄	ezyj	0
+𫇵	ezym	0
 药费	ezyn	984000
 𤮀	ezys	0
 𧀼	ezys	0
@@ -30502,6 +31600,7 @@ encoder:
 𦭺	ezzi	0
 𦰯	ezzj	0
 𦾯	ezzk	0
+𫊄	ezzk	0
 𦮙	ezzl	0
 芗	ezzm	803000
 𦭺	ezzm	0
@@ -30554,6 +31653,7 @@ encoder:
 木匠	fahp	1770000
 桺	fahx	110000
 𣝄	faia	0
+𪱱	faid	0
 柾	faii	251000
 𣖀	faix	0
 𣒘	faiy	0
@@ -30566,6 +31666,7 @@ encoder:
 𣐸	fajo	0
 𣘅	fajr	0
 梪	faju	66800
+𪲓	faju	0
 本题	faka	2470000
 𣜂	faka	0
 𣕭	fakb	0
@@ -30578,8 +31679,10 @@ encoder:
 桠	faku	388000
 本周	falb	64300000
 𣑛	falb	0
+𪲳	falf	0
 木炭	falg	5040000
 杮	fali	128000
+𪲔	fall	0
 𣐈	falm	0
 柄	falo	42200000
 欐	falt	1210000
@@ -30609,6 +31712,7 @@ encoder:
 栵	fark	407000
 𣚐	faru	0
 本色	fary	13400000
+𪲐	fary	0
 本部	fasj	19200000
 本市	fasl	15500000
 本文	faso	390000000
@@ -30637,6 +31741,7 @@ encoder:
 𣓉	faxi	0
 本届	faxk	8550000
 橊	faxk	66100
+𪳋	faxw	0
 棲	faxz	2520000
 本子	faya	7680000
 杆子	faya	891000
@@ -30689,6 +31794,7 @@ encoder:
 𣝔	fbgf	0
 票面	fbgj	1450000
 𩒺	fbgo	0
+𫎉	fbgq	0
 𤞷	fbgs	0
 票友	fbgx	944000
 桂东	fbhk	486000
@@ -30708,6 +31814,7 @@ encoder:
 杜鹃	fbjq	3830000
 喸	fbjr	20200
 榬	fbjr	24600
+𪳮	fbju	0
 甄别	fbjy	3430000
 标量	fbka	264000
 标题	fbka	654000000
@@ -30722,6 +31829,7 @@ encoder:
 盙	fblk	21100
 櫝	fbll	63500
 槓	fblo	1980000
+𪳌	fbly	0
 票箱	fbmf	217000
 㲡	fbmh	4680
 标签	fbmo	133000000
@@ -30735,6 +31843,7 @@ encoder:
 甫自	fbnl	86500
 标价	fbno	5970000
 票价	fbno	8200000
+𪲒	fbno	0
 𣔭	fbob	0
 枎	fbod	434000
 𣗂	fbof	0
@@ -30762,9 +31871,11 @@ encoder:
 标语	fbsb	5610000
 标识	fbsj	27500000
 敷	fbsm	21500000
+𪵐	fbsq	0
 旉	fbsy	47200
 标记	fbsy	79400000
 标准	fbtn	328000000
+𪲟	fbub	0
 樹	fbud	51000000
 橲	fbuj	45200
 𣙀	fbuq	0
@@ -30805,7 +31916,10 @@ encoder:
 标引	fbyi	243000
 㯧	fbyj	3880
 桂阳	fbyk	768000
+𪳞	fbym	0
 𦑵	fbyy	0
+𪲢	fbyy	0
+𪲶	fbzj	0
 榼	fbzl	81800
 枑	fbzm	655000
 杜绝	fbzr	12800000
@@ -30824,6 +31938,7 @@ encoder:
 棒球	fccd	12000000
 槥	fccx	38000
 𣚒	fccy	0
+𪳧	fccy	0
 梼	fcds	509000
 椰菜	fcep	311000
 椰树	fcfx	556000
@@ -30851,6 +31966,7 @@ encoder:
 𣜚	fcwz	0
 棷	fcxs	99000
 櫘	fcxw	216000
+𪳍	fcxx	0
 棒子	fcya	2090000
 椰子	fcya	5680000
 楔	fcyg	2050000
@@ -30878,12 +31994,14 @@ encoder:
 䣪	fdal	3420
 𨡺	fdal	0
 𨣈	fdal	0
+𫑺	fdal	0
 𨢲	fdan	0
 𨣡	fdan	0
 𨠟	fdau	0
 𨟹	fdax	0
 𨠎	fdax	0
 𨢑	fdax	0
+𫑸	fdax	0
 𣖖	fdbd	0
 𨢃	fdbi	0
 𨡑	fdbj	0
@@ -30900,6 +32018,7 @@ encoder:
 𨠻	fdbr	0
 醳	fdbu	36300
 醺	fdbu	884000
+𫑷	fdbv	0
 酵	fdby	2440000
 酝	fdbz	660000
 𨠂	fdbz	0
@@ -30934,11 +32053,13 @@ encoder:
 醥	fdfb	27700
 𨣤	fdfb	0
 𨣽	fdfb	0
+𫑼	fdfd	0
 醂	fdff	54900
 醹	fdfg	21200
 𨣆	fdfg	0
 𨠴	fdfj	0
 𨡋	fdfj	0
+𫑽	fdfj	0
 釄	fdfk	21800
 𨣴	fdfm	0
 𨣙	fdfr	0
@@ -30986,13 +32107,16 @@ encoder:
 𨢺	fdiq	0
 𨠐	fdir	0
 𨠃	fdix	0
+𫑴	fdiy	0
 酲	fdjc	188000
 醻	fdjd	26000
+𫑵	fdjd	0
 𨣛	fdje	0
 醧	fdjj	29800
 醽	fdjj	41600
 𨡞	fdjj	0
 𨤀	fdjj	0
+𫑻	fdjj	0
 䣼	fdjk	3530
 䤄	fdjk	5090
 醕	fdjk	49800
@@ -31009,6 +32133,7 @@ encoder:
 醴	fdju	1110000
 𤐿	fdju	0
 𨢉	fdju	0
+𫑶	fdju	0
 𨣝	fdjw	0
 𣓊	fdjx	0
 醇	fdjy	21900000
@@ -31018,6 +32143,7 @@ encoder:
 𨣚	fdka	0
 𨣲	fdka	0
 𨣒	fdkb	0
+𫑾	fdkb	0
 醰	fdke	496000
 𨡙	fdke	0
 𨡟	fdke	0
@@ -31091,6 +32217,7 @@ encoder:
 醯	fdnl	1110000
 𨣓	fdnl	0
 醮	fdnu	1360000
+𫑿	fdnu	0
 醙	fdnx	49500
 酫	fdoc	33800
 醛	fdoc	9780000
@@ -31114,6 +32241,7 @@ encoder:
 𨠦	fdoo	0
 𨠿	fdoo	0
 𨤍	fdoo	0
+𫑹	fdoo	0
 醦	fdop	30600
 醪	fdop	1120000
 酸	fdor	89500000
@@ -31140,6 +32268,7 @@ encoder:
 䤅	fdqk	4200
 𥂹	fdql	0
 酘	fdqx	101000
+𫑳	fdqy	0
 𨡦	fdqz	0
 𨠏	fdra	0
 𨟴	fdrb	0
@@ -31331,6 +32460,7 @@ encoder:
 醋栗	feff	261000
 𣟒	feff	0
 𣞦	fefk	0
+𪳾	fefk	0
 欗	fefl	45500
 植株	fefm	2470000
 模板	fefp	35900000
@@ -31368,8 +32498,10 @@ encoder:
 楜	fejq	67900
 𣒖	fejr	0
 橭	fejs	25200
+𪴊	feju	0
 㰇	feka	4280
 㯵	fekb	4020
+𪳰	fekf	0
 模	fekg	91300000
 槽	fekk	26300000
 𣞦	fekk	0
@@ -31558,6 +32690,7 @@ encoder:
 𠢵	ffby	0
 樗	ffbz	268000
 橒	ffbz	42500
+𪲡	ffbz	0
 𩤆	ffcu	0
 樷	ffcx	240000
 禁毒	ffcz	2170000
@@ -31574,14 +32707,17 @@ encoder:
 𣛧	ffff	0
 𣡕	ffff	0
 𣡽	ffff	0
+𪴖	ffff	0
 𣙑	fffg	0
 𩕌	fffg	0
 𠾤	fffj	0
 𣝬	fffj	0
 梦想	fffl	135000000
+𪴜	fffl	0
 𣚵	fffu	0
 栖霞	fffx	2390000
 𡘽	ffgd	0
+𪳽	ffgf	0
 梦魇	ffgg	2820000
 辳	ffgh	26100
 檽	ffgl	169000
@@ -31589,6 +32725,7 @@ encoder:
 𣡄	ffgm	0
 䫐	ffgo	3750
 𤍾	ffgu	0
+𪴠	ffgw	0
 𣗡	ffgy	0
 𣘝	ffgy	0
 楚雄	ffgz	2940000
@@ -31608,8 +32745,10 @@ encoder:
 𣠄	ffjj	0
 楋	ffjk	475000
 𣠌	ffjl	0
+𫜴	ffjl	0
 𣙙	ffjm	0
 樕	ffjr	39000
+𪳟	ffjr	0
 𧯴	ffju	0
 𧰔	ffju	0
 楂	ffka	1730000
@@ -31633,8 +32772,10 @@ encoder:
 彬县	fflz	241000
 林县	fflz	729000
 郴县	fflz	37700
+𪵝	ffmh	0
 𢽳	ffmo	0
 𣛲	ffmu	0
+𪴟	ffmy	0
 栖身	ffnc	1370000
 𣒜	ffnd	0
 㰌	ffni	4640
@@ -31654,6 +32795,7 @@ encoder:
 棼	ffoy	154000
 彬	ffpd	15100000
 禁锢	ffpj	2370000
+𪬟	ffpw	0
 梵	ffqd	9760000
 𣑽	ffqd	0
 檒	ffqi	97300
@@ -31691,6 +32833,7 @@ encoder:
 焚	ffuo	9830000
 𣗇	ffuo	0
 𤍕	ffuo	0
+𪳝	ffuo	0
 𣞖	ffuu	0
 林海	ffvm	2960000
 郴州	ffvn	5650000
@@ -31700,6 +32843,7 @@ encoder:
 𣏟	ffvv	0
 禁演	ffvw	165000
 禁运	ffwb	847000
+𪳯	ffwb	0
 㰈	ffwf	4400
 禁军	ffwh	508000
 𣕾	ffwm	0
@@ -31708,6 +32852,7 @@ encoder:
 梦寐	ffwz	408000
 橞	ffwz	36400
 𢛓	ffwz	0
+𪳉	ffwz	0
 㯬	ffxb	4350
 樰	ffxb	140000
 𣝪	ffxd	0
@@ -31715,6 +32860,8 @@ encoder:
 楚	ffxi	49800000
 檚	ffxi	181000
 㯟	ffxk	3920
+𪴛	ffxk	0
+𪴐	ffxw	0
 禁书	ffxy	1020000
 𣗗	ffxy	0
 𣜺	ffxy	0
@@ -31732,12 +32879,16 @@ encoder:
 婪	ffzm	478000
 楆	ffzm	74400
 梦幻	ffzz	46800000
+𪲵	ffzz	0
 𣔏	fgae	0
 𣖍	fgai	0
 椅	fgaj	61000000
+𪴑	fgan	0
 楏	fgbb	38700
 𣔦	fgbb	0
+𪲆	fgbd	0
 柘城	fgbh	504000
+𪱺	fgbi	0
 㮈	fgbk	4470
 楕	fgbq	369000
 桍	fgbz	44100
@@ -31755,10 +32906,12 @@ encoder:
 𣑊	fgib	0
 𣒽	fgir	0
 栫	fgiy	1120000
+𪲴	fgjf	0
 檶	fgjj	49500
 㮌	fgjk	4160
 槗	fgjl	279000
 𣖻	fgjl	0
+𪲲	fgjy	0
 𣕨	fgki	0
 橑	fgkk	30400
 𣞀	fgkl	0
@@ -31779,6 +32932,7 @@ encoder:
 樉	fgoo	102000
 𣔸	fgoo	0
 杯盘	fgpl	412000
+𪳊	fgqf	0
 㮋	fgqy	3990
 㮷	fgrk	3840
 震颤	fgsj	1630000
@@ -31787,6 +32941,7 @@ encoder:
 𣖂	fguc	0
 橱	fgud	5740000
 櫉	fgud	56100
+𪲄	fguo	0
 震惊	fgus	18400000
 𣓣	fguz	0
 柘	fgvv	2050000
@@ -31811,6 +32966,7 @@ encoder:
 栻	fhbi	118000
 桱	fhbi	50600
 樲	fhbl	50300
+𪲃	fhcd	0
 㰉	fhcm	5290
 𣝽	fhcm	0
 框框	fhfh	2100000
@@ -31839,6 +32995,7 @@ encoder:
 椻	fhkz	511000
 𣕩	fhkz	0
 𣐝	fhli	0
+𪴢	fhlj	0
 欖	fhll	1370000
 𣖿	fhlo	0
 桟	fhma	495000
@@ -31896,6 +33053,7 @@ encoder:
 樝	filc	29300
 𣙏	filf	0
 𣝱	filh	0
+𪳣	filj	0
 𣟷	film	0
 桢	filo	1720000
 楨	filo	1300000
@@ -31911,6 +33069,7 @@ encoder:
 𣚀	firl	0
 𣚁	firl	0
 𣜁	firn	0
+𪳠	firn	0
 𣐑	firr	0
 橴	firz	176000
 榩	fiso	22800
@@ -31949,6 +33108,7 @@ encoder:
 㶾	fjau	4040
 西平	fjau	1720000
 𧟺	fjax	0
+𪲥	fjax	0
 枵	fjaz	204000
 𥜞	fjaz	0
 𧟯	fjaz	0
@@ -31964,6 +33124,7 @@ encoder:
 䚈	fjbl	3870
 西贡	fjbl	639000
 𧢄	fjbl	0
+𫌬	fjbl	0
 𢿖	fjbm	0
 彯	fjbp	61800
 瓢	fjbp	7380000
@@ -32002,9 +33163,11 @@ encoder:
 𩙀	fjeq	0
 西苑	fjer	1870000
 鷣	fjer	24500
+𫜃	fjer	0
 𤍰	fjeu	0
 㩽	fjex	4130
 𨝸	fjey	0
+𫑬	fjey	0
 西药	fjez	11900000
 𧟾	fjez	0
 檲	fjfd	50400
@@ -32016,6 +33179,7 @@ encoder:
 𧢀	fjfl	0
 整机	fjfq	28700000
 鷅	fjfr	30400
+𫛽	fjfr	0
 𢣬	fjfw	0
 𨜼	fjfy	0
 整套	fjgc	9040000
@@ -32037,6 +33201,7 @@ encoder:
 𢎋	fjhs	0
 𣙬	fjhx	0
 整顿	fjhz	18000000
+𫃉	fjhz	0
 整点	fjij	1040000
 西餐	fjir	7300000
 槵	fjiw	79900
@@ -32049,14 +33214,18 @@ encoder:
 橾	fjjf	144000
 𥽹	fjjf	0
 梙	fjji	20800
+𪳱	fjji	0
 楍	fjjj	62600
 榀	fjjj	275000
 𣖎	fjjj	0
+𪴋	fjjj	0
 𠠅	fjjk	0
 西路	fjjr	22800000
 𠒹	fjjr	0
 𧠃	fjjr	0
+𪳏	fjjs	0
 𢣱	fjjw	0
+𫑒	fjjw	0
 𧠅	fjjy	0
 整日	fjka	3680000
 𩐋	fjka	0
@@ -32094,8 +33263,10 @@ encoder:
 𪆲	fjlr	0
 𪈎	fjlr	0
 𪈐	fjlr	0
+𫌞	fjlr	0
 露骨	fjlw	3100000
 𢤿	fjlw	0
+𪬯	fjlw	0
 𨞝	fjly	0
 酃县	fjlz	38500
 𡏴	fjmb	0
@@ -32105,6 +33276,7 @@ encoder:
 𧟨	fjme	0
 䅇	fjmf	5390
 棞	fjmf	95700
+𫌚	fjmf	0
 𣑟	fjmg	0
 𣭵	fjmh	0
 䊲	fjmm	4760
@@ -32120,6 +33292,8 @@ encoder:
 整篇	fjmw	1820000
 覂	fjmw	147000
 遫	fjmw	27200
+𫐿	fjmw	0
+𫑋	fjmw	0
 𡠼	fjmz	0
 杏仁	fjnb	10600000
 整体	fjnf	92300000
@@ -32136,6 +33310,7 @@ encoder:
 𣐳	fjos	0
 整个	fjov	135000000
 𧟺	fjow	0
+𪲥	fjow	0
 𧟬	fjpd	0
 西岳	fjpl	423000
 𥢝	fjpr	0
@@ -32148,6 +33323,7 @@ encoder:
 𪇃	fjqr	0
 西服	fjqy	6280000
 𠣩	fjra	0
+𫌛	fjrc	0
 柷	fjrd	158000
 𣡫	fjrd	0
 㯝	fjrj	4270
@@ -32173,6 +33349,7 @@ encoder:
 西文	fjso	4630000
 𧞙	fjsr	0
 𤊆	fjsu	0
+𫑐	fjsw	0
 西方	fjsy	46400000
 西装	fjtb	15800000
 西北	fjtr	48500000
@@ -32182,16 +33359,19 @@ encoder:
 㔄	fjuk	5480
 𣯼	fjum	0
 䙳	fjuo	4090
+𪲗	fjuo	0
 𤑶	fjuu	0
 𣙢	fjuy	0
 整数	fjuz	6530000
 整洁	fjvb	7930000
 西江	fjvb	2610000
 西湖	fjve	31800000
+𪴁	fjvr	0
 整流	fjvs	1830000
 西洋	fjvu	26300000
 杏	fjvv	27600000
 束	fjvv	22900000
+𪱳	fjvv	0
 西汉	fjvx	2760000
 整治	fjvz	38600000
 西宁	fjwa	9260000
@@ -32209,6 +33389,7 @@ encoder:
 𣗧	fjxl	0
 𠭄	fjxs	0
 𣐏	fjxs	0
+𪠧	fjxs	0
 𡥟	fjya	0
 𣒪	fjya	0
 枴	fjyd	82600
@@ -32222,9 +33403,11 @@ encoder:
 𪄏	fjyr	0
 𪄷	fjyr	0
 𫜼	fjyr	0
+𫛶	fjyr	0
 㼼	fjys	6310
 甄	fjys	9470000
 𤭾	fjys	0
+𪬈	fjyw	0
 𧟱	fjyx	0
 𧟵	fjyx	0
 翲	fjyy	69700
@@ -32304,6 +33487,8 @@ encoder:
 転	fkbz	6350000
 𨋆	fkbz	0
 𨍘	fkbz	0
+𪴘	fkbz	0
+𫏲	fkbz	0
 𨏴	fkcc	0
 𨌀	fkce	0
 𨎵	fkch	0
@@ -32335,6 +33520,7 @@ encoder:
 𨍷	fkec	0
 𣑬	fked	0
 𨍝	fkee	0
+𫏿	fkef	0
 輾	fkeh	796000
 軲	fkej	21700
 輴	fkel	37500
@@ -32374,6 +33560,7 @@ encoder:
 𨌿	fkfk	0
 𨎿	fkfk	0
 𨐄	fkfk	0
+𫐃	fkfk	0
 𨋵	fkfl	0
 𨏭	fkfl	0
 𨏼	fkfl	0
@@ -32408,8 +33595,10 @@ encoder:
 𣔑	fkgs	0
 𣚕	fkgs	0
 𨋩	fkgs	0
+𫏺	fkgx	0
 軛	fkgy	190000
 𨋛	fkgy	0
+𫏸	fkgy	0
 䡌	fkgz	4080
 𨌆	fkgz	0
 𨍥	fkgz	0
@@ -32426,6 +33615,7 @@ encoder:
 查到	fkhk	8150000
 𨍀	fkhk	0
 𨍌	fkhk	0
+𫏳	fkhm	0
 𨏺	fkhp	0
 𨌡	fkhx	0
 䡸	fkhz	3770
@@ -32433,6 +33623,7 @@ encoder:
 柚	fkia	10900000
 𤰔	fkia	0
 柙	fkib	216000
+𫏷	fkib	0
 柛	fkic	2550000
 𨊣	fkid	0
 𣠢	fkig	0
@@ -32445,6 +33636,7 @@ encoder:
 𨍅	fkil	0
 𨌳	fkiq	0
 𨍐	fkiq	0
+𪳡	fkir	0
 𢡴	fkiw	0
 軙	fkix	20800
 𨋤	fkix	0
@@ -32493,6 +33685,7 @@ encoder:
 𨏙	fkjr	0
 䡶	fkjs	4000
 𨎤	fkju	0
+𪴀	fkju	0
 轗	fkjw	58300
 𨍖	fkjy	0
 𨝩	fkjy	0
@@ -32506,6 +33699,7 @@ encoder:
 𣠠	fkkb	0
 輫	fkkc	37800
 𠜒	fkkd	0
+𪲇	fkkd	0
 䡲	fkke	8900
 雷暴	fkke	720000
 𨌬	fkke	0
@@ -32586,6 +33780,7 @@ encoder:
 槾	fklx	104000
 𣕃	fklz	0
 軠	fkmb	57500
+𫏹	fkmb	0
 𡭏	fkmd	0
 𨌦	fkme	0
 輮	fkmf	50500
@@ -32606,6 +33801,7 @@ encoder:
 轞	fkml	38600
 𣗨	fkml	0
 𨌽	fkmm	0
+𪲦	fkmm	0
 軼	fkmo	1320000
 𢽬	fkmo	0
 𨊴	fkmo	0
@@ -32618,6 +33814,7 @@ encoder:
 𨊰	fkmy	0
 𨋖	fkmy	0
 𨋱	fkmy	0
+𪲺	fkmy	0
 𣒹	fkmz	0
 𨋶	fknc	0
 𨌈	fknc	0
@@ -32632,6 +33829,7 @@ encoder:
 𨿢	fkni	0
 䰤	fknj	4280
 𨍹	fknj	0
+𫏴	fknk	0
 𨏳	fknl	0
 𨌓	fkno	0
 䡚	fknr	4190
@@ -32666,6 +33864,7 @@ encoder:
 𨊽	fkoo	0
 𨌻	fkoo	0
 𨏤	fkoo	0
+𫏶	fkoo	0
 軫	fkop	168000
 轇	fkop	46500
 𨎗	fkop	0
@@ -32725,6 +33924,7 @@ encoder:
 轚	fkqf	56300
 𨎼	fkqf	0
 𨣗	fkqf	0
+𫐁	fkqf	0
 礊	fkqg	322000
 𥖳	fkqg	0
 蟿	fkqi	34200
@@ -32761,6 +33961,7 @@ encoder:
 𨎟	fkrj	0
 𨎣	fkrj	0
 𨎲	fkrj	0
+𫏾	fkrj	0
 䡘	fkrk	3890
 𨋎	fkrk	0
 𨋮	fkrk	0
@@ -32838,6 +34039,7 @@ encoder:
 軿	fkue	57200
 𨍍	fkue	0
 輶	fkuf	73200
+𪳑	fkuf	0
 䡵	fkug	3580
 𣝢	fkug	0
 𣡲	fkug	0
@@ -32857,6 +34059,7 @@ encoder:
 𨎦	fkve	0
 杳渺	fkvl	36400
 𨋫	fkvr	0
+𪳒	fkvr	0
 東	fkvv	137000000
 杳	fkvv	4470000
 𣏬	fkvv	0
@@ -32898,6 +34101,7 @@ encoder:
 䡭	fkxe	4050
 𨋀	fkxe	0
 䡦	fkxf	4230
+𫐀	fkxf	0
 䡹	fkxi	4590
 𤴝	fkxi	0
 𨋋	fkxi	0
@@ -33003,11 +34207,13 @@ encoder:
 相干	flae	4120000
 𢿋	flai	0
 𣗵	flai	0
+𪲕	flax	0
 枏	flbd	66800
 𠄬	flbd	0
 𣑭	flbd	0
 𣝣	flbd	0
 桐城	flbh	2210000
+𪱽	flbi	0
 椆	flbj	61100
 想来	flbk	13400000
 𣞍	flbm	0
@@ -33028,6 +34234,7 @@ encoder:
 㯰	flel	3780
 樱花	flen	12800000
 椣	fleo	82100
+𪲸	flfj	0
 棗	flfl	3280000
 棘	flfl	7550000
 𣝯	flfl	0
@@ -33052,6 +34259,7 @@ encoder:
 𣞲	fljr	0
 榿	flju	92200
 㭗	flka	3820
+𪳢	flka	0
 檌	flkc	151000
 𦖝	flkc	0
 刺	flkd	50300000
@@ -33059,6 +34267,7 @@ encoder:
 𣍃	flki	0
 𧌐	flki	0
 𣗶	flkv	0
+𪶛	flkv	0
 相思	flkw	24900000
 相当	flkx	148000000
 相同	flld	81600000
@@ -33076,6 +34285,8 @@ encoder:
 𧠵	fllr	0
 𧡮	fllr	0
 𧡴	fllr	0
+𫌫	fllr	0
+𪴂	flls	0
 𤏡	fllu	0
 刺骨	fllw	2670000
 𣡠	fllx	0
@@ -33112,6 +34323,7 @@ encoder:
 𣖱	flor	0
 想念	flos	36500000
 相邻	flow	5140000
+𪲕	flow	0
 梤	floy	73300
 𢒞	flpd	0
 相貌	flpn	9050000
@@ -33133,6 +34345,7 @@ encoder:
 𣞻	flrr	0
 椤	flrs	3730000
 𩰦	flrx	0
+𪲤	flry	0
 鶫	flrz	62000
 𪀜	flrz	0
 𪂼	flrz	0
@@ -33187,6 +34400,7 @@ encoder:
 𪔇	flzn	0
 相约	flzr	17700000
 相继	flzz	16600000
+𪲻	fmac	0
 酷刑	fmae	6080000
 𣔼	fmae	0
 㯚	fmaj	3510
@@ -33211,6 +34425,7 @@ encoder:
 霉素	fmcz	3930000
 酷热	fmdq	2600000
 棰	fmeb	1180000
+𪲙	fmeb	0
 檱	fmec	56000
 𣗍	fmec	0
 杵	fmed	2650000
@@ -33219,6 +34434,7 @@ encoder:
 橅	fmeu	53300
 𣠓	fmfb	0
 𣟔	fmfd	0
+𪴧	fmfl	0
 枖	fmgd	119000
 𣕊	fmgk	0
 桥	fmgn	132000000
@@ -33230,22 +34446,27 @@ encoder:
 𣟢	fmhk	0
 𣙖	fmhl	0
 𣘷	fmhm	0
+𪲘	fmhm	0
 𣜀	fmhz	0
 柞	fmid	1350000
 楀	fmil	1620000
 柹	fmim	28700
+𪴓	fmin	0
 𣖯	fmiw	0
 梴	fmiy	32800
 𣞳	fmjk	0
+𪳲	fmjk	0
 㰏	fmjl	5040
 橋	fmjl	31900000
 𩏴	fmjm	0
+𪳤	fmjw	0
 楿	fmka	206000
 𣞯	fmka	0
 㮔	fmkb	3820
 酷暑	fmkb	3500000
 梸	fmkd	24000
 𣙔	fmkf	0
+𪴡	fmkk	0
 𣘺	fmkl	0
 𣜤	fmkm	0
 株	fmko	94100000
@@ -33287,6 +34508,7 @@ encoder:
 橁	fmrk	69600
 𣠱	fmrk	0
 欑	fmrl	1180000
+𪴙	fmrl	0
 鬱	fmrp	9760000
 𣖰	fmrr	0
 𣘵	fmrr	0
@@ -33298,6 +34520,7 @@ encoder:
 桥头	fmtg	6230000
 𣓽	fmtr	0
 𣔪	fmtr	0
+𪳕	fmtr	0
 㭔	fmua	4160
 楸	fmuo	1420000
 𣡅	fmuq	0
@@ -33315,17 +34538,21 @@ encoder:
 𣞂	fmwl	0
 𣠗	fmwl	0
 櫷	fmwx	28700
+𪴌	fmwy	0
 棅	fmxb	121000
+𪴅	fmxb	0
 𣡡	fmxd	0
 𣒀	fmxi	0
 𣙨	fmxi	0
 𣠰	fmxk	0
 櫛	fmxy	1410000
+𪱿	fmya	0
 杚	fmyd	31900
 柂	fmyi	54000
 𣙭	fmyj	0
 𣒴	fmym	0
 𣛏	fmys	0
+𪴚	fmyu	0
 槌	fmyw	5530000
 𣒤	fmyy	0
 𣞫	fmzf	0
@@ -33350,6 +34577,7 @@ encoder:
 桦南	fnel	215000
 棉花	fnen	18500000
 柏木	fnfa	2080000
+𪳔	fnfa	0
 柏林	fnff	11600000
 𨑋	fnfg	0
 柏树	fnfx	914000
@@ -33393,12 +34621,14 @@ encoder:
 𣔬	fnoe	0
 𣝼	fnol	0
 𣟨	fnol	0
+𪴤	fnol	0
 欅	fnom	475000
 𣙺	fnor	0
 𣞛	fnor	0
 㭡	fnos	5580
 𣠙	fnou	0
 㰒	fnoy	4100
+𪴃	fnpg	0
 霍邱	fnpy	750000
 棿	fnrd	361000
 桦	fnre	4750000
@@ -33412,6 +34642,7 @@ encoder:
 梎	fnrr	21400
 𣓛	fnrr	0
 𣔢	fnrr	0
+𪳳	fnrr	0
 𣚔	fnru	0
 樬	fnrw	25700
 檄	fnsm	1530000
@@ -33452,6 +34683,7 @@ encoder:
 松下	foai	38200000
 零下	foai	4090000
 𣔥	foai	0
+𪴺	foai	0
 㭘	foaj	4230
 𠎙	foaj	0
 棆	foal	87100
@@ -33526,6 +34758,7 @@ encoder:
 𪎀	fogb	0
 䫶	fogg	3430
 礬	fogg	149000
+𫖺	fogg	0
 蠜	fogi	26500
 𣒅	fogj	0
 桸	fogl	127000
@@ -33654,6 +34887,7 @@ encoder:
 棥	foof	51800
 顂	foog	28600
 樅	fooi	261000
+𪲧	fooi	0
 㭲	fooj	5310
 𣠬	fook	0
 𤲝	fook	0
@@ -33706,6 +34940,7 @@ encoder:
 𪋿	fori	0
 𪌛	fori	0
 𪍹	fori	0
+𫜐	fori	0
 𪌣	forj	0
 𪌾	fork	0
 𪍞	fork	0
@@ -33756,6 +34991,7 @@ encoder:
 䴺	fosj	6420
 𣛉	fosl	0
 𪍮	fosm	0
+𫇒	fosn	0
 樧	fosq	29600
 䙪	fosr	3600
 𩻜	fosr	0
@@ -33764,6 +35000,7 @@ encoder:
 𢠗	fosw	0
 枔	fosx	426000
 零讯	fosy	6920
+𪱸	fotd	0
 𪌉	fote	0
 𪍎	fote	0
 零头	fotg	1240000
@@ -33861,6 +35098,7 @@ encoder:
 𪎆	fozn	0
 𩸝	fozr	0
 𪁿	fozr	0
+𪝗	fozr	0
 松	fozs	90400000
 枩	fozs	149000
 棇	fozw	29300
@@ -33869,6 +35107,8 @@ encoder:
 检出	fozz	3480000
 𤕩	fozz	0
 𪌥	fozz	0
+𪲉	fpaj	0
+𪲾	fpaj	0
 𣖩	fpak	0
 𣨗	fpar	0
 栀	fpay	4610000
@@ -33877,6 +35117,7 @@ encoder:
 𣑂	fpaz	0
 𣔔	fpbn	0
 板块	fpbx	41800000
+𪲀	fpda	0
 㭩	fpds	4500
 板报	fpdy	1880000
 𣏸	fped	0
@@ -33888,6 +35129,7 @@ encoder:
 杉树	fpfx	536000
 𣛪	fpgo	0
 楥	fpgx	92200
+𪳗	fpgx	0
 板式	fphb	2690000
 板车	fphe	1980000
 榹	fpih	23100
@@ -33923,6 +35165,7 @@ encoder:
 板子	fpya	3100000
 桴	fpya	1340000
 𣐧	fpys	0
+𪳵	fpyu	0
 𣑿	fpyy	0
 榽	fpzg	25000
 桵	fpzm	102000
@@ -33934,6 +35177,7 @@ encoder:
 机井	fqbn	416000
 机场	fqby	38300000
 机动	fqbz	22600000
+𪳴	fqbz	0
 机耕	fqcb	504000
 杋	fqda	35800
 枠	fqed	21600000
@@ -33968,6 +35212,7 @@ encoder:
 𩛳	fqox	0
 机舱	fqpo	1290000
 栅	fqqa	9520000
+𪲊	fqqd	0
 机务	fqry	785000
 𣐠	fqss	0
 机床	fqtf	14200000
@@ -33988,6 +35233,7 @@ encoder:
 朹	fqya	74500
 棚子	fqya	633000
 𣏒	fqya	0
+𪣖	fqyb	0
 𣏫	fqym	0
 棴	fqyx	130000
 机翼	fqyy	937000
@@ -34002,9 +35248,11 @@ encoder:
 𣖼	fraz	0
 𣟓	frbg	0
 柳城	frbh	520000
+𪲋	frbi	0
 𣘤	frbk	0
 桻	frci	34200
 槰	frcw	58900
+𪳧	frcy	0
 𣑣	frds	0
 𣖑	frei	0
 桅杆	frfa	1070000
@@ -34032,10 +35280,14 @@ encoder:
 𣕍	frkg	0
 㭵	frki	5410
 𣓂	frki	0
+𪴝	frkk	0
 栎	frko	683000
+𪱾	frko	0
 构思	frkw	7840000
 𣖆	frky	0
+𪳥	frkz	0
 桷	frld	405000
+𪲰	frlg	0
 槝	frll	46800
 㭥	frlo	7640
 槇	frlo	721000
@@ -34058,6 +35310,7 @@ encoder:
 𣓌	froj	0
 𣓗	frok	0
 檐	fros	5840000
+𪲨	frow	0
 格律	frox	669000
 𣑤	froz	0
 𣞗	frpk	0
@@ -34120,6 +35373,7 @@ encoder:
 𣚪	fsbi	0
 槠	fsbm	160000
 櫧	fsbm	188000
+𪲭	fsbr	0
 校场	fsby	395000
 校长	fsch	26900000
 梳理	fsck	5740000
@@ -34135,6 +35389,7 @@ encoder:
 𣠥	fsfn	0
 校样	fsfu	97600
 榜样	fsfu	17900000
+𪺂	fsfu	0
 核桃	fsfv	7750000
 樟树	fsfx	1240000
 核酸	fsfz	4630000
@@ -34172,6 +35427,7 @@ encoder:
 柿	fsli	9480000
 𣚌	fslj	0
 𣟎	fslr	0
+𪳩	fslr	0
 樆	fslz	85300
 𣘄	fsmh	0
 核算	fsml	21100000
@@ -34180,12 +35436,14 @@ encoder:
 𣖺	fsmr	0
 椸	fsmy	36900
 𣙮	fsnb	0
+𪲎	fsnd	0
 𣚳	fsni	0
 橀	fsnl	1650000
 核价	fsno	218000
 棭	fsnr	122000
 醇化	fsnr	158000
 椊	fsoe	40700
+𪲱	fsog	0
 𣖞	fsoj	0
 校舍	fsom	2590000
 校	fsoo	206000000
@@ -34197,6 +35455,7 @@ encoder:
 校风	fsqo	1190000
 㮵	fsqs	3850
 樟脑	fsqs	442000
+𪲌	fsqs	0
 𩰩	fsrd	0
 𣐿	fsrh	0
 校外	fsri	8370000
@@ -34233,6 +35492,7 @@ encoder:
 楴	fswl	50900
 㯠	fswm	21900
 酿造	fswm	5020000
+𪳄	fswq	0
 鶐	fswr	19700
 榜	fsws	119000000
 核实	fswt	24600000
@@ -34240,6 +35500,7 @@ encoder:
 怷	fswz	70000
 怸	fswz	23700
 核心	fswz	90600000
+𪴦	fsxd	0
 㯀	fsxi	4250
 校验	fsxo	6480000
 桹	fsxo	34900
@@ -34274,8 +35535,10 @@ encoder:
 𣙦	ftbd	0
 榳	ftby	43700
 枓	fted	179000
+𪴗	fteo	0
 樜	fteu	55300
 𣙃	fteu	0
+𪳁	ftex	0
 𣙪	ftff	0
 𣟖	ftfg	0
 𣘍	ftfk	0
@@ -34307,9 +35570,11 @@ encoder:
 槦	ftxl	644000
 𣘋	ftxl	0
 椩	ftxo	23400
+𪲮	ftxs	0
 櫠	ftyq	606000
 𣝠	ftyz	0
 𣠯	ftzr	0
+𪴇	ftzu	0
 梯形	fuae	1750000
 楼下	fuai	15800000
 𣞼	fuax	0
@@ -34317,6 +35582,7 @@ encoder:
 栏	fubd	211000000
 槎	fubi	1780000
 𣕲	fubk	0
+𪜅	fubn	0
 𣘰	fubp	0
 㮓	fubr	3790
 𣕗	fubr	0
@@ -34334,6 +35600,7 @@ encoder:
 楼梯	fufu	14400000
 𣜃	fufu	0
 𡑻	fugb	0
+𪳸	fugb	0
 栚	fugd	54100
 𣖙	fugd	0
 𣔾	fugq	0
@@ -34352,10 +35619,12 @@ encoder:
 様	fukv	161000000
 栏目	fula	199000000
 𣕂	fuli	0
+𪲍	fuli	0
 橧	fulk	35300
 𣙥	fulk	0
 檥	fumh	40500
 𣜧	fums	0
+𪳂	funl	0
 杰作	funm	6060000
 檤	funw	481000
 榏	fuol	22600
@@ -34363,6 +35632,7 @@ encoder:
 𣞼	fuox	0
 楼盘	fupl	37200000
 椾	fuqk	375000
+𪲞	furd	0
 橉	furm	23800
 𩽑	furr	0
 𣘎	furz	0
@@ -34403,6 +35673,7 @@ encoder:
 㮶	fuzq	4260
 𣖬	fuzr	0
 𣜑	fuzu	0
+𪴆	fuzw	0
 杰出	fuzz	15200000
 𣕜	fuzz	0
 𣘎	fuzz	0
@@ -34428,6 +35699,7 @@ encoder:
 霳	fvam	43300
 𩃫	fvan	0
 𩆕	fvan	0
+𪬓	fvaw	0
 𣙄	fvax	0
 𩃨	fvax	0
 𩂾	fvaz	0
@@ -34445,6 +35717,7 @@ encoder:
 𩅯	fvbr	0
 𩇇	fvbr	0
 䨹	fvbu	3960
+𫕵	fvbu	0
 要地	fvbv	1600000
 霆	fvby	4560000
 䨺	fvbz	4120
@@ -34458,6 +35731,7 @@ encoder:
 𩇔	fvbz	0
 𩃳	fvcb	0
 𩄴	fvcb	0
+𫕰	fvcb	0
 𩇋	fvcc	0
 𩂽	fvce	0
 𩄺	fvce	0
@@ -34468,10 +35742,12 @@ encoder:
 𩄾	fvcl	0
 𩄄	fvco	0
 䨝	fvcq	3520
+𫑄	fvcw	0
 䨮	fvcx	4910
 要素	fvcz	38700000
 𩂻	fvcz	0
 要挟	fvdb	2210000
+𫕫	fvdg	0
 要事	fvdj	1780000
 𩃂	fvdm	0
 𩃑	fvdn	0
@@ -34491,8 +35767,11 @@ encoder:
 𩅰	fvep	0
 霸	fveq	92000000
 𩆶	fver	0
+𫕳	fver	0
 酬劳	fvew	1390000
 𩂏	fvex	0
+𫕬	fvey	0
+𫕮	fvey	0
 䨢	fvez	7000
 霮	fvez	28400
 𦉣	fvez	0
@@ -34537,6 +35816,7 @@ encoder:
 需	fvgl	329000000
 𩃄	fvgm	0
 䰰	fvgn	5280
+𫕨	fvgp	0
 䨖	fvgq	3800
 𩂚	fvgq	0
 𩂢	fvgq	0
@@ -34555,6 +35835,7 @@ encoder:
 𩆫	fvhx	0
 霕	fvhz	22600
 𩂄	fvhz	0
+𫕩	fvib	0
 𧓑	fvii	0
 要点	fvij	44100000
 霑	fvij	929000
@@ -34562,6 +35843,7 @@ encoder:
 𩄷	fvij	0
 䨞	fvil	3330
 雺	fvim	56100
+𪬓	fviw	0
 㪮	fvix	4150
 䨷	fvix	3700
 𣀀	fvix	0
@@ -34583,11 +35865,13 @@ encoder:
 霣	fvjl	36700
 𧢥	fvjl	0
 𩆚	fvjl	0
+𫕥	fvjl	0
 𩆐	fvjm	0
 𩆻	fvjm	0
 𩇆	fvjm	0
 𩵀	fvjn	0
 𩵂	fvjn	0
+𫕷	fvjn	0
 𩂝	fvjo	0
 𩂲	fvjo	0
 𩆒	fvjo	0
@@ -34621,6 +35905,7 @@ encoder:
 䨵	fvke	3970
 𩅈	fvke	0
 𩅦	fvke	0
+𫕭	fvke	0
 䨔	fvkg	3810
 𩃙	fvkg	0
 𩄻	fvkg	0
@@ -34654,6 +35939,7 @@ encoder:
 𩅆	fvkr	0
 𩅳	fvkr	0
 𪆼	fvkr	0
+𫕴	fvkr	0
 𩃯	fvku	0
 𩄪	fvku	0
 𩄰	fvku	0
@@ -34663,6 +35949,7 @@ encoder:
 靆	fvkw	38700
 要紧	fvkx	7010000
 𨟘	fvky	0
+𫑪	fvky	0
 䨡	fvkz	3910
 電	fvkz	140000000
 𩃗	fvkz	0
@@ -34700,6 +35987,7 @@ encoder:
 霪	fvmb	242000
 𨗒	fvmb	0
 𩂐	fvmb	0
+𫕤	fvmb	0
 𠧍	fvme	0
 䨋	fvmh	3750
 雮	fvmh	121000
@@ -34735,6 +36023,7 @@ encoder:
 𩂛	fvnd	0
 檪	fvnf	78600
 𩂯	fvnf	0
+𫕱	fvnf	0
 𩂠	fvnh	0
 𩃷	fvnh	0
 霍	fvni	17800000
@@ -34807,6 +36096,7 @@ encoder:
 雰	fvoy	808000
 𨟯	fvoy	0
 𩃼	fvoy	0
+𫕧	fvoy	0
 𩃍	fvoz	0
 𩃭	fvoz	0
 酬金	fvpa	1360000
@@ -34822,6 +36112,7 @@ encoder:
 𩁸	fvqd	0
 𩃵	fvqf	0
 𩄏	fvqi	0
+𫕲	fvqk	0
 霰	fvqm	1340000
 霺	fvqm	75900
 𩂑	fvqo	0
@@ -34839,9 +36130,11 @@ encoder:
 𩂣	fvrj	0
 𩅗	fvrj	0
 𩅬	fvrj	0
+𪳅	fvrj	0
 𩂶	fvrk	0
 𩄉	fvrk	0
 𩅨	fvrk	0
+𫕪	fvrk	0
 霿	fvrl	35300
 𣛯	fvrl	0
 𩆂	fvrl	0
@@ -34874,6 +36167,7 @@ encoder:
 𪂕	fvrz	0
 𣕝	fvsb	0
 𩆔	fvsb	0
+𫕶	fvsb	0
 霔	fvsc	31000
 𩄊	fvse	0
 𩅁	fvse	0
@@ -34900,6 +36194,7 @@ encoder:
 霎	fvsz	1460000
 要闻	fvtc	49100000
 䨏	fvtr	4060
+𫕡	fvtr	0
 𩅄	fvtx	0
 𩄝	fvub	0
 䨴	fvud	4400
@@ -34928,6 +36223,7 @@ encoder:
 雿	fvvr	583000
 𩃎	fvvs	0
 𩃜	fvvs	0
+𫕦	fvvs	0
 𩅃	fvwb	0
 要害	fvwc	5680000
 𩅴	fvwf	0
@@ -34985,10 +36281,12 @@ encoder:
 𩇈	fvxx	0
 𩂵	fvxy	0
 霋	fvxz	27200
+𪳪	fvxz	0
 桃子	fvya	6970000
 𩅱	fvyb	0
 𩁶	fvyd	0
 𩄛	fvyf	0
+𫕠	fvyi	0
 要强	fvyj	4250000
 霤	fvyk	101000
 𩆎	fvyk	0
@@ -35008,6 +36306,7 @@ encoder:
 𩆛	fvys	0
 𩆣	fvys	0
 𩄩	fvyt	0
+𫕯	fvyu	0
 𩃁	fvyx	0
 䨒	fvyy	3990
 霛	fvyy	107000
@@ -35043,9 +36342,11 @@ encoder:
 要好	fvzy	16600000
 鄠	fvzy	85900
 𨝽	fvzy	0
+𫕢	fvzy	0
 𩂗	fvzz	0
 𩃚	fvzz	0
 𩅏	fvzz	0
+𪳘	fwag	0
 柠	fwai	14300000
 槣	fwaj	55200
 𣟧	fwal	0
@@ -35068,11 +36369,14 @@ encoder:
 枕木	fwfa	612000
 棺材	fwfd	6840000
 柠檬	fwfe	13800000
+𪴠	fwfg	0
 㯈	fwfj	3670
 楎	fwfk	26500
 槤	fwfk	584000
 𣚢	fwfk	0
+𪳚	fwfk	0
 榕树	fwfx	4800000
+𪴐	fwfx	0
 𣚢	fwfz	0
 惠存	fwgi	53200
 㯌	fwgq	3710
@@ -35086,17 +36390,20 @@ encoder:
 梿	fwhe	161000
 惠东	fwhk	832000
 𣔝	fwhz	0
+𪴣	fwjg	0
 𣘌	fwjr	0
 𣟳	fwjr	0
 𣟴	fwjr	0
 𣡬	fwjr	0
 𣠲	fwju	0
 槴	fwjy	71500
+𪲩	fwka	0
 𣘔	fwkg	0
 榊	fwki	2290000
 𣔴	fwki	0
 㯾	fwkk	3910
 𣟆	fwkk	0
+𪴔	fwkk	0
 檳	fwkl	872000
 惠临	fwkm	54800
 𣘹	fwko	0
@@ -35125,8 +36432,10 @@ encoder:
 㭦	fwmh	4530
 榨	fwmi	4050000
 櫁	fwmi	70300
+𪳤	fwmj	0
 榓	fwml	30000
 樒	fwml	76300
+𪳃	fwmq	0
 槌	fwmy	5530000
 榷	fwni	925000
 𣙜	fwni	0
@@ -35137,6 +36446,7 @@ encoder:
 棎	fwof	358000
 榕	fwoj	12800000
 𣟯	fwoj	0
+𪳶	fwot	0
 𣔱	fwox	0
 𣔅	fwpd	0
 㰂	fwpk	5970
@@ -35150,6 +36460,7 @@ encoder:
 枕	fwrd	28200000
 𣏝	fwrd	0
 楁	fwrj	1300000
+𪳖	fwrm	0
 𣛱	fwrn	0
 柁	fwrr	173000
 𣞐	fwru	0
@@ -35185,10 +36496,13 @@ encoder:
 𣑑	fwya	0
 𣐖	fwyd	0
 𣑒	fwyd	0
+𪳇	fwyj	0
 惠阳	fwyk	1220000
 惠及	fwym	2230000
 㮼	fwyy	4330
 𣗈	fwzf	0
+𪴎	fwzl	0
+𪴥	fwzl	0
 桉	fwzm	1450000
 惠允	fwzr	14200
 树干	fxae	2860000
@@ -35197,6 +36511,7 @@ encoder:
 𣛣	fxae	0
 楑	fxag	47200
 树下	fxai	14400000
+𪳜	fxau	0
 𣜓	fxax	0
 𣐓	fxbd	0
 𣑵	fxbd	0
@@ -35234,6 +36549,8 @@ encoder:
 𡐨	fxfb	0
 树枝	fxfe	5700000
 树林	fxff	10600000
+𪳻	fxff	0
+𪴈	fxff	0
 霹雳	fxfg	7470000
 雪柜	fxfh	218000
 树梢	fxfk	1650000
@@ -35246,6 +36563,7 @@ encoder:
 权术	fxfs	547000
 树桩	fxft	575000
 概要	fxfv	140000000
+𪳬	fxfv	0
 懋	fxfw	3920000
 树根	fxfx	1650000
 㭈	fxgd	3840
@@ -35290,11 +36608,14 @@ encoder:
 㮀	fxkz	4700
 桶	fxld	45700000
 𡭌	fxld	0
+𪲯	fxld	0
+𪴕	fxlk	0
 雪山	fxll	11900000
 雪崩	fxlq	2290000
 雪峰	fxlr	1930000
 樋	fxlw	763000
 𣖽	fxlx	0
+𪳆	fxly	0
 𣜔	fxlz	0
 楙	fxmf	146000
 楺	fxmf	34400
@@ -35424,7 +36745,9 @@ encoder:
 𣚦	fyji	0
 椭圆	fyjj	5370000
 配器	fyjj	12900000
+𪳺	fyjl	0
 𤋐	fyju	0
+𪳇	fyjw	0
 𣑌	fyjz	0
 𣙶	fyka	0
 极少	fykm	8450000
@@ -35433,6 +36756,7 @@ encoder:
 配置	fyle	116000000
 𣓶	fylk	0
 极具	fylo	13700000
+𪴏	fylx	0
 杞县	fylz	282000
 梃	fymb	474000
 𣗕	fymb	0
@@ -35475,6 +36799,7 @@ encoder:
 配方	fysy	31200000
 极度	fytv	18100000
 极差	fyub	5450000
+𪳹	fyug	0
 配料	fyut	5360000
 极为	fyuv	30600000
 杨浦	fyvf	3720000
@@ -35517,6 +36842,7 @@ encoder:
 桳	fzge	49800
 𣔊	fzgj	0
 㮥	fzgk	7600
+𫖟	fzgo	0
 椮	fzgp	28900
 椽	fzgq	1860000
 𣗭	fzhi	0
@@ -35540,6 +36866,7 @@ encoder:
 酸化	fznr	5870000
 槮	fzop	550000
 梭	fzor	19800000
+𪴉	fzor	0
 𣚈	fzou	0
 㯿	fzoz	5920
 㭇	fzrd	4010
@@ -35548,9 +36875,11 @@ encoder:
 𣖊	fzrk	0
 桚	fzrs	20000
 𩿤	fzrz	0
+𫛠	fzrz	0
 札记	fzsy	6220000
 酸度	fztv	1350000
 酸痛	fztx	3800000
+𪲛	fzuf	0
 酸类	fzug	918000
 酸性	fzum	5580000
 酸洗	fzvm	1250000
@@ -35572,6 +36901,7 @@ encoder:
 𣝵	fzzk	0
 𣠭	fzzl	0
 𣚓	fzzq	0
+𪲏	fzzr	0
 㭃	fzzs	6780
 柪	fzzy	49900
 酸奶	fzzy	4880000
@@ -35690,6 +37020,7 @@ encoder:
 左贡	gbbl	170000
 左联	gbcu	176000
 压抑	gbdr	5050000
+𪿚	gbds	0
 𥔫	gbek	0
 压榨	gbfw	2330000
 左权	gbfx	765000
@@ -35727,6 +37058,7 @@ encoder:
 𥓪	gbob	0
 砆	gbod	190000
 𥗇	gbof	0
+𪿵	gboh	0
 硅谷	gboo	13100000
 碐	gbor	27300
 压铸	gbpc	1850000
@@ -35737,6 +37069,8 @@ encoder:
 硅胶	gbqs	3360000
 夸脱	gbqu	92000
 压服	gbqy	137000
+𪿑	gbrd	0
+𪿔	gbrd	0
 压条	gbrf	380000
 左角	gbrl	232000
 硓	gbrr	56900
@@ -35780,6 +37114,7 @@ encoder:
 压缩	gbzw	55900000
 䂶	gbzy	5030
 耷拉	gcds	1860000
+𪿞	gcds	0
 套鞋	gceb	195000
 套餐	gcir	33200000
 聋哑	gcja	2630000
@@ -35794,6 +37129,7 @@ encoder:
 套件	gcnm	8250000
 礟	gcoo	53700
 礮	gcoo	42000
+𪿦	gcrh	0
 𥗗	gcsr	0
 套装	gctb	35400000
 套间	gctk	1220000
@@ -35802,8 +37138,10 @@ encoder:
 套牢	gcwm	3000000
 套衫	gcwp	316000
 套房	gcws	17000000
+𪿼	gcxg	0
 碶	gcyg	337000
 磝	gcym	57300
+𪿶	gcyz	0
 碡	gczy	106000
 丆	gdaa	82800
 	gdaa	0
@@ -35831,6 +37169,7 @@ encoder:
 𩠣	gdan	0
 𡘂	gdao	0
 𪍢	gdaq	0
+𪥈	gdau	0
 㦽	gdaz	3900
 㚝	gdbb	4080
 大款	gdbb	3670000
@@ -35838,6 +37177,7 @@ encoder:
 𡙔	gdbb	0
 夳	gdbd	53700
 左	gdbi	186000000
+𪩣	gdbi	0
 大鼓	gdbj	984000
 奝	gdbj	40900
 奈	gdbk	24100000
@@ -35948,6 +37288,7 @@ encoder:
 𩕑	gdgg	0
 耐碱	gdgh	602000
 大面	gdgj	1040000
+𪟃	gdgk	0
 𧡅	gdgl	0
 大雁	gdgn	4150000
 𢒊	gdgp	0
@@ -35960,6 +37301,7 @@ encoder:
 𡚓	gdhb	0
 大车	gdhe	2080000
 大致	gdhm	22900000
+𪥅	gdhm	0
 奁	gdho	574000
 大成	gdhv	9490000
 奆	gdhx	25100
@@ -35971,6 +37313,7 @@ encoder:
 大叔	gdia	5950000
 在	gdib	2700000000
 𡗱	gdii	0
+𫋒	gdii	0
 大战	gdij	33300000
 大步	gdik	9070000
 𡘧	gdik	0
@@ -36002,6 +37345,7 @@ encoder:
 𡙗	gdjj	0
 𣎥	gdjj	0
 𪌦	gdjj	0
+𪡐	gdjj	0
 剞	gdjk	313000
 奤	gdjk	39800
 𡙲	gdjk	0
@@ -36010,6 +37354,7 @@ encoder:
 大员	gdjl	991000
 𠳮	gdjl	0
 𥁓	gdjl	0
+𪥜	gdjl	0
 大跌	gdjm	6120000
 𢽽	gdjm	0
 𤯱	gdjm	0
@@ -36021,6 +37366,7 @@ encoder:
 大路	gdjr	7490000
 欹	gdjr	939000
 鵸	gdjr	22800
+𪥚	gdjr	0
 𡘰	gdju	0
 大中	gdjv	15300000
 𪓡	gdjw	0
@@ -36060,12 +37406,15 @@ encoder:
 𤊽	gdku	0
 𤋯	gdku	0
 大水	gdkv	4490000
+𪥋	gdkv	0
+𪵪	gdkv	0
 大堂	gdkw	5960000
 遼	gdkw	2850000
 𡘨	gdkx	0
 𨝷	gdky	0
 奄	gdkz	4640000
 𡘤	gdkz	0
+𪥍	gdkz	0
 大幅	gdla	67100000
 夺目	gdla	5380000
 㚗	gdlc	3890
@@ -36100,6 +37449,7 @@ encoder:
 𤯗	gdmc	0
 𡗧	gdme	0
 𠬗	gdmh	0
+𪱤	gdmh	0
 大竹	gdmi	3130000
 𡗸	gdmi	0
 𧌝	gdmi	0
@@ -36150,6 +37500,7 @@ encoder:
 大街	gdob	55600000
 𡘫	gdob	0
 𪌴	gdob	0
+𪥓	gdob	0
 大全	gdoc	142000000
 大人	gdod	95800000
 𠦵	gdoe	0
@@ -36178,6 +37529,7 @@ encoder:
 鵊	gdor	32000
 鷞	gdor	39800
 㤲	gdow	8730
+𪥆	gdox	0
 郟	gdoy	385000
 𠷔	gdoz	0
 大丘	gdpd	174000
@@ -36188,6 +37540,7 @@ encoder:
 大兵	gdpo	4020000
 𡗷	gdps	0
 大凡	gdqd	1670000
+𫜲	gdqg	0
 大胆	gdqk	37500000
 䀁	gdql	9600
 𧠶	gdql	0
@@ -36244,11 +37597,13 @@ encoder:
 大意	gdsk	10100000
 𡘐	gdsk	0
 𡘒	gdsk	0
+𪟁	gdsk	0
 盇	gdsl	50900
 盋	gdsl	28500
 大话	gdsm	28900000
 大齐	gdsn	519000
 𨾩	gdsn	0
+𪥏	gdso	0
 𨫦	gdsp	0
 飆	gdsq	6300000
 䳊	gdsr	3540
@@ -36284,6 +37639,7 @@ encoder:
 㚔	gdub	4010
 大半	gdub	18500000
 𥘾	gdub	0
+𪱰	gdub	0
 羍	gduc	53500
 𩢙	gduc	0
 𢌾	gdue	0
@@ -36334,6 +37690,7 @@ encoder:
 大宁	gdwa	982000
 大宗	gdwb	10100000
 夺冠	gdwb	11600000
+𪧡	gdwd	0
 大寨	gdwe	1020000
 大赛	gdwe	139000000
 耐寒	gdwe	3880000
@@ -36352,6 +37709,7 @@ encoder:
 耐心	gdwz	35600000
 大尉	gdxb	1260000
 𡚛	gdxb	0
+𫆕	gdxb	0
 𨷎	gdxc	0
 大殿	gdxe	5440000
 大戏	gdxh	3530000
@@ -36369,6 +37727,7 @@ encoder:
 𡙕	gdyb	0
 𡙺	gdyb	0
 𡯁	gdyd	0
+𪥂	gdyd	0
 大巴	gdyi	5380000
 夿	gdyi	106000
 𡗵	gdyi	0
@@ -36377,15 +37736,18 @@ encoder:
 夯	gdym	5070000
 耐力	gdym	8670000
 𤙼	gdym	0
+𪥑	gdym	0
 㚕	gdyn	4060
 𩁭	gdyn	0
 大办	gdyo	602000
 大队	gdyo	15700000
 大阪	gdyp	130000000
+𪼵	gdyp	0
 鴺	gdyr	27300
 㼪	gdys	4390
 㼽	gdys	5120
 𤭨	gdys	0
+𫗌	gdyt	0
 大院	gdyw	8590000
 𡙈	gdyx	0
 翃	gdyy	124000
@@ -36409,6 +37771,7 @@ encoder:
 𠞒	gdzk	0
 𡙂	gdzk	0
 𡭡	gdzk	0
+𪟉	gdzk	0
 大姐	gdzl	11800000
 大纲	gdzl	13500000
 𢽱	gdzm	0
@@ -36420,6 +37783,7 @@ encoder:
 瓠	gdzp	1080000
 𤬄	gdzp	0
 䫺	gdzq	3600
+𪵈	gdzq	0
 㰭	gdzr	4480
 匏	gdzr	414000
 大约	gdzr	44100000
@@ -36429,6 +37793,7 @@ encoder:
 𠣻	gdzr	0
 𣣚	gdzr	0
 𩿅	gdzr	0
+𫛦	gdzr	0
 厷	gdzs	666000
 厺	gdzs	108000
 大娘	gdzs	1930000
@@ -36444,6 +37809,7 @@ encoder:
 𡗰	gdzz	0
 𡘘	gdzz	0
 𡘛	gdzz	0
+𪥕	gdzz	0
 礞	geag	118000
 𥔽	geaj	0
 奔赴	gebi	2920000
@@ -36489,6 +37855,7 @@ encoder:
 𥕪	geoy	0
 𥒴	geoz	0
 𥕶	gepd	0
+𪿾	gepk	0
 䃟	geqm	5490
 奔腾	gequ	12700000
 磺胺	geqw	952000
@@ -36534,6 +37901,7 @@ encoder:
 碴	gfka	2580000
 磹	gfke	1490000
 礌	gfki	433000
+𪿥	gfmo	0
 礭	gfni	33300
 䂾	gfoo	4820
 𥓜	gfoo	0
@@ -36567,6 +37935,7 @@ encoder:
 砺	ggay	1910000
 𠩳	ggay	0
 硕士	ggba	37100000
+𪠐	ggba	0
 厓	ggbb	343000
 𠪤	ggbb	0
 𠪆	ggbd	0
@@ -36574,6 +37943,7 @@ encoder:
 𠨭	ggbi	0
 𥑰	ggbi	0
 𥐘	ggbj	0
+𪠅	ggbj	0
 𧡋	ggbl	0
 𠨶	ggbo	0
 𠪑	ggbq	0
@@ -36586,16 +37956,20 @@ encoder:
 𠪩	ggbu	0
 𠪯	ggbu	0
 𠩍	ggbx	0
+𪠦	ggbx	0
 䣑	ggby	3510
 𠨼	ggby	0
 𨞋	ggby	0
 𨞬	ggby	0
+𫑮	ggby	0
 𠩂	ggbz	0
 𥑹	ggbz	0
 𠫑	ggcc	0
 厂长	ggch	5650000
+𪠍	ggch	0
 𠨵	ggci	0
 𠪚	ggcm	0
+𪠛	ggcm	0
 𠩻	ggcq	0
 㻹	ggcs	8760
 𠪏	ggcx	0
@@ -36607,12 +37981,14 @@ encoder:
 厝	ggek	3820000
 𠪄	ggek	0
 𥕉	ggek	0
+𪠋	ggel	0
 𠩷	ggeo	0
 𠪙	ggeo	0
 厮	ggep	4480000
 𠪜	ggep	0
 𠫌	ggeq	0
 𩿫	gger	0
+𪴪	gger	0
 厌世	ggev	525000
 磊落	ggev	738000
 厒	ggez	160000
@@ -36621,6 +37997,7 @@ encoder:
 㕊	ggfb	4290
 𠪖	ggfb	0
 𠩚	ggfd	0
+𪠑	ggfd	0
 𠩵	ggff	0
 𠪝	ggfg	0
 歴	ggfi	14700000
@@ -36634,6 +38011,7 @@ encoder:
 厯	ggfw	42000
 𢟍	ggfw	0
 𨟥	ggfy	0
+𪤬	gggb	0
 碝	gggd	59900
 𥗉	gggg	0
 𥗐	gggg	0
@@ -36685,6 +38063,7 @@ encoder:
 𠪶	ggju	0
 𠪔	ggjx	0
 𠩭	ggjy	0
+𪠈	ggjz	0
 厂里	ggkb	2350000
 厘	ggkb	40100000
 𠪵	ggkb	0
@@ -36695,6 +38074,8 @@ encoder:
 𠪧	ggkf	0
 願	ggkg	26300000
 𩖒	ggkg	0
+𪠊	ggkg	0
+𫖸	ggkg	0
 㕅	ggki	4630
 𠪿	ggki	0
 𧏐	ggki	0
@@ -36702,10 +38083,12 @@ encoder:
 𠪥	ggkk	0
 𥕴	ggkk	0
 𠫂	ggkl	0
+𪠓	ggko	0
 𠩼	ggkr	0
 𣢭	ggkr	0
 𣤔	ggkr	0
 𪄁	ggkr	0
+𪠖	ggku	0
 𣱷	ggkv	0
 愿	ggkw	193000000
 𠪰	ggkw	0
@@ -36715,6 +38098,8 @@ encoder:
 硽	ggkz	21600
 𠪎	ggkz	0
 𥕠	ggkz	0
+𪠄	ggkz	0
+𪿬	ggkz	0
 𥑢	ggli	0
 厕	gglk	7790000
 厠	gglk	485000
@@ -36748,6 +38133,7 @@ encoder:
 𪙪	ggmi	0
 曆	ggmk	50300000
 𠩯	ggmk	0
+𪠚	ggmk	0
 𧗖	ggml	0
 厤	ggmm	328000
 𩴣	ggmn	0
@@ -36774,6 +38160,7 @@ encoder:
 𠩡	ggnn	0
 𨿳	ggnn	0
 厂价	ggno	3580000
+𪠇	ggno	0
 𦢖	ggnq	0
 厦	ggnr	13500000
 鴈	ggnr	267000
@@ -36817,17 +38204,22 @@ encoder:
 𩔟	ggpg	0
 𠪢	ggpr	0
 𠨹	ggpx	0
+𪠙	ggqg	0
 𠪣	ggqm	0
 𠩇	ggqp	0
 𠪘	ggqq	0
+𫚯	ggqr	0
 𠪑	ggqs	0
 𠨻	ggqx	0
 橜	ggrf	26500
 𥕳	ggrg	0
+𪠌	ggrg	0
 𠨸	ggrh	0
 𠨿	ggrh	0
 𤑂	ggrh	0
 蟨	ggri	27800
+𪠉	ggri	0
+𪿸	ggri	0
 蹷	ggrj	28300
 𥔇	ggrj	0
 劂	ggrk	173000
@@ -36839,6 +38231,7 @@ encoder:
 𩀾	ggrn	0
 𨬐	ggrp	0
 𦠒	ggrq	0
+𪠔	ggrq	0
 䃎	ggrr	4730
 鷢	ggrr	25400
 𠨬	ggrr	0
@@ -36852,6 +38245,7 @@ encoder:
 𠡲	ggry	0
 𠢤	ggry	0
 𠢭	ggry	0
+𪿤	ggry	0
 鳫	ggrz	67800
 𡡕	ggrz	0
 壓	ggsb	26200000
@@ -36888,24 +38282,29 @@ encoder:
 懕	ggsw	93500
 㕂	ggsx	4550
 𥀬	ggsx	0
+𪠏	ggsx	0
 厂方	ggsy	1650000
 厌弃	ggsz	128000
 嬮	ggsz	984000
 㕏	ggte	4230
 𣂀	ggte	0
+𪯯	ggte	0
 𣃞	ggts	0
 𠩽	ggua	0
 㕓	ggub	3950
 𠪉	ggub	0
 㕑	ggud	6820
 厨	ggud	32000000
+𪠆	ggue	0
 𠩕	gguf	0
 厌烦	ggug	3870000
 㓹	gguk	4020
 𤉓	gguk	0
 𠫈	ggum	0
 𣯅	ggum	0
+𪠕	ggun	0
 𥔕	gguo	0
+𪿙	gguo	0
 𠩔	ggur	0
 𠩦	ggur	0
 𠪛	gguu	0
@@ -36913,6 +38312,7 @@ encoder:
 𠪊	ggux	0
 𠪼	ggux	0
 𠩋	gguz	0
+𪠒	gguz	0
 𠩓	ggvr	0
 𠩗	ggvr	0
 砳	ggvv	39600
@@ -36953,6 +38353,8 @@ encoder:
 𧠏	ggyl	0
 历	ggym	40400000
 厫	ggym	118000
+𪠘	ggym	0
+𫀳	ggym	0
 𪃱	ggyr	0
 㽁	ggys	4700
 𠨳	ggys	0
@@ -36987,6 +38389,7 @@ encoder:
 𠩐	ggzt	0
 𠪱	ggzt	0
 𨑄	ggzt	0
+𪠎	ggzw	0
 勵	ggzy	2310000
 𠨷	ggzy	0
 𥗠	ggzy	0
@@ -37019,6 +38422,7 @@ encoder:
 𥕇	ghjo	0
 𥗄	ghjr	0
 䃭	ghjw	4370
+𫑥	ghjy	0
 𥓫	ghkd	0
 𥔌	ghkz	0
 砸	ghli	64100000
@@ -37027,6 +38431,7 @@ encoder:
 𣭽	ghmh	0
 礛	ghml	151000
 敐	ghmo	486000
+𪿻	ghms	0
 砸毁	ghnb	271000
 砸伤	ghnm	668000
 碱化	ghnr	347000
@@ -37042,12 +38447,14 @@ encoder:
 碱性	ghum	4280000
 砸烂	ghuu	798000
 碱熔	ghuw	12400
+𪢏	ghvy	0
 𪓧	ghwx	0
 𢛚	ghwz	0
 䃘	ghxb	4540
 𥓼	ghxf	0
 礥	ghxl	27000
 砌	ghyd	16800000
+𪡪	ghyj	0
 砘	ghzi	158000
 𡝌	ghzm	0
 𣎴	giaa	0
@@ -37057,6 +38464,7 @@ encoder:
 不正	giai	21500000
 歪	giai	46700000
 不可	giaj	322000000
+𪜄	giaj	0
 不严	giak	2770000
 不再	gial	118000000
 𣬾	giam	0
@@ -37117,6 +38525,7 @@ encoder:
 不止	giii	26900000
 𥓢	giii	0
 𥖋	giii	0
+𪴻	giij	0
 不肯	giiq	23600000
 𦝽	giiq	0
 砧	gija	1520000
@@ -37136,6 +38545,7 @@ encoder:
 𤰺	giki	0
 不少	gikm	123000000
 𠀰	gikm	0
+𪴽	gikm	0
 不小	giko	20600000
 𥒼	giko	0
 不明	gikq	104000000
@@ -37158,6 +38568,7 @@ encoder:
 覔	gilr	26600
 不用	gilv	152000000
 存贮	gilw	1780000
+𪿹	gilz	0
 不等	gimb	21100000
 𤘮	gimb	0
 𤯚	gimc	0
@@ -37224,6 +38635,7 @@ encoder:
 不久	girs	106000000
 存包	giry	265000
 鴀	girz	50700
+𫛜	girz	0
 不计	gise	9200000
 存亡	gish	3820000
 不高	gisj	26300000
@@ -37239,6 +38651,7 @@ encoder:
 不问	gitj	8650000
 不准	gitn	25600000
 不应	gitv	17700000
+𪧽	giud	0
 不惜	giue	16900000
 不慎	giue	2510000
 不懂	giue	66400000
@@ -37264,6 +38677,7 @@ encoder:
 不清	givc	46100000
 不满	give	30100000
 不测	givl	3120000
+𪿛	givv	0
 不觉	givw	25100000
 不宁	giwa	1980000
 不定	giwd	58800000
@@ -37289,6 +38703,7 @@ encoder:
 不予	gixx	14100000
 不屈	gixz	5150000
 不加	giyj	13700000
+𪴻	giyj	0
 不力	giym	9040000
 不及	giym	20300000
 不改	giym	8720000
@@ -37308,9 +38723,11 @@ encoder:
 不好	gizy	117000000
 孬	gizy	1550000
 𩈅	gjae	0
+𫖀	gjaf	0
 右下	gjai	3860000
 𩈔	gjaj	0
 靧	gjal	31600
+𫖃	gjal	0
 𩈖	gjax	0
 𩈎	gjaz	0
 𩈮	gjbj	0
@@ -37361,6 +38778,7 @@ encoder:
 𩈊	gjkg	0
 𩔁	gjkg	0
 𩈤	gjkj	0
+𫏔	gjkj	0
 䩍	gjkk	3950
 䩄	gjkl	3890
 靦	gjkl	1060000
@@ -37442,6 +38860,7 @@ encoder:
 面料	gjut	16700000
 面洽	gjvo	238000
 右派	gjvp	2290000
+𫖁	gjvr	0
 否定	gjwd	50800000
 𩈬	gjwi	0
 𩈭	gjwl	0
@@ -37575,6 +38994,7 @@ encoder:
 𦓢	glgs	0
 碳	glgu	24600000
 𢡵	glgw	0
+𪭔	glhh	0
 布匹	glhr	1320000
 而成	glhv	33700000
 布点	glij	818000
@@ -37646,8 +39066,10 @@ encoder:
 𦓕	glzm	0
 𥗴	glzn	0
 𥗿	glzn	0
+𪿪	gmac	0
 䶮	gmag	31100
 	gmag	0
+𪿽	gmal	0
 𥗁	gmbm	0
 龙井	gmbn	2710000
 聋	gmce	7740000
@@ -37694,6 +39116,8 @@ encoder:
 𥗎	gmrk	0
 礸	gmrl	52900
 𪁪	gmrz	0
+𫛟	gmrz	0
+𪿺	gmse	0
 袭	gmsr	51300000
 龙头	gmtg	28400000
 龙门	gmtl	7720000
@@ -37736,11 +39160,13 @@ encoder:
 原图	gnjr	13900000
 原野	gnkb	4380000
 原由	gnki	1960000
+𪿧	gnko	0
 原是	gnkv	6890000
 𥗰	gnlg	0
 䃇	gnli	4600
 原则	gnlk	121000000
 原罪	gnlk	3280000
+𪿰	gnlo	0
 原籍	gnmc	1720000
 原告	gnmj	5840000
 原先	gnmr	18900000
@@ -37803,6 +39229,7 @@ encoder:
 𩖏	gogg	0
 页面	gogj	416000000
 𩔊	gogo	0
+𫖧	gojk	0
 䃸	goka	4980
 𥑒	goko	0
 𥖩	golk	0
@@ -37814,6 +39241,7 @@ encoder:
 𩒈	gook	0
 礆	gooo	93500
 䪾	goop	3290
+𫖬	goop	0
 𥓻	goor	0
 䂚	goos	4920
 䂦	gopd	5120
@@ -37843,6 +39271,7 @@ encoder:
 𩑍	gozz	0
 𥕬	gpai	0
 𥒖	gpaj	0
+𪿿	gpcm	0
 䂡	gpda	5240
 𥕬	gpei	0
 碷	gpel	23600
@@ -37853,6 +39282,7 @@ encoder:
 𥕫	gpil	0
 𥗦	gpkb	0
 磻	gpki	952000
+𪿱	gplk	0
 𥓕	gpmb	0
 𥕬	gpmi	0
 𥔿	gpnb	0
@@ -37935,10 +39365,12 @@ encoder:
 𧱾	gqgs	0
 燹	gqgu	138000
 𧱉	gqgu	0
+𫐾	gqgw	0
 𧱅	gqgy	0
 𧰯	gqgz	0
 豘	gqhz	23300
 𧲋	gqig	0
+𫖨	gqig	0
 蟸	gqii	29800
 𧲒	gqii	0
 𧲟	gqii	0
@@ -37991,14 +39423,17 @@ encoder:
 𧲐	gqok	0
 有余	gqom	8450000
 𧱼	gqoo	0
+𫎆	gqoo	0
 𧱕	gqoq	0
 𧱭	gqor	0
 砜	gqos	989000
 𧰻	gqow	0
 𧰾	gqow	0
 𧱢	gqow	0
+𫐴	gqow	0
 䝓	gqoz	4480
 有错	gqpe	5070000
+𫎈	gqpg	0
 有钱	gqph	34200000
 𧱻	gqpl	0
 有所	gqpv	1970000
@@ -38103,6 +39538,7 @@ encoder:
 㞆	graj	4050
 𡯽	graj	0
 尵	gral	150000
+𪨇	gral	0
 𥒛	graz	0
 𥐩	grbd	0
 𥖷	grbj	0
@@ -38130,6 +39566,7 @@ encoder:
 𡯰	grhe	0
 𢍽	grhs	0
 确切	grhy	12200000
+𪨈	grji	0
 𡰏	grjk	0
 𡰑	grjl	0
 𡰝	grjn	0
@@ -38154,6 +39591,7 @@ encoder:
 𡯪	grlc	0
 确	grld	56000000
 砾岩	grlg	161000
+𪾊	grlk	0
 确山	grll	340000
 𡰋	grln	0
 𡯞	grlo	0
@@ -38257,6 +39695,7 @@ encoder:
 磅礴	gsge	2290000
 太不	gsgi	9780000
 太厚	gsgk	1200000
+𪿴	gsgm	0
 太原	gsgn	33900000
 太太	gsgs	20800000
 飙车	gshe	1390000
@@ -38320,6 +39759,7 @@ encoder:
 硋	gszo	62300
 䃷	gszq	4310
 磙	gszr	202000
+𪿖	gszz	0
 𥑈	gtai	0
 𥖂	gtar	0
 矿工	gtbi	4960000
@@ -38331,6 +39771,7 @@ encoder:
 矿藏	gteh	993000
 𥕒	gtek	0
 𥔷	gtel	0
+𪿳	gtff	0
 礳	gtfg	29200
 䃺	gtfk	5010
 𥗂	gtfm	0
@@ -38468,6 +39909,7 @@ encoder:
 磲	gvxf	321000
 在即	gvxy	10100000
 在线	gvzh	1100000000
+𪿡	gwae	0
 𥕯	gwan	0
 𥕈	gwar	0
 硿	gwbi	102000
@@ -38477,9 +39919,12 @@ encoder:
 磍	gwcj	25100
 牵挂	gwdb	16200000
 牵扯	gwdi	3740000
+𪿲	gwez	0
 碗柜	gwfh	343000
 䃛	gwfk	4420
 碗碟	gwge	714000
+𪿭	gwgq	0
+𪿯	gwgq	0
 䃐	gwgs	5140
 𥓎	gwgs	0
 硡	gwgz	39400
@@ -38497,6 +39942,7 @@ encoder:
 牵制	gwml	5310000
 磓	gwmy	34800
 確	gwni	7520000
+𪿮	gwoj	0
 𥔉	gwox	0
 𥓸	gwpd	0
 𥐱	gwqd	0
@@ -38507,6 +39953,7 @@ encoder:
 砣	gwrr	1800000
 𥖽	gwru	0
 碗	gwry	74200000
+𪿜	gwry	0
 牵头	gwtg	5650000
 礈	gwug	317000
 𥖾	gwul	0
@@ -38515,6 +39962,7 @@ encoder:
 牵涉	gwvi	6180000
 牵连	gwwh	3400000
 𥖶	gwxl	0
+𪿷	gwxl	0
 砨	gwyd	27200
 牵引	gwyi	6840000
 𥔱	gwyy	0
@@ -38536,6 +39984,7 @@ encoder:
 破损	gxdj	4440000
 𥖖	gxdy	0
 碾	gxeh	5230000
+𪿩	gxej	0
 𥔤	gxeo	0
 破获	gxeq	3700000
 破落	gxev	667000
@@ -38572,9 +40021,11 @@ encoder:
 䃤	gxnd	4760
 码位	gxns	78000
 友人	gxod	47300000
+𪿫	gxoo	0
 友邻	gxow	1130000
 友爱	gxpw	7000000
 破解	gxrl	101000000
+𪿗	gxrr	0
 䂘	gxsa	4940
 𥗲	gxsg	0
 破产	gxsm	11500000
@@ -38594,12 +40045,14 @@ encoder:
 𠬷	gxxs	0
 𥑊	gxxs	0
 碬	gxxx	31000
+𪜘	gxyd	0
 破费	gxyn	644000
 破除	gxyo	3320000
 𥗮	gxzr	0
 破绽	gxzw	4000000
 友好	gxzy	34400000
 历来	gybk	7140000
+𪿣	gyby	0
 乭	gyda	60700
 𥔊	gyhb	0
 䂥	gyhd	5220
@@ -38740,11 +40193,13 @@ encoder:
 转增	hbbu	2270000
 转动	hbbz	10400000
 臻	hbcm	7930000
+𫇑	hbcm	0
 贰拾	hbdo	257000
 转折	hbdp	5590000
 转播	hbdp	5860000
 转换	hbdr	116000000
 𦥃	hbeo	0
+𫇎	hbfj	0
 转机	hbfq	4410000
 式样	hbfu	3630000
 转存	hbgi	993000
@@ -38796,6 +40251,7 @@ encoder:
 转会	hbob	4020000
 转入	hbod	9100000
 𠤱	hbod	0
+𫇏	hboo	0
 至今	hbos	65700000
 转盘	hbpl	2650000
 转船	hbpq	56200
@@ -38822,6 +40278,7 @@ encoder:
 转运	hbwb	2390000
 转速	hbwf	7020000
 转达	hbwg	1740000
+𫇐	hbxa	0
 转录	hbxk	2440000
 𦥌	hbxk	0
 𦤽	hbxr	0
@@ -38834,11 +40291,13 @@ encoder:
 转给	hbzo	1980000
 转发	hbzv	26000000
 转嫁	hbzw	2270000
+𪥎	hcgd	0
 𩒑	hcgo	0
 賾	hclo	90200
 赜	hclo	345000
 𦣱	hclo	0
 𢼳	hcmo	0
+𪯵	hcsy	0
 匡	hcvv	6460000
 劻	hcym	83700
 七百	hdan	4010000
@@ -38888,6 +40347,7 @@ encoder:
 顿	hdzg	80500000
 屯	hdzi	30300000
 旾	hdzk	28200
+𪞿	hdzk	0
 𡵭	hdzl	0
 巰	hdzn	30200
 㼊	hdzp	4730
@@ -38902,12 +40362,16 @@ encoder:
 𨐆	heae	0
 辏	heag	229000
 轲	heaj	1030000
+𫐎	heaj	0
 戒严	heak	803000
 车工	hebi	1290000
+𫏕	hebj	0
+𫐏	hebj	0
 车夫	hebo	1610000
 车长	hech	980000
 辖	hecj	8560000
 𨐉	hecx	0
+𫐕	hecx	0
 戒毒	hecz	2730000
 辄	hecz	1530000
 戒指	hedr	18800000
@@ -38923,7 +40387,9 @@ encoder:
 匿	hegj	5940000
 𨐇	hegm	0
 轿	hegn	9510000
+𫐄	hegr	0
 轭	hegy	538000
+𫐆	hegy	0
 车臣	heha	1370000
 车辆	heha	103000000
 轼	hehb	3420000
@@ -38938,36 +40404,49 @@ encoder:
 𧏾	heji	0
 辌	hejk	30900
 辐	hejk	1580000
+𫎡	hejl	0
 轵	hejo	368000
 𠥟	hejp	0
 辕	hejr	12300000
 慝	hejw	216000
+𫐘	hejw	0
 𡠷	hejz	0
 𨐈	hekg	0
 轴	heki	24000000
+𫐙	hekk	0
 辒	hekl	47000
+𫐗	heku	0
 辋	held	244000
+𫐅	hell	0
 𦣶	helo	0
+𫐇	helo	0
 𨐊	helw	0
 车手	hemd	4540000
+𫐓	hemf	0
 车程	hemj	6540000
 轶	hemo	7210000
 轷	hemu	51400
 䢀	hemy	5430
 车身	henc	9610000
+𫐍	henc	0
 匶	henn	42100
 车牌	henn	6470000
 𠥬	henn	0
+𫐐	henr	0
 车位	hens	4150000
 辁	heoc	57500
 较	heoo	241000000
 辆	heoo	57700000
 轸	heop	406000
+𫐖	heop	0
 轮	heor	98800000
+𫐉	heow	0
 堑	hepb	1510000
 斩	hepd	18700000
 椠	hepf	106000
+𫏐	hepj	0
 暂	hepk	298000000
+𪮃	hepm	0
 车铃	hepo	174000
 錾	hepp	408000
 辀	hepy	42100
@@ -38983,6 +40462,7 @@ encoder:
 辚	herm	212000
 软	hero	97500000
 辊	herr	3780000
+𫐒	hers	0
 车站	hesi	16400000
 车市	hesl	14500000
 䢂	hesu	4190
@@ -38994,16 +40474,19 @@ encoder:
 车资	hetr	201000
 辘	hetx	285000
 车灯	heua	2300000
+𫐌	heue	0
 戒烟	heuj	4700000
 车前	heuq	3380000
 车流	hevs	1740000
 车速	hewf	4330000
 车祸	hewj	12200000
 𠥖	hewl	0
+𫐑	hewy	0
 戒心	hewz	2800000
 车马	hexa	2050000
 轻	hexb	170000000
 车展	hexe	11400000
+𫐈	hexs	0
 轰	hexx	17700000
 辍	hexx	1200000
 车子	heya	23400000
@@ -39013,6 +40496,7 @@ encoder:
 车队	heyo	9510000
 轫	heys	146000
 辎	hezk	121000
+𫐔	hezl	0
 转	hezs	985000000
 辅路	hfjr	369000
 辅助	hfly	42000000
@@ -39033,6 +40517,8 @@ encoder:
 匦	hhqy	578000
 𦣦	hhvv	0
 𦣩	hhvv	0
+𫇆	hhvv	0
+𪟭	hhxi	0
 𠤲	hhzi	0
 𤘌	hiaj	0
 𠃢	hian	0
@@ -39075,6 +40561,7 @@ encoder:
 雅	hini	142000000
 𠥬	hinn	0
 𠥞	hioc	0
+𪺨	hioe	0
 𣻊	hiok	0
 𣀗	hioo	0
 䭆	hiox	3800
@@ -39096,6 +40583,7 @@ encoder:
 𢗬	hiwz	0
 𢛶	hiwz	0
 𡏃	hixb	0
+𪺧	hixg	0
 𤘎	hixi	0
 牙刷	hixl	4310000
 㸧	hixo	7010
@@ -39133,7 +40621,9 @@ encoder:
 歐	hjjr	34800000
 鷗	hjjr	1740000
 𠥹	hjjr	0
+𪠯	hjjx	0
 𠢔	hjjy	0
+𫑧	hjjy	0
 匰	hjke	114000
 或是	hjkv	74700000
 𠿦	hjmb	0
@@ -39207,6 +40697,7 @@ encoder:
 东部	hksj	17100000
 东郊	hkso	1700000
 东方	hksy	126000000
+𪯭	hkte	0
 东北	hktr	74400000
 到底	hktr	154000000
 东兰	hkub	377000
@@ -39293,13 +40784,16 @@ encoder:
 威	hmaz	114000000
 医士	hmba	207000
 𨢒	hmbf	0
+𫀄	hmbk	0
 𢎐	hmbl	0
 𥊇	hmbl	0
 𧵸	hmbl	0
 𢦶	hmbo	0
+𪱞	hmbq	0
 𣤮	hmbr	0
 黳	hmbu	32100
 𡦋	hmby	0
+𪭏	hmbz	0
 𢧔	hmco	0
 轶事	hmdj	5280000
 医护	hmdw	8810000
@@ -39327,8 +40821,10 @@ encoder:
 盞	hmhl	3080000
 𧶤	hmhl	0
 戔	hmhm	533000
+𫇇	hmhm	0
 𣂧	hmhp	0
 𢧓	hmhy	0
+𫑠	hmhy	0
 𡒥	hmia	0
 𢨜	hmii	0
 𧕹	hmii	0
@@ -39371,6 +40867,7 @@ encoder:
 划	hmkd	178000000
 刬	hmkd	76300
 顣	hmkg	530000
+𫖹	hmkg	0
 𢦦	hmki	0
 𤰭	hmki	0
 𧐶	hmki	0
@@ -39396,8 +40893,10 @@ encoder:
 𤀩	hmlk	0
 𥁘	hmlk	0
 𥁫	hmlk	0
+𪭌	hmlk	0
 覽	hmll	42300000
 𥃆	hmll	0
+𪭑	hmll	0
 㲯	hmlm	3970
 擥	hmlm	59700
 𣱄	hmlm	0
@@ -39408,13 +40907,16 @@ encoder:
 譼	hmls	9710
 𥽏	hmlu	0
 𨞐	hmly	0
+𪧂	hmly	0
 医生	hmmc	59800000
 𢦩	hmme	0
+𪭎	hmmk	0
 𥃉	hmml	0
 𢦕	hmmq	0
 致辞	hmms	11500000
 㥻	hmmw	3720
 致使	hmna	18500000
+𪭎	hmne	0
 𨾓	hmni	0
 𢧩	hmnj	0
 致命	hmoa	23300000
@@ -39428,6 +40930,7 @@ encoder:
 𢦲	hmpd	0
 𣫫	hmpp	0
 𢦞	hmpv	0
+𪭐	hmpy	0
 㙠	hmqb	4730
 瑿	hmqc	39900
 𩥯	hmqc	0
@@ -39500,7 +41003,9 @@ encoder:
 𠤷	hmyi	0
 𢦽	hmyj	0
 盛	hmyl	90500000
+𪨯	hmyl	0
 致力	hmym	33400000
+𪭊	hmym	0
 𪁋	hmyr	0
 㼩	hmys	4380
 㽉	hmys	4060
@@ -39524,6 +41029,7 @@ encoder:
 𣤭	hmzr	0
 𩿰	hmzr	0
 𨜠	hmzy	0
+𫑛	hmzy	0
 𢦙	hmzz	0
 𢦻	hmzz	0
 𠥉	hned	0
@@ -39535,6 +41041,7 @@ encoder:
 𠥥	hnni	0
 㔱	hnod	10600
 𠥑	hnrf	0
+𪟰	hnrj	0
 雅座	hnto	714000
 𦣳	hnuo	0
 雅兴	hnva	877000
@@ -39556,6 +41063,7 @@ encoder:
 区码	hogx	722000
 轮辐	hoha	127000
 轮式	hohb	1230000
+𫇉	hohi	0
 轮轴	hohk	428000
 𧇬	hoih	0
 区别	hojy	55500000
@@ -39609,6 +41117,7 @@ encoder:
 轮子	hoya	2500000
 𦣡	hoyd	0
 欧阳	hoyk	10400000
+𪟮	hoyo	0
 瓯	hoys	5380000
 𠤰	hozs	0
 欧姆	hozz	3030000
@@ -39630,9 +41139,11 @@ encoder:
 斩首	hpun	1670000
 暂定	hpwd	2510000
 𠥃	hpyl	0
+𪦑	hpzm	0
 暂缓	hpzp	2670000
 䝂	hqju	4610
 𧷙	hqlo	0
+𪟬	hqvv	0
 轨迹	hqws	21700000
 轨道	hqwu	30700000
 𣄰	hraj	0
@@ -39654,6 +41165,7 @@ encoder:
 䫬	hrkg	3420
 㔆	hrkk	5090
 𣄷	hrkk	0
+𪯘	hrkm	0
 𩀿	hrkn	0
 𪅽	hrkr	0
 䣟	hrky	3270
@@ -39668,6 +41180,7 @@ encoder:
 鸦片	hrnx	3020000
 匢	hrod	63000
 𣄭	hrod	0
+𫇅	hrod	0
 匫	hrok	29100
 软盘	hrpl	10900000
 软肋	hrqy	2410000
@@ -39698,6 +41211,7 @@ encoder:
 貳	hsbl	2860000
 贰	hsbl	3950000
 𥁦	hsbl	0
+𪟲	hsbl	0
 𪀦	hsbr	0
 𪉅	hsbr	0
 𠤶	hsbz	0
@@ -39721,6 +41235,7 @@ encoder:
 隿	hsni	24000
 𨾍	hsni	0
 较低	hsnr	20500000
+𫇈	hsoe	0
 𢎂	hsoo	0
 𢎏	hsoo	0
 䬥	hsox	4210
@@ -39756,6 +41271,7 @@ encoder:
 𧏆	htei	0
 𦨃	huac	0
 𠥙	hufd	0
+𪟱	hufj	0
 𢽇	hugm	0
 𠥛	huho	0
 𧡼	hulr	0
@@ -39839,6 +41355,7 @@ encoder:
 𢀭	hxeq	0
 轻薄	hxev	7250000
 轻飘	hxfb	751000
+𪩦	hxff	0
 轻松	hxfo	141000000
 巨大	hxgd	98700000
 辗转	hxhb	6130000
@@ -39876,18 +41393,22 @@ encoder:
 轻信	hxns	5210000
 轻佻	hxnv	1450000
 巨人	hxod	19500000
+𪩩	hxog	0
 䵖	hxok	4200
 轻微	hxol	11700000
 𦜜	hxoo	0
+𪩪	hxor	0
 𩜬	hxox	0
 轻钢	hxpl	828000
 轻铁	hxpm	69300
 轰然	hxrg	3240000
+𪩤	hxrk	0
 𢀲	hxrl	0
 𢀱	hxrm	0
 𩿝	hxrz	0
 轻言	hxsa	1910000
 㻨	hxsc	4580
+𪩥	hxsj	0
 竪	hxsu	495000
 轻率	hxsv	1520000
 巨变	hxsx	5160000
@@ -39999,6 +41520,7 @@ encoder:
 𧌀	iagj	0
 𩙤	iagq	0
 𩺁	iagr	0
+𪜈	iahd	0
 卡车	iahe	7060000
 𢅓	iahl	0
 𥋚	iahl	0
@@ -40029,9 +41551,11 @@ encoder:
 𠟗	iajk	0
 螎	iajl	22000
 𧁌	iajo	0
+𫊳	iajo	0
 𧄼	iaju	0
 𨞯	iajy	0
 凸显	iakk	6900000
+𫋖	iakk	0
 𧋑	iako	0
 𣤬	iakr	0
 𧏲	iaku	0
@@ -40105,6 +41629,7 @@ encoder:
 𣤾	iaxr	0
 𪇡	iaxr	0
 卡尺	iaxs	431000
+𫋂	iaxz	0
 凸	iaya	27000000
 虫子	iaya	10600000
 𥌱	iayh	0
@@ -40124,16 +41649,20 @@ encoder:
 𧊌	ibaz	0
 蟯	ibbg	412000
 𧑱	ibbj	0
+𫋦	ibcx	0
+𫊵	ibds	0
 𡐪	ibeb	0
 𧓜	ibgf	0
 㒫	ibgr	4310
 𧑰	ibhl	0
 𧑅	ibhz	0
 虹口	ibja	7170000
+𫋤	ibjd	0
 𧒗	ibjj	0
 虹吸	ibjy	514000
 𧉿	ibko	0
 𧔖	ibll	0
+𫋐	iblo	0
 𥎨	ibma	0
 𧐻	ibni	0
 𧋒	ibno	0
@@ -40147,12 +41676,14 @@ encoder:
 螧	ibrk	21900
 蛯	ibrr	180000
 𪅵	ibrr	0
+𫋚	ibud	0
 蟢	ibuj	30600
 𧌥	ibuk	0
 蛱	ibuo	266000
 蟛	ibup	209000
 蟽	ibuw	28700
 蛙泳	ibvs	519000
+𫊥	ibvv	0
 𧋺	ibwz	0
 𧑕	ibwz	0
 𧋋	ibxj	0
@@ -40176,7 +41707,9 @@ encoder:
 𧐐	iclo	0
 螓	icmf	922000
 𧐍	icnb	0
+𫋑	icoc	0
 𧑜	icrr	0
+𫋑	icuc	0
 蚟	icvv	52300
 𩰋	icvv	0
 𧒓	icwm	0
@@ -40205,6 +41738,7 @@ encoder:
 忐	idaw	4520000
 𢤰	idaw	0
 𠧕	idax	0
+𪥤	idaz	0
 𧎋	idbd	0
 𢧍	idbh	0
 𢧡	idbh	0
@@ -40222,6 +41756,7 @@ encoder:
 𪉼	idcx	0
 𪉴	idef	0
 㦸	ideh	4580
+𪟿	idei	0
 𣧮	idej	0
 𨿧	iden	0
 𢒛	idep	0
@@ -40230,6 +41765,7 @@ encoder:
 鵫	ider	43000
 𪊊	ider	0
 𫜷	ider	0
+𫛱	ider	0
 逴	idew	37900
 𢛂	idew	0
 𢻃	idex	0
@@ -40308,6 +41844,7 @@ encoder:
 𧮸	idjx	0
 𠛤	idjy	0
 𨟩	idjy	0
+𪟂	idjy	0
 乩	idjz	887000
 䪥	idka	3810
 韰	idka	53000
@@ -40323,6 +41860,7 @@ encoder:
 𪉨	idkk	0
 𢂦	idkl	0
 𧠪	idkl	0
+𫜊	idkl	0
 𢒦	idkp	0
 𢒭	idkp	0
 䴛	idkq	3710
@@ -40334,6 +41872,7 @@ encoder:
 𣩻	idkr	0
 𪀖	idkr	0
 𪊉	idkr	0
+𫛧	idkr	0
 𢙤	idkw	0
 𢤕	idkw	0
 叔	idkx	16900000
@@ -40347,6 +41886,7 @@ encoder:
 𣦵	idld	0
 𥹟	idld	0
 𠨇	idlf	0
+𫖣	idlg	0
 卨	idlj	61700
 盀	idlk	34900
 𠛯	idlk	0
@@ -40385,10 +41925,12 @@ encoder:
 𥐂	idlz	0
 𥜽	idlz	0
 𥜾	idlz	0
+𫜉	idlz	0
 𦕢	idmb	0
 𠦲	idme	0
 𣗴	idmf	0
 𣧕	idmg	0
+𫊴	idmh	0
 𥌟	idml	0
 𪊀	idml	0
 𪊇	idml	0
@@ -40398,6 +41940,7 @@ encoder:
 𧌕	idmy	0
 𠚝	idmz	0
 𪉥	idmz	0
+𫁅	idmz	0
 𠧇	idne	0
 𨾇	idni	0
 𡌓	idob	0
@@ -40440,6 +41983,7 @@ encoder:
 𠧹	idot	0
 𥻆	idou	0
 𥾄	idou	0
+𫜇	idou	0
 鹷	idow	31100
 𠧟	idoz	0
 𠧤	idoz	0
@@ -40509,6 +42053,7 @@ encoder:
 𥹄	idwp	0
 肻	idwq	32100
 𪉛	idwq	0
+𫆶	idwq	0
 壑	idxb	2830000
 壡	idxb	25200
 𡋹	idxb	0
@@ -40517,6 +42062,7 @@ encoder:
 𡓝	idxb	0
 𦘖	idxb	0
 𧷎	idxb	0
+𪠀	idxb	0
 𤫀	idxc	0
 𦖥	idxc	0
 梷	idxf	20700
@@ -40537,6 +42083,7 @@ encoder:
 𥉆	idxl	0
 𥌄	idxl	0
 𧷧	idxl	0
+𪾏	idxl	0
 卢	idxm	32200000
 餐	idxo	84500000
 𩜨	idxo	0
@@ -40583,16 +42130,19 @@ encoder:
 𪉷	idzi	0
 𧡹	idzl	0
 𪉾	idzm	0
+𪟷	idzm	0
 鼑	idzn	38800
 𣣸	idzr	0
 𠨀	idzz	0
 𧋪	iead	0
 蠓	ieag	253000
 𧋞	ieag	0
+𫋓	ieaj	0
 𧔠	ieaz	0
 𧓥	iebz	0
 𧑑	iecb	0
 𧎣	iece	0
+𫋛	iecq	0
 𧑍	ieeb	0
 蠎	ieee	150000
 蟦	ieel	31700
@@ -40702,6 +42252,7 @@ encoder:
 蟟	igkk	27500
 𧌄	igkz	0
 𧉩	igli	0
+𫋋	iglk	0
 蠣	iglz	263000
 𧔝	igmi	0
 螈	ignk	319000
@@ -40752,6 +42303,7 @@ encoder:
 𧇊	ihbz	0
 𧇏	ihbz	0
 𧈃	ihbz	0
+𫊠	ihci	0
 𧷤	ihcl	0
 𧇶	ihco	0
 𩤌	ihcu	0
@@ -40875,6 +42427,7 @@ encoder:
 㔧	ihly	4600
 䣜	ihly	3560
 𧆮	ihlz	0
+𫊟	ihmb	0
 𧆠	ihmd	0
 𧇮	ihmj	0
 𧓦	ihml	0
@@ -40891,6 +42444,7 @@ encoder:
 𢨘	ihnh	0
 雐	ihni	17600
 𧆽	ihnk	0
+𫊡	ihnl	0
 𧇚	ihnn	0
 𧈄	ihnr	0
 𪇦	ihnr	0
@@ -40945,6 +42499,7 @@ encoder:
 齾	ihsi	26500
 𪚊	ihsi	0
 㓺	ihsk	4180
+𫊢	ihsn	0
 虔	ihso	1940000
 𧇻	ihso	0
 𧇠	ihsq	0
@@ -40974,10 +42529,13 @@ encoder:
 䖛	ihwz	3450
 虑	ihwz	9960000
 𧆹	ihwz	0
+𫊞	ihxb	0
 𧆿	ihxl	0
+𫋟	ihxl	0
 𧇹	ihxm	0
 𧆛	ihxs	0
 𧆰	ihya	0
+𫊧	ihyd	0
 𢧝	ihyh	0
 虏	ihym	3810000
 甗	ihys	66300
@@ -41018,6 +42576,7 @@ encoder:
 歭	iibd	78900
 𣦙	iibi	0
 𥘣	iibk	0
+𪴶	iibk	0
 𧢏	iibl	0
 𣦈	iibm	0
 𣥞	iibn	0
@@ -41042,6 +42601,8 @@ encoder:
 㱗	iigs	4060
 𧖃	iigs	0
 𧭹	iigs	0
+𫍐	iigs	0
+𪴼	iihh	0
 歫	iihx	24900
 𣥌	iiia	0
 蝆	iiib	23100
@@ -41098,6 +42659,7 @@ encoder:
 𦡖	iikq	0
 𣤠	iikr	0
 𣦇	iikr	0
+𫛄	iikr	0
 𤉭	iiku	0
 𤎵	iiku	0
 𧓻	iikw	0
@@ -41193,6 +42755,7 @@ encoder:
 𣥅	iirr	0
 𣥻	iirr	0
 𪉈	iirr	0
+𫚖	iirr	0
 㱑	iirs	4200
 訾	iirs	802000
 𤇬	iiru	0
@@ -41214,13 +42777,16 @@ encoder:
 𢧼	iiwb	0
 𣦅	iiwb	0
 㱕	iiwl	3590
+𪴸	iiwm	0
 𡎙	iixb	0
 𣦠	iixb	0
 𣥣	iixi	0
 𪘚	iixj	0
 𣥸	iixl	0
 𧓩	iixl	0
+𪴷	iixl	0
 𤚜	iixm	0
+𫊮	iixm	0
 𣥦	iixo	0
 𣦲	iixs	0
 𣦳	iixs	0
@@ -41328,6 +42894,7 @@ encoder:
 点子	ijya	9630000
 点阵	ijyh	1720000
 𧋾	ijyi	0
+𫊽	ijyk	0
 𧊅	ijym	0
 战绩	ijzc	7150000
 占线	ijzh	853000
@@ -41352,6 +42919,7 @@ encoder:
 虚夸	ikgb	164000
 桌面	ikgj	63900000
 卓有	ikgq	380000
+𫊶	ikgr	0
 旧历	ikgy	403000
 旧式	ikhb	1690000
 旧车	ikhe	2790000
@@ -41367,6 +42935,7 @@ encoder:
 蟷	ikjk	145000
 𧑊	ikjk	0
 蟐	ikjl	31600
+𫋠	ikju	0
 𧕫	ikkb	0
 蛐	ikkd	270000
 𧓅	ikkg	0
@@ -41393,6 +42962,7 @@ encoder:
 频段	iknc	3990000
 𣇑	iknc	0
 步伐	iknh	27900000
+𫋗	ikni	0
 虚像	iknr	756000
 虚伪	iknu	8990000
 虚假	iknx	26800000
@@ -41459,6 +43029,7 @@ encoder:
 贞操	ildj	2440000
 𧌎	ileo	0
 贞节	iley	715000
+𫊬	ilgd	0
 𧔇	ilgg	0
 𧍒	ilgl	0
 𧏱	ilgl	0
@@ -41486,6 +43057,7 @@ encoder:
 蜆	ilra	1240000
 𧏢	ilrc	0
 蠋	ilri	115000
+𫋩	ilru	0
 𧑵	ilrz	0
 䘃	ilub	4940
 𧊁	ilvv	0
@@ -41498,6 +43070,7 @@ encoder:
 𧌯	imeb	0
 蟱	imeu	22100
 𧊦	imez	0
+𫊸	imgn	0
 虴	imhd	124000
 蛾	imhm	9020000
 䘊	imhs	4230
@@ -41528,6 +43101,7 @@ encoder:
 𧐹	imrr	0
 𣱱	imtd	0
 蝌	imte	238000
+𫊯	imua	0
 𧎐	imuo	0
 𧒸	imuw	0
 𧎯	imxg	0
@@ -41550,6 +43124,7 @@ encoder:
 𧐃	ingd	0
 螑	ings	20100
 蟘	inhl	24600
+𫋌	inhl	0
 蚮	inhs	27900
 蝗虫	inia	1090000
 𧓈	iniy	0
@@ -41590,6 +43165,7 @@ encoder:
 𪘁	ioaj	0
 𪘇	ioaj	0
 蜦	ioal	35100
+𫜥	ioaq	0
 𪗹	iobb	0
 𪘬	iobb	0
 𪗺	iobd	0
@@ -41597,7 +43173,9 @@ encoder:
 𪗾	iobj	0
 𪗞	iobn	0
 齶	iobz	59600
+𫊹	iobz	0
 𪙏	iocj	0
+𫜯	iocj	0
 䶦	iocl	4100
 䶫	iocm	3660
 齱	iocx	32400
@@ -41608,12 +43186,15 @@ encoder:
 𪗕	ioed	0
 𪙕	ioeh	0
 齰	ioek	37700
+𫜬	ioek	0
 𪙳	ioel	0
 䶪	ioen	3980
 𪘾	ioen	0
 齛	ioez	54600
 𪘠	iofa	0
 齽	iofb	29200
+𫜦	iofb	0
+𫜫	iofb	0
 𧒆	iofd	0
 𪙍	iofd	0
 𪚂	iofd	0
@@ -41685,6 +43266,7 @@ encoder:
 𪘹	iokr	0
 𪙰	iokr	0
 𪙅	iokx	0
+𫜧	iola	0
 齟	iolc	183000
 龃	iolc	460000
 𪘍	iold	0
@@ -41716,6 +43298,7 @@ encoder:
 𪘾	iomn	0
 𪗫	iomo	0
 齴	iomp	30700
+𫜮	iomp	0
 齕	iomy	48500
 龁	iomy	63100
 𪗟	iomy	0
@@ -41739,6 +43322,7 @@ encoder:
 䶨	iooo	4260
 齩	iooo	23300
 𪘨	iooo	0
+𫜪	iooo	0
 䗄	ioop	3400
 𪙆	iooq	0
 蝬	ioor	600000
@@ -41820,13 +43404,18 @@ encoder:
 齦	ioxo	110000
 龈	ioxo	1290000
 齭	ioxp	27200
+𫜭	ioxp	0
 𪙩	ioxq	0
 蚡	ioyd	108000
 䶔	ioyi	3730
 䶕	ioyi	3750
+𫜨	ioyi	0
 齠	ioyj	67000
 龆	ioyj	231000
+𫋞	ioyo	0
 螉	ioyy	26400
+𫋞	ioyy	0
+𫊿	ioze	0
 齝	iozj	35900
 齥	iozm	25100
 𪗯	iozr	0
@@ -41849,12 +43438,14 @@ encoder:
 蚯蚓	ipiy	3770000
 𧕥	ipkg	0
 蟠	ipki	3510000
+𫋜	ipld	0
 𧐎	iplr	0
 𧕉	ipoj	0
 𧓳	ippl	0
 𧓙	ipqf	0
 𧏘	ipqx	0
 䖰	iprh	3680
+𫋆	ipvv	0
 𧓁	ipwr	0
 𧌅	ipwx	0
 蟋	ipwz	445000
@@ -41895,6 +43486,7 @@ encoder:
 雌雄	irgz	2210000
 餐车	irhe	399000
 此致	irhm	1530000
+𫊰	irid	0
 餐桌	irik	10900000
 𧓾	irix	0
 蟓	irjg	114000
@@ -41962,6 +43554,7 @@ encoder:
 蚁王	isca	77100
 𧏃	iscg	0
 蠰	iser	39000
+𫋨	isfl	0
 𧌬	isjk	0
 𧎸	isjl	0
 𧐛	isjr	0
@@ -42013,6 +43606,7 @@ encoder:
 𧕳	isyu	0
 蚊媒	isze	20600
 蟀	isze	1480000
+𫋔	isze	0
 𧏷	iszk	0
 𧊷	iszm	0
 𧌃	iszm	0
@@ -42029,6 +43623,7 @@ encoder:
 𧓼	iteu	0
 䗫	itff	3550
 𧍈	itij	0
+𫋧	itko	0
 螏	itma	22200
 𧕄	itnw	0
 𧒐	itob	0
@@ -42063,6 +43658,7 @@ encoder:
 𧑹	iukk	0
 䗒	iuku	3390
 蟻	iumh	4780000
+𫋎	iunl	0
 蜕化	iunr	403000
 螠	iuol	34600
 𧓲	iuox	0
@@ -42076,6 +43672,7 @@ encoder:
 䗊	iuuo	3530
 𧕊	iuux	0
 蠑	iuwf	145000
+𫋥	iuwq	0
 𧓌	iuwu	0
 蟧	iuwy	28900
 𧏮	iuwz	0
@@ -42191,6 +43788,7 @@ encoder:
 𧎊	iwfk	0
 𧐖	iwfk	0
 𧏿	iwgq	0
+𫋕	iwgq	0
 蜧	iwgs	20300
 𧎛	iwgs	0
 螲	iwhb	27700
@@ -42221,15 +43819,18 @@ encoder:
 𧏴	iwnx	0
 𧔚	iwny	0
 𧑚	iwot	0
+𫋅	iwpd	0
 𧏖	iwpo	0
 䗦	iwrc	3650
 𧉡	iwrd	0
+𫋍	iwrj	0
 蛇	iwrr	39500000
 𧊼	iwrt	0
 𧓺	iwru	0
 蜿	iwry	5230000
 𧒫	iwsl	0
 螟	iwso	1730000
+𫋈	iwsy	0
 𧒠	iwul	0
 𧒴	iwun	0
 䗏	iwux	3090
@@ -42238,6 +43839,7 @@ encoder:
 𧐺	iwxl	0
 𧓍	iwxl	0
 螁	iwxo	43100
+𫋢	iwxu	0
 𧉵	iwyd	0
 𧎥	iwyy	0
 𧍜	ixag	0
@@ -42245,6 +43847,7 @@ encoder:
 𧐇	ixbd	0
 𠁲	ixbn	0
 𧖆	ixbu	0
+𫊻	ixds	0
 䖡	ixed	3670
 蜛	ixej	27400
 𧕗	ixfl	0
@@ -42287,6 +43890,7 @@ encoder:
 𧎇	ixsi	0
 颅部	ixsj	22600
 𧋅	ixst	0
+𫋢	ixuw	0
 𧔛	ixuy	0
 卢湾	ixvs	4260000
 蚂	ixvv	3110000
@@ -42320,6 +43924,7 @@ encoder:
 𧊱	iymf	0
 蜒	iymi	8920000
 𧌡	iymi	0
+𫊩	iyms	0
 𧎤	iymz	0
 𧉸	iynd	0
 𧑈	iynl	0
@@ -42337,6 +43942,7 @@ encoder:
 蛡	iyyt	19200
 蛠	iyyy	23600
 𢍭	iyze	0
+𫋙	iyzi	0
 𧏬	izai	0
 𧏂	izbg	0
 𧉳	izbi	0
@@ -42345,6 +43951,7 @@ encoder:
 蟣	izho	31900
 𧕂	izka	0
 𧑀	izkf	0
+𫋘	izki	0
 𧑳	izku	0
 𧌍	izkv	0
 𧖖	izll	0
@@ -42361,6 +43968,7 @@ encoder:
 𧎒	izrs	0
 虬	izvv	1390000
 𧈞	izvv	0
+𫊺	izvv	0
 𧑾	izyy	0
 䘎	izyz	3930
 𧔉	izzf	0
@@ -42384,6 +43992,7 @@ encoder:
 𡂍	jagl	0
 𠽒	jago	0
 呒	jagr	437000
+𫚾	jagr	0
 㖭	jagu	6100
 号码	jagx	194000000
 𠳒	jaia	0
@@ -42422,6 +44031,7 @@ encoder:
 𠺅	jaku	0
 口水	jakv	26600000
 叮当	jakx	5730000
+𫑣	jaky	0
 𠵾	jakz	0
 𠱻	jalb	0
 𣚧	jalf	0
@@ -42482,6 +44092,7 @@ encoder:
 號	jazi	217000000
 𢿙	jazm	0
 𣭖	jazm	0
+𪠻	jazn	0
 飸	jazo	41000
 𣪆	jazq	0
 鴞	jazr	131000
@@ -42524,8 +44135,10 @@ encoder:
 𡀁	jbjj	0
 唖	jbjk	321000
 哮喘	jbjl	9480000
+𪢙	jbjl	0
 𠹣	jbjm	0
 𠵪	jbjo	0
+𪡫	jbjr	0
 噎	jbju	3760000
 𠷸	jbju	0
 𡃨	jbjw	0
@@ -42533,6 +44146,7 @@ encoder:
 咺	jbka	80000
 𠹺	jbkb	0
 𡁲	jbki	0
+𪡺	jbkl	0
 味	jbko	156000000
 𡁻	jbkq	0
 𠳃	jbkv	0
@@ -42561,6 +44175,7 @@ encoder:
 𡄇	jbqg	0
 𠽃	jbqs	0
 𠺱	jbqw	0
+𪵉	jbqx	0
 𠵕	jbrb	0
 味儿	jbrd	2920000
 𠰂	jbrd	0
@@ -42569,6 +44184,7 @@ encoder:
 𠲊	jbrs	0
 吐痰	jbtu	1490000
 啈	jbub	66000
+𪡒	jbub	0
 味精	jbuc	3850000
 𠾢	jbud	0
 嘻	jbuj	41900000
@@ -42611,6 +44227,7 @@ encoder:
 𠸫	jcag	0
 国歌	jcaj	3520000
 国画	jcak	13700000
+𪢧	jcaw	0
 𠻠	jcax	0
 国土	jcba	40600000
 唪	jcbi	88000
@@ -42650,11 +44267,14 @@ encoder:
 𠻷	jclr	0
 𧡈	jclr	0
 𡂮	jclz	0
+𪢎	jcmb	0
 国籍	jcmc	16100000
 嗪	jcmf	1860000
 国策	jcmf	8430000
+𪡱	jcmh	0
 𠺾	jcmk	0
 嚽	jcml	38800
+𪢕	jcml	0
 国税	jcmu	12600000
 㗦	jcmy	4070
 𠽅	jcnb	0
@@ -42732,7 +44352,9 @@ encoder:
 爴	jdap	29200
 𣂽	jdap	0
 𡇕	jdar	0
+𫛐	jdar	0
 𢠝	jdaw	0
+𪡆	jdax	0
 𡆭	jday	0
 𡆽	jdaz	0
 𡇭	jdaz	0
@@ -42761,6 +44383,7 @@ encoder:
 国	jdcs	526000000
 𡈊	jdcu	0
 团聚	jdcx	4690000
+𪢚	jdcx	0
 因素	jdcz	96300000
 𡇦	jdcz	0
 团	jddm	220000000
@@ -42770,6 +44393,7 @@ encoder:
 固	jdej	73700000
 𡇣	jdej	0
 𡈌	jdel	0
+𪢯	jdel	0
 𠴜	jdex	0
 𡇐	jdfa	0
 圃	jdfb	4900000
@@ -42781,7 +44405,9 @@ encoder:
 𩒱	jdfg	0
 𡇯	jdfj	0
 𠜠	jdfk	0
+𪢫	jdfk	0
 团校	jdfs	713000
+𪢩	jdga	0
 𡒀	jdgb	0
 𡈔	jdgg	0
 𠺲	jdgh	0
@@ -42875,6 +44501,7 @@ encoder:
 𡈝	jdlp	0
 𡈪	jdlp	0
 朙	jdlq	410000
+𪢰	jdlq	0
 圐	jdls	48600
 𢚊	jdlw	0
 𡈟	jdlx	0
@@ -42951,12 +44578,14 @@ encoder:
 𠲴	jdqx	0
 𡇀	jdqx	0
 𠴋	jdqy	0
+𪠺	jdqy	0
 𠁤	jdrd	0
 𡆿	jdrh	0
 𡇾	jdrj	0
 囫	jdro	174000
 欭	jdro	30300
 𡇘	jdrr	0
+𪢬	jdrr	0
 𡇹	jdrs	0
 图	jdrt	941000000
 𡈡	jdrt	0
@@ -42967,10 +44596,12 @@ encoder:
 𡀴	jdrz	0
 𡈎	jdrz	0
 𡈙	jdrz	0
+𪢮	jdsf	0
 𡆲	jdsh	0
 团部	jdsj	311000
 𠟑	jdsk	0
 团旗	jdsm	491000
+𪢨	jdso	0
 囥	jdsq	690000
 𡈂	jdsr	0
 𡈃	jdsr	0
@@ -42978,14 +44609,17 @@ encoder:
 啦	jdsu	516000000
 𡇅	jdsy	0
 𡇁	jdsz	0
+𪡸	jdsz	0
 唞	jdte	36100
 𡈳	jdtm	0
 図	jdto	41100000
 𡇸	jdtr	0
 𡈷	jdtz	0
+𪢪	jduc	0
 𡇒	jduf	0
 𡇬	jdui	0
 𡈚	jduk	0
+𪢭	jduk	0
 𡈕	jdul	0
 図	jduo	41100000
 𡇂	jduo	0
@@ -43002,6 +44636,7 @@ encoder:
 恩	jdwz	121000000
 𡆴	jdxe	0
 𦊧	jdxf	0
+𪢅	jdxh	0
 𠵿	jdxi	0
 𠽕	jdxi	0
 𡆹	jdxi	0
@@ -43084,6 +44719,7 @@ encoder:
 鄙薄	jeev	263000
 𠽢	jefd	0
 囒	jefl	65700
+𪢠	jefl	0
 喷雾	jefr	6310000
 𠶙	jegi	0
 叶面	jegj	1220000
@@ -43175,9 +44811,11 @@ encoder:
 𠶋	jeon	0
 𡅧	jeon	0
 𡂕	jeop	0
+𫛗	jeor	0
 哎	jeos	40000000
 𠹅	jeou	0
 𠸖	jeow	0
+𪡝	jeoy	0
 嘶	jepd	9790000
 固镇	jepe	789000
 𠼼	jepy	0
@@ -43275,6 +44913,7 @@ encoder:
 𡆀	jfff	0
 𡃎	jffg	0
 呆板	jffp	2420000
+𪢇	jffw	0
 𠼖	jffz	0
 嚅	jfgl	1630000
 困惑	jfhj	22200000
@@ -43325,6 +44964,7 @@ encoder:
 哺乳	jfpy	7110000
 𡀑	jfpy	0
 𠺝	jfrj	0
+𪢐	jfrl	0
 𠿙	jfry	0
 𪁣	jfrz	0
 𠵉	jfsq	0
@@ -43343,6 +44983,7 @@ encoder:
 呆子	jfya	1700000
 𡂆	jfyk	0
 𡃤	jfyl	0
+𪡭	jfyy	0
 喓	jfzm	1080000
 𠻇	jfzm	0
 𠿊	jfzq	0
@@ -43460,6 +45101,7 @@ encoder:
 𠿑	jhjw	0
 喊叫	jhjz	3100000
 𠴼	jhkd	0
+𪡄	jhki	0
 𡄱	jhkj	0
 𡂔	jhkw	0
 𠸯	jhkz	0
@@ -43494,6 +45136,7 @@ encoder:
 啭	jhzs	489000
 	jiaa	0
 𧾷	jiaa	0
+𫏦	jiab	0
 𨃅	jiac	0
 忠于	jiad	4580000
 趶	jiad	29100
@@ -43540,12 +45183,16 @@ encoder:
 𥅌	jial	0
 𨆨	jial	0
 𨇙	jial	0
+𫏩	jial	0
 蹜	jian	36500
 𧿄	jian	0
 𠁵	jiao	0
 𨂳	jiao	0
 𧿊	jiaq	0
 𨇋	jiaq	0
+𫏎	jiar	0
+𪜉	jiau	0
+𫏁	jiau	0
 𨁊	jiax	0
 𨆖	jiax	0
 𠯡	jiay	0
@@ -43573,6 +45220,7 @@ encoder:
 𨅡	jibj	0
 𨅧	jibj	0
 跊	jibk	20300
+𫏌	jibk	0
 𨇛	jibl	0
 踷	jibm	18600
 䟚	jibn	3330
@@ -43587,6 +45235,7 @@ encoder:
 𨀿	jibr	0
 𨁚	jibr	0
 𨂟	jibr	0
+𫏓	jibr	0
 躂	jibu	353000
 𨂧	jibu	0
 𨅟	jibu	0
@@ -43606,11 +45255,13 @@ encoder:
 𨃖	jibz	0
 𨅫	jibz	0
 𨇞	jibz	0
+𫏥	jibz	0
 躡	jicc	132000
 足球	jicd	118000000
 踌	jicd	331000
 𨁦	jice	0
 䠆	jich	5310
+𫏃	jich	0
 𧿣	jici	0
 𨀤	jick	0
 蹟	jicl	1260000
@@ -43618,6 +45269,8 @@ encoder:
 蹖	jicn	42000
 踳	jico	48400
 𨆱	jicq	0
+𫏏	jicq	0
+𫏗	jicq	0
 𧿷	jics	0
 踙	jicx	24500
 𨀱	jicx	0
@@ -43629,6 +45282,7 @@ encoder:
 𨃁	jidm	0
 䟷	jidp	3410
 𨄸	jidp	0
+𫏀	jids	0
 𨁩	jidy	0
 𧿰	jiea	0
 𧿱	jiea	0
@@ -43637,6 +45291,7 @@ encoder:
 𨁠	jieb	0
 𨄎	jieb	0
 𨅯	jieb	0
+𫏄	jieb	0
 䠜	jiec	4060
 踑	jiec	40300
 𧾽	jied	0
@@ -43661,12 +45316,14 @@ encoder:
 𨂾	jiel	0
 𨆛	jiel	0
 𨇿	jiel	0
+𫏛	jiel	0
 𨂵	jien	0
 𨇧	jien	0
 䠄	jieo	5280
 䠣	jieo	4260
 𨂚	jieo	0
 𨅜	jieo	0
+𫏇	jieo	0
 𨀭	jieq	0
 𨅤	jieq	0
 𨅹	jieq	0
@@ -43692,6 +45349,7 @@ encoder:
 𨃙	jiff	0
 𨅾	jiff	0
 𨇢	jifg	0
+𫏧	jifg	0
 跴	jifj	37500
 踈	jifj	108000
 𠾋	jifj	0
@@ -43729,6 +45387,7 @@ encoder:
 𨀁	jigm	0
 𨀗	jigm	0
 𨄉	jigm	0
+𫏋	jign	0
 𨂠	jigo	0
 𨂪	jigp	0
 噱	jigq	313000
@@ -43747,6 +45406,7 @@ encoder:
 𨂨	jigu	0
 跶	jigw	204000
 䟦	jigx	4100
+𫏖	jigx	0
 跠	jigy	22000
 跪	jigy	23600000
 踯	jigy	541000
@@ -43754,6 +45414,7 @@ encoder:
 躑	jigy	152000
 躚	jigy	26300
 𨇴	jigy	0
+𫏟	jigy	0
 跮	jihb	22600
 踁	jihb	34300
 𨀕	jihc	0
@@ -43800,13 +45461,16 @@ encoder:
 𧿓	jiis	0
 𨄲	jiiw	0
 𨀛	jiiy	0
+𫏜	jija	0
 蹚	jijb	187000
 贵国	jijc	694000
 𨁎	jijc	0
+𫘘	jijc	0
 躊	jijd	129000
 躁	jijf	6040000
 𨁉	jijf	0
 𨅨	jijf	0
+𫏡	jijg	0
 𨅝	jijh	0
 踀	jiji	43500
 蹿	jiji	2540000
@@ -43875,6 +45539,7 @@ encoder:
 嚬	jikg	403000
 蹴	jikg	3870000
 𨆞	jikg	0
+𫏈	jikg	0
 𡃰	jikh	0
 𨃄	jikh	0
 䟧	jiki	3770
@@ -43886,10 +45551,12 @@ encoder:
 𨄩	jikk	0
 𨇉	jikk	0
 𨇡	jikk	0
+𫏣	jikk	0
 䠀	jikl	16900
 嚧	jikl	138000
 𨂅	jikl	0
 𨇖	jikl	0
+𫏘	jikl	0
 䟞	jikm	3200
 贵省	jikm	98700
 𨁭	jikm	0
@@ -43928,6 +45595,8 @@ encoder:
 𨀜	jild	0
 䫭	jilg	3350
 踹	jilg	5630000
+𫏅	jilg	0
+𫏢	jilg	0
 贵贱	jilh	1340000
 踻	jilj	19700
 𨀩	jilj	0
@@ -43957,6 +45626,7 @@ encoder:
 𠿖	jilr	0
 𨁍	jilr	0
 𨁞	jilr	0
+𫏑	jilr	0
 躧	jilt	36500
 遗	jilw	16600000
 遺	jilw	6310000
@@ -43972,6 +45642,7 @@ encoder:
 𨁎	jimb	0
 𨁗	jimb	0
 𨂘	jimb	0
+𫏊	jimb	0
 𧿐	jime	0
 𧿘	jime	0
 跥	jimf	32900
@@ -44002,10 +45673,12 @@ encoder:
 蹫	jiml	25700
 𨆦	jiml	0
 𨇣	jiml	0
+𫏠	jiml	0
 𨄕	jimm	0
 𨂵	jimn	0
 𨇧	jimn	0
 跌	jimo	68700000
+𫏂	jimo	0
 𧿦	jimq	0
 跣	jimr	380000
 趿	jims	291000
@@ -44015,6 +45688,7 @@ encoder:
 𨄥	jimu	0
 䟪	jimw	3410
 跹	jimw	205000
+𫑍	jimw	0
 趷	jimy	36500
 𧿶	jimy	0
 𨀊	jimy	0
@@ -44110,6 +45784,7 @@ encoder:
 𧿚	jioy	0
 𨃈	jioy	0
 𨇫	jioy	0
+𫏒	jioy	0
 躐	jioz	110000
 𧿖	jioz	0
 䟬	jipd	3670
@@ -44132,6 +45807,7 @@ encoder:
 𨄠	jipw	0
 𧿨	jipx	0
 𨁡	jipz	0
+𫏙	jipz	0
 跚	jiqa	3580000
 𨁨	jiqc	0
 𧾾	jiqd	0
@@ -44170,6 +45846,7 @@ encoder:
 𨂥	jirj	0
 𨃶	jirj	0
 𨆿	jirj	0
+𫏉	jirj	0
 䟢	jirk	3670
 跞	jirk	133000
 𨀴	jirk	0
@@ -44214,6 +45891,7 @@ encoder:
 𨂂	jiru	0
 𨇟	jiru	0
 𨇤	jiru	0
+𫏨	jiru	0
 𪛅	jirw	0
 踭	jirx	84600
 跑	jiry	159000000
@@ -44235,6 +45913,7 @@ encoder:
 贵部	jisj	66200
 踣	jisj	122000
 𨁮	jisj	0
+𫏚	jisj	0
 𨅩	jisk	0
 𨃋	jisl	0
 贵族	jism	21700000
@@ -44244,6 +45923,7 @@ encoder:
 跻	jisn	515000
 𨂋	jisn	0
 㗔	jiso	3770
+𪯡	jiso	0
 䟘	jisq	3360
 𨀫	jisq	0
 蹨	jisu	62500
@@ -44299,9 +45979,11 @@ encoder:
 𨄇	jiuk	0
 蹢	jiul	34200
 𨇇	jiul	0
+𫏝	jiul	0
 𨃪	jium	0
 𤆪	jiuo	0
 𧿮	jiuo	0
+𫏞	jiup	0
 𨄴	jiuq	0
 𨄶	jius	0
 𨅀	jius	0
@@ -44416,6 +46098,7 @@ encoder:
 㕜	jixs	4330
 䟕	jixs	3430
 跋	jixs	4770000
+𫏆	jixs	0
 踗	jixw	21300
 蹆	jixw	77900
 𨆲	jixw	0
@@ -44451,6 +46134,7 @@ encoder:
 蹾	jiym	87200
 𧾼	jiym	0
 𨄨	jiym	0
+𫏍	jiym	0
 躍	jiyn	3820000
 𧿳	jiyn	0
 𨄌	jiyn	0
@@ -44505,8 +46189,10 @@ encoder:
 足以	jizo	29400000
 𨀖	jizo	0
 𨇰	jizp	0
+𫏞	jizp	0
 𨀮	jizq	0
 𨂔	jizq	0
+𫏤	jizq	0
 䟲	jizr	3600
 蹶	jizr	858000
 𨀨	jizr	0
@@ -44533,6 +46219,7 @@ encoder:
 𡆔	jjaj	0
 嘳	jjal	34900
 𢃋	jjal	0
+𪡞	jjal	0
 𠱐	jjas	0
 𤊌	jjau	0
 鼉	jjaw	47200
@@ -44621,6 +46308,7 @@ encoder:
 回车	jjhe	10200000
 回到	jjhk	169000000
 𢦸	jjhm	0
+𪹬	jjhu	0
 𧕛	jjii	0
 𧕦	jjii	0
 圆桌	jjik	3290000
@@ -44678,6 +46366,7 @@ encoder:
 𩱴	jjjl	0
 𠻖	jjjm	0
 𣀬	jjjm	0
+𪯟	jjjm	0
 咽喉	jjjn	9810000
 回响	jjjn	4280000
 𩀏	jjjn	0
@@ -44709,6 +46398,7 @@ encoder:
 𡀋	jjkz	0
 𡁥	jjkz	0
 圆周	jjlb	956000
+𪡼	jjlg	0
 𠲢	jjli	0
 器皿	jjlk	4020000
 𠞫	jjlk	0
@@ -44720,6 +46410,7 @@ encoder:
 回见	jjlr	715000
 𠺐	jjlr	0
 回用	jjlv	988000
+𪟣	jjly	0
 𠾧	jjlz	0
 𡀈	jjmb	0
 𡅚	jjmb	0
@@ -44807,17 +46498,20 @@ encoder:
 串通	jjwx	1880000
 回避	jjwx	24800000
 圆通	jjwx	1250000
+𫜝	jjwx	0
 器官	jjwy	16800000
 串案	jjwz	157000
 嗯	jjwz	44700000
 圆心	jjwz	953000
 患	jjwz	96700000
+𪫰	jjwz	0
 回函	jjxk	2000000
 㖐	jjxm	4080
 患难	jjxn	2030000
 𡁳	jjxs	0
 𪛄	jjxx	0
 𡄞	jjxy	0
+𪡰	jjxy	0
 圆子	jjya	729000
 嚣张	jjyc	7890000
 回民	jjyh	1410000
@@ -44902,6 +46596,7 @@ encoder:
 唱段	jknc	477000
 㘍	jknh	4580
 𠻘	jkni	0
+𪡽	jkob	0
 嚗	jkok	739000
 𠷟	jkon	0
 𡄗	jkos	0
@@ -44916,6 +46611,7 @@ encoder:
 啺	jkro	93900
 𠴭	jkro	0
 𠿒	jkrr	0
+𪡓	jkrr	0
 喝	jkry	226000000
 𠵫	jkry	0
 𡅩	jkry	0
@@ -44936,6 +46632,7 @@ encoder:
 踏实	jkwt	9060000
 𠹵	jkwz	0
 𠾦	jkwz	0
+𪠽	jkxb	0
 唱戏	jkxh	1340000
 嘢	jkxi	1780000
 吵架	jkyj	13600000
@@ -44948,6 +46645,7 @@ encoder:
 𡂡	jkzm	0
 𡀾	jkzu	0
 喂奶	jkzy	1410000
+𫑡	jkzy	0
 𠵄	jlad	0
 𠵚	jlae	0
 𠽭	jlai	0
@@ -44969,6 +46667,7 @@ encoder:
 𠼌	jlcm	0
 𡆑	jlcm	0
 𡂼	jlcu	0
+𪡮	jlds	0
 𠳣	jled	0
 唺	jleo	61500
 𠾨	jler	0
@@ -44980,7 +46679,9 @@ encoder:
 喘	jlgl	19400000
 𠹃	jlgl	0
 䫟	jlgo	3230
+𫖲	jlgo	0
 𠾪	jlgq	0
+𪡩	jlgu	0
 嚺	jlgw	23700
 𠸵	jlhd	0
 𠯧	jlia	0
@@ -45032,12 +46733,14 @@ encoder:
 呐	jlod	22900000
 呙	jlod	194000
 剐	jlok	2760000
+𪠼	jloo	0
 𡂅	jlor	0
 𠵙	jlow	0
 𠼹	jlpd	0
 吊销	jlpk	4530000
 吊舱	jlpo	201000
 吊钩	jlpr	358000
+𪢛	jlpx	0
 嘣	jlqq	969000
 员外	jlri	901000
 噣	jlri	521000
@@ -45047,6 +46750,7 @@ encoder:
 啰	jlrs	3080000
 𦫮	jlry	0
 鶰	jlrz	18600
+𫛫	jlrz	0
 𠺯	jlsh	0
 𧷯	jlsj	0
 勋章	jlsk	58700000
@@ -45054,6 +46758,7 @@ encoder:
 㖗	jlsx	3760
 㗄	jlsy	3730
 吊装	jltb	1910000
+𪡯	jltl	0
 吊灯	jlua	1530000
 嚜	jlub	1340000
 𡀕	jluu	0
@@ -45063,7 +46768,9 @@ encoder:
 郧阳	jlyk	654000
 勋	jlym	5130000
 勛	jlym	1880000
+𪼺	jlys	0
 𤏩	jlyu	0
+𪬩	jlyw	0
 翤	jlyy	20800
 囉	jlzn	46600000
 𪔅	jlzn	0
@@ -45095,6 +46802,7 @@ encoder:
 呼机	jmfq	921000
 㕭	jmgd	4250
 𠰙	jmgk	0
+𪡀	jmgn	0
 𠺑	jmgs	0
 跌破	jmgx	7820000
 吒	jmhd	2090000
@@ -45110,6 +46818,7 @@ encoder:
 呼喊	jmjh	6310000
 吃喝	jmjk	22300000
 嘺	jmjl	36200
+𪢤	jmjl	0
 呼呼	jmjm	8090000
 呼唤	jmjr	14600000
 𠾔	jmjr	0
@@ -45129,14 +46838,18 @@ encoder:
 吃水	jmkv	1710000
 吃紧	jmkx	1870000
 跌幅	jmla	11300000
+𪢉	jmld	0
+𪢊	jmlg	0
 𠲣	jmlk	0
 𠶜	jmlk	0
 𡀹	jmlo	0
 哖	jmmb	1420000
 𠵮	jmmb	0
 𣽿	jmmb	0
+𪡾	jmmc	0
 跃升	jmme	1390000
 㗛	jmmg	3860
+𪠿	jmmi	0
 吃香	jmmk	1550000
 𠽶	jmmm	0
 𠾆	jmmm	0
@@ -45182,11 +46895,13 @@ encoder:
 𠽩	jmxb	0
 跃居	jmxe	2240000
 𠺋	jmxg	0
+𪢑	jmxj	0
 𡅉	jmxk	0
 𡅣	jmxn	0
 𡅌	jmxq	0
 𡀝	jmxw	0
 𡅯	jmxw	0
+𪢖	jmxw	0
 㘉	jmxy	4590
 吃	jmyd	516000000
 𠰹	jmyi	0
@@ -45222,6 +46937,7 @@ encoder:
 𤳧	jneo	0
 𡀯	jnfd	0
 𡃽	jnfg	0
+𪢋	jnfl	0
 响板	jnfp	123000
 𠹎	jnfu	0
 嗥	jnge	890000
@@ -45243,6 +46959,7 @@ encoder:
 𠷊	jnko	0
 𡂈	jnku	0
 响水	jnkv	992000
+𪡠	jnkv	0
 𡀭	jnky	0
 𠼸	jnkz	0
 𡂗	jnld	0
@@ -45262,6 +46979,7 @@ encoder:
 𪅺	jnmr	0
 喺	jnmz	1040000
 𡁫	jnnb	0
+𪡈	jnnk	0
 咱们	jnnt	26900000
 𠸘	jnoj	0
 𡃪	jnol	0
@@ -45279,10 +46997,14 @@ encoder:
 哗	jnre	7060000
 𠺧	jnrf	0
 哗然	jnrg	4110000
+𪡉	jnri	0
+𪡇	jnrk	0
 𡄊	jnrl	0
+𪢀	jnrm	0
 吪	jnrr	68300
 𠹇	jnrr	0
 𠿬	jnrr	0
+𪡟	jnrr	0
 啲	jnrs	9770000
 𠴓	jnrs	0
 喞	jnry	79000
@@ -45293,6 +47015,7 @@ encoder:
 噭	jnsm	65000
 𠵱	jnsr	0
 𠴖	jnsu	0
+𪢥	jnsw	0
 哗变	jnsx	202000
 喉癌	jntj	261000
 响应	jntv	22000000
@@ -45326,6 +47049,7 @@ encoder:
 𠾑	joai	0
 哈	joaj	190000000
 㖮	joal	4130
+𪢝	joaw	0
 𠯋	joaz	0
 𠸤	jobd	0
 𡆁	jobg	0
@@ -45333,6 +47057,7 @@ encoder:
 𠻀	jobo	0
 𠹐	jobr	0
 史地	jobv	3030000
+𪡋	jobv	0
 哙	jobz	330000
 叺	joda	151000
 𠾑	joei	0
@@ -45355,9 +47080,11 @@ encoder:
 㖉	joii	3840
 嘥	joii	87300
 只占	joij	4940000
+𪡖	jojd	0
 啽	joje	40000
 𠹞	joje	0
 𠼟	jojk	0
+𪟔	jojk	0
 嗱	jojm	338000
 吩咐	jojn	9010000
 哈哈	jojo	68300000
@@ -45407,6 +47134,7 @@ encoder:
 哈欠	joro	1790000
 𠿮	joro	0
 嗲	jorr	4040000
+𪠵	jorr	0
 𩿦	jorz	0
 𪀎	jorz	0
 只读	jose	5600000
@@ -45454,6 +47182,7 @@ encoder:
 嗂	jpez	25900
 啋	jpfa	643000
 𡀖	jpfa	0
+𪢜	jpfb	0
 𡄮	jpfl	0
 𠾫	jpgo	0
 喛	jpgx	125000
@@ -45483,6 +47212,7 @@ encoder:
 𠾠	jprj	0
 𠾬	jpro	0
 𡃶	jpro	0
+𪡗	jpro	0
 𠹕	jprs	0
 听讲	jpsb	1750000
 听课	jpsk	8960000
@@ -45512,6 +47242,7 @@ encoder:
 𠹻	jqag	0
 㕨	jqda	4220
 𠯥	jqed	0
+𪡿	jqhb	0
 叽叽	jqjq	763000
 剈	jqkd	22600
 𡄯	jqkw	0
@@ -45558,6 +47289,7 @@ encoder:
 鸣枪	jrfo	507000
 图样	jrfu	2010000
 𡗽	jrgd	0
+𪥒	jrgd	0
 路面	jrgj	13300000
 𡄠	jrgl	0
 㗋	jrgm	3800
@@ -45591,6 +47323,7 @@ encoder:
 跑题	jrka	1500000
 𠳉	jrka	0
 路由	jrki	25700000
+𪠸	jrko	0
 图景	jrks	1250000
 𣵯	jrkv	0
 𠼓	jrkz	0
@@ -45598,6 +47331,7 @@ encoder:
 唃	jrld	37500
 唤	jrlg	12700000
 喚	jrlg	2820000
+𪾍	jrlk	0
 𠼠	jrlo	0
 跪拜	jrma	1210000
 吹牛	jrmb	5700000
@@ -45629,6 +47363,7 @@ encoder:
 𠸀	jroo	0
 噡	jros	34200
 𠰯	jros	0
+𪠴	jros	0
 唿	jrow	255000
 路径	jrox	18300000
 哛	jroy	18900
@@ -45642,6 +47377,7 @@ encoder:
 图象	jrrj	13400000
 图解	jrrl	15700000
 喈	jrrn	330000
+𪡕	jrro	0
 吡	jrrr	3100000
 哆	jrrs	10100000
 嚵	jrrs	34500
@@ -45710,6 +47446,7 @@ encoder:
 𠾍	jsef	0
 𨅇	jsej	0
 嚷	jser	7350000
+𪢘	jsfj	0
 嚫	jsfl	65600
 囃	jsfn	212000
 噺	jsfp	1770000
@@ -45753,10 +47490,12 @@ encoder:
 𡄶	jslg	0
 𠽜	jslj	0
 𠽆	jslo	0
+𪢟	jslu	0
 𠻗	jslz	0
 𠻾	jsmb	0
 𠼯	jsme	0
 𡅷	jsmh	0
+𪢁	jsmh	0
 嗾	jsmm	207000
 喭	jsmp	37600
 𡆈	jsmr	0
@@ -45774,6 +47513,7 @@ encoder:
 𠸠	jsoj	0
 咬	jsoo	40100000
 𠺡	jsor	0
+𪢃	jsor	0
 唹	jsot	183000
 𠲲	jspd	0
 㘖	jspg	4220
@@ -45790,6 +47530,7 @@ encoder:
 𡆙	jsrs	0
 𡁈	jsse	0
 𡅼	jsss	0
+𪯮	jste	0
 㕸	jsua	4640
 𠱪	jsua	0
 嘀	jsul	9040000
@@ -45809,10 +47550,12 @@ encoder:
 哴	jsxo	66800
 𠻴	jsxq	0
 啷	jsxy	1450000
+𪡙	jsxy	0
 𠾓	jsyj	0
 噋	jsym	20600
 𡁹	jsym	0
 㗥	jsyy	3720
+𪡴	jsyy	0
 𠻜	jsze	0
 𠴬	jszf	0
 㗜	jszk	3680
@@ -45823,7 +47566,9 @@ encoder:
 𡀲	jszo	0
 唷	jszq	31600000
 𠵷	jszr	0
+𪡁	jszr	0
 呟	jszz	207000
+𪡛	jtaj	0
 㘎	jtcm	15700
 	jtcm	0
 呌	jted	33600
@@ -45834,10 +47579,12 @@ encoder:
 嘛	jtff	122000000
 嚰	jtfg	39200
 𠺟	jtfk	0
+𪢌	jtfl	0
 嚤	jtfm	364000
 𠶧	jtij	0
 㖢	jtir	4130
 𠹂	jtir	0
+𪡦	jtiy	0
 𡄁	jtjm	0
 𡀧	jtkh	0
 𠶦	jtki	0
@@ -45853,6 +47600,7 @@ encoder:
 𠹔	jtxj	0
 𠻞	jtxk	0
 嘃	jtxl	21700
+𪢔	jtzu	0
 嚒	jtzz	444000
 𡂺	juax	0
 嗟	jubi	1880000
@@ -45862,9 +47610,11 @@ encoder:
 𠵐	jubz	0
 𡁔	jucq	0
 噂	jufd	19100000
+𪡧	jufd	0
 圈套	jugc	5070000
 咲	jugd	10100000
 𠸍	jugd	0
+𪢂	jugl	0
 𠸌	jugq	0
 嚺	jugw	23700
 𡂸	jugy	0
@@ -45887,6 +47637,7 @@ encoder:
 𠶞	jumc	0
 𠷘	jumf	0
 𠿿	jumh	0
+𪢂	juml	0
 𡂰	jumy	0
 嗌	juol	1030000
 𡂺	juox	0
@@ -45929,6 +47680,7 @@ encoder:
 𠶑	juzi	0
 喽	juzm	25300000
 𠷩	juzm	0
+𪢒	juzm	0
 𠾌	juzn	0
 嗍	juzq	72300
 㘂	juzw	5410
@@ -45957,6 +47709,7 @@ encoder:
 中的	jvdv	501000000
 中南	jvel	22500000
 中英	jvel	9040000
+𪡥	jveo	0
 中期	jveq	23100000
 中药	jvez	24200000
 𠾻	jvez	0
@@ -45987,6 +47740,7 @@ encoder:
 中国	jvjc	2130000000
 中叶	jvje	2120000
 跳跃	jvjm	9430000
+𪡵	jvjq	0
 中路	jvjr	24100000
 𡁺	jvjr	0
 跳跳	jvjv	4140000
@@ -46006,6 +47760,7 @@ encoder:
 𠿭	jvlw	0
 中等	jvmb	41500000
 𠽍	jvmb	0
+𪡚	jvmc	0
 中午	jvme	65000000
 跳舞	jvme	22800000
 𠴎	jvmg	0
@@ -46094,6 +47849,7 @@ encoder:
 咛	jwai	760000
 𠳽	jwai	0
 𠽰	jwai	0
+𪡣	jwak	0
 𠴴	jwal	0
 𠸐	jwax	0
 𠰇	jwaz	0
@@ -46103,6 +47859,7 @@ encoder:
 𠷪	jwbj	0
 喧	jwbk	4330000
 𠵻	jwbk	0
+𪢆	jwbm	0
 唍	jwbr	264000
 噠	jwbu	519000
 嗐	jwcj	721000
@@ -46127,6 +47884,7 @@ encoder:
 𠴈	jwgz	0
 㗌	jwhb	3940
 㗧	jwhb	3930
+𪡏	jwhe	0
 𠴨	jwix	0
 𡁁	jwix	0
 𠾯	jwjf	0
@@ -46158,6 +47916,7 @@ encoder:
 哰	jwmb	36800
 咤	jwmh	591000
 𠻉	jwmi	0
+𪢗	jwmi	0
 𠻛	jwmj	0
 嘧	jwml	1950000
 𠷖	jwmw	0
@@ -46189,6 +47948,7 @@ encoder:
 𠾰	jwrh	0
 喀	jwrj	9260000
 咜	jwrr	177000
+𪡶	jwrs	0
 啘	jwry	202000
 𠶐	jwry	0
 𠹼	jwse	0
@@ -46207,6 +47967,7 @@ encoder:
 𠸺	jwuz	0
 𠻩	jwvr	0
 𠯣	jwvv	0
+𪢥	jwws	0
 嗵	jwxl	513000
 𠺙	jwxo	0
 𠸽	jwxr	0
@@ -46267,6 +48028,7 @@ encoder:
 𡂛	jxju	0
 跟踪	jxjw	38800000
 𠹴	jxjy	0
+𪡰	jxjy	0
 㗲	jxka	5320
 𠱺	jxka	0
 𡃢	jxka	0
@@ -46310,6 +48072,8 @@ encoder:
 𠿷	jxsl	0
 𠲙	jxsq	0
 跟头	jxtg	1830000
+𪡃	jxtg	0
+𪡨	jxuf	0
 嚍	jxul	75300
 跟着	jxul	42700000
 𠴌	jxuo	0
@@ -46421,12 +48185,14 @@ encoder:
 吸入	jyod	10900000
 噿	jyoe	32600
 另行	jyoi	11400000
+𪡷	jyom	0
 𡄉	jyoo	0
 𡄣	jyoo	0
 𤕦	jyoo	0
 嘐	jyop	83700
 𠻱	jyor	0
 哪个	jyov	61300000
+𪡎	jyow	0
 䬭	jyox	3770
 𠸳	jyoz	0
 𠔦	jypo	0
@@ -46473,6 +48239,7 @@ encoder:
 吸附	jyyn	5660000
 嚁	jyyn	29000
 嗋	jyyq	62900
+𪢄	jyys	0
 𠺁	jyyt	0
 𠱿	jyyy	0
 𠱳	jyyz	0
@@ -46489,6 +48256,7 @@ encoder:
 呉	jzao	4200000
 𡅍	jzbg	0
 𠸣	jzbi	0
+𪢍	jzbj	0
 𠵈	jzbk	0
 𡆓	jzbn	0
 𠿆	jzcr	0
@@ -46524,6 +48292,7 @@ encoder:
 𠶼	jzlz	0
 唉	jzma	54300000
 哞	jzmb	1060000
+𪡂	jzmb	0
 𠹷	jzmh	0
 𠲠	jzmo	0
 𠺻	jzms	0
@@ -46611,9 +48380,11 @@ encoder:
 师大	kagd	16800000
 昊	kagd	11200000
 𩑰	kago	0
+𪰯	kagx	0
 日历	kagy	92700000
 𨛴	kagy	0
 𣊰	kaib	0
+𪧺	kaid	0
 題	kaig	59400000
 题	kaig	93700000
 是	kaii	2210000000
@@ -46625,9 +48396,12 @@ encoder:
 𧡰	kail	0
 晸	kaim	626000
 𦧪	kaim	0
+𪰱	kaim	0
 匙	kair	9160000
 鶗	kair	61100
 𫜾	kair	0
+𫛸	kair	0
+𫃆	kaiu	0
 遈	kaiw	528000
 㪋	kaix	3830
 𢾙	kaix	0
@@ -46666,6 +48440,7 @@ encoder:
 师生	kamc	19300000
 日程	kamj	33300000
 𣊋	kamj	0
+𪰬	kamk	0
 量筒	kaml	435000
 𣉺	kamo	0
 旱稻	kamp	87100
@@ -46696,6 +48471,7 @@ encoder:
 𣆃	karb	0
 旱象	karj	70300
 题名	karj	20300000
+𪰾	kark	0
 题解	karl	1210000
 𧤘	karl	0
 昜	karo	836000
@@ -46716,8 +48492,10 @@ encoder:
 旱冰	katk	654000
 师资	katr	12000000
 量度	katv	1050000
+𪰓	kaua	0
 旱情	kauc	1250000
 量瓶	kaue	120000
+𫖥	kaug	0
 日益	kauo	37200000
 日前	kauq	90200000
 𤓐	kauu	0
@@ -46731,6 +48509,7 @@ encoder:
 旱灾	kawu	2980000
 鼂	kawx	26000
 题字	kawy	1010000
+𪰿	kawy	0
 𢘇	kawz	0
 㫸	kaxi	3970
 日子	kaya	106000000
@@ -46750,6 +48529,7 @@ encoder:
 日出	kazz	12900000
 暑天	kbag	328000
 𨤷	kbaj	0
+𫒁	kbal	0
 尘土	kbba	4790000
 晆	kbba	24900
 𣈹	kbbb	0
@@ -46765,6 +48545,7 @@ encoder:
 野营	kbew	5050000
 𢻣	kbex	0
 里面	kbgj	102000000
+𫖢	kbgo	0
 𣌐	kbia	0
 墅	kbib	15100000
 𣆞	kbii	0
@@ -46774,7 +48555,9 @@ encoder:
 𤍓	kbiu	0
 野味	kbjb	1540000
 𣋬	kbjd	0
+𪰥	kbjk	0
 曀	kbju	86400
+𪰹	kbkb	0
 野果	kbkf	626000
 昧	kbko	1940000
 里昂	kbkr	4490000
@@ -46784,6 +48567,7 @@ encoder:
 野生	kbmc	18100000
 里程	kbmj	8990000
 𢢨	kbmw	0
+𪰉	kbnd	0
 𣊌	kbni	0
 㫱	kbno	3640
 㬨	kbno	3950
@@ -46793,12 +48577,15 @@ encoder:
 𣊚	kboo	0
 𣇾	kbor	0
 𣊎	kbqs	0
+𪰈	kbrd	0
 里外	kbri	3830000
 野外	kbri	20600000
+𪰰	kbri	0
 𣉟	kbrk	0
 𨤧	kbrk	0
 𢄾	kbrl	0
 𣇾	kbrr	0
+𪰚	kbrr	0
 野蛮	kbsi	17600000
 𧚣	kbsr	0
 黙	kbsu	864000
@@ -46810,6 +48597,7 @@ encoder:
 𤜔	kbum	0
 野火	kbuo	1710000
 黒	kbuo	98100000
+𪹶	kbuo	0
 𣊎	kbuq	0
 野炊	kbur	1080000
 𨤮	kbuu	0
@@ -46881,6 +48669,7 @@ encoder:
 𩇸	kcmj	0
 䩁	kcmm	4330
 最矮	kcmm	268000
+𪪈	kcmm	0
 最先	kcmr	9950000
 旺季	kcmy	13400000
 最佳	kcnb	154000000
@@ -46894,6 +48683,7 @@ encoder:
 䪤	kcpk	4180
 𩈀	kcpk	0
 非凡	kcqd	17300000
+𪱕	kcri	0
 最多	kcrv	267000000
 𪂏	kcrz	0
 𪂞	kcrz	0
@@ -46928,21 +48718,27 @@ encoder:
 㬩	kcxw	7360
 𩇫	kcya	0
 㐟	kcyd	4330
+𪰳	kcyg	0
 𩇯	kcyi	0
 朂	kcym	118000
+𫅰	kcyo	0
 䨽	kcyy	3870
 翡	kcyy	1880000
+𫅰	kcyy	0
 婓	kczm	903000
 晴纶	kczo	400000
 最能	kczq	9660000
 最终	kczr	125000000
 最好	kczy	183000000
+𫎇	kdag	0
 𣥠	kdai	0
 师	kdal	416000000
 𩇧	kday	0
 𣥠	kdbi	0
 𤯶	kdbm	0
 𠁿	kdbs	0
+𫔸	kdbt	0
+𫑀	kdbw	0
 时髦	kdcm	7370000
 时事	kddj	43800000
 时报	kddy	41700000
@@ -46954,10 +48750,12 @@ encoder:
 时区	kdho	26200000
 时日	kdka	5640000
 时时	kdkd	18600000
+𪲹	kdkf	0
 时光	kdkg	39500000
 时尚	kdkl	288000000
 时常	kdkw	15200000
 帅	kdli	248000000
+𪟎	kdlk	0
 临	kdmk	61500000
 监	kdml	70100000
 览	kdml	65800000
@@ -46989,6 +48787,7 @@ encoder:
 𣈓	kdxi	0
 䝨	kdxl	3490
 贤	kdxl	37900000
+𪾋	kdxl	0
 肾	kdxq	25700000
 竖	kdxs	14800000
 时局	kdxy	1260000
@@ -47014,6 +48813,7 @@ encoder:
 早报	kedy	13900000
 曄	keeb	1290000
 曅	keeb	102000
+𪰞	keeb	0
 暁	keeg	4240000
 早期	keeq	65100000
 𣊿	keeq	0
@@ -47065,6 +48865,7 @@ encoder:
 㬮	keon	5050
 𣌖	keon	0
 暪	keoo	162000
+𪱉	keoo	0
 早饭	keop	4810000
 𣋸	keor	0
 謈	keos	24700
@@ -47082,6 +48883,7 @@ encoder:
 𣉪	kesn	0
 𣇷	kesy	0
 𣇪	keuo	0
+𪸣	keuo	0
 𣊴	keve	0
 㫒	kevv	3610
 暴涨	kevy	6330000
@@ -47106,6 +48908,7 @@ encoder:
 㬍	kfds	4340
 暷	kfds	29000
 𢻔	kfex	0
+𪳿	kfex	0
 果木	kffa	431000
 𣋜	kffb	0
 果枝	kffe	195000
@@ -47137,6 +48940,7 @@ encoder:
 曤	kfni	87200
 𣌟	kfoo	0
 𣛤	kfoo	0
+𪰪	kfoo	0
 㬡	kfow	4080
 晰	kfpd	2600000
 𢒙	kfpd	0
@@ -47161,6 +48965,7 @@ encoder:
 𠕖	kfvv	0
 果农	kfwr	953000
 果实	kfwt	11200000
+𪱇	kfwz	0
 果敢	kfxc	2450000
 𣌊	kfxx	0
 果子	kfya	6350000
@@ -47174,6 +48979,7 @@ encoder:
 晇	kgbz	47500
 光热	kgdq	757000
 晨报	kgdy	17400000
+𪰫	kgee	0
 辉南	kgel	308000
 光芒	kges	22600000
 光荣	kgew	28200000
@@ -47198,6 +49004,7 @@ encoder:
 晨曦	kgku	6220000
 光是	kgkv	8390000
 光照	kgky	6650000
+𪰲	kgky	0
 光电	kgkz	13800000
 晻	kgkz	123000
 耀眼	kglx	11200000
@@ -47222,7 +49029,9 @@ encoder:
 尖锐	kgpu	11200000
 𩉉	kgrn	0
 鷐	kgrz	28800
+𫜀	kgrz	0
 𡒦	kgsb	0
+𪱑	kgsb	0
 光亮	kgsj	7830000
 尖端	kgsl	6760000
 光谱	kgsu	2660000
@@ -47231,6 +49040,7 @@ encoder:
 光源	kgvg	8350000
 光滑	kgvl	21700000
 光州	kgvn	598000
+𪰒	kgvv	0
 光学	kgvw	27700000
 光波	kgvx	1780000
 光泽	kgvx	9240000
@@ -47249,6 +49059,7 @@ encoder:
 光能	kgzq	1170000
 𣆜	khai	0
 𣇁	khbi	0
+𪰜	khbi	0
 暱	khgj	887000
 晓	khgr	63500000
 𣇈	khgr	0
@@ -47256,12 +49067,15 @@ encoder:
 𩳺	khjn	0
 𢤃	khjw	0
 𠕥	khkd	0
+𪰝	khkd	0
 𣈿	khkz	0
 𣋣	khml	0
 晓得	khok	18100000
 畏惧	khul	6220000
+𪥖	khxg	0
 畏难	khxn	1150000
 煚	khxu	81300
+𪰩	khxy	0
 旽	khzi	82400
 畏缩	khzw	2350000
 𤱤	kiaa	0
@@ -47279,12 +49093,16 @@ encoder:
 𤱉	kiag	0
 𤳃	kiag	0
 𤰣	kiah	0
+𪽉	kiah	0
 町	kiai	148000000
 甼	kiai	39700
 𤲂	kiai	0
 𤲣	kiai	0
 畸	kiaj	4980000
 𤳴	kiaj	0
+𪟡	kiaj	0
+𪽍	kiaj	0
+𪽎	kiaj	0
 𣷛	kiak	0
 𤳨	kiak	0
 𢄖	kial	0
@@ -47310,11 +49128,13 @@ encoder:
 𤳐	kiau	0
 迪	kiaw	138000000
 𡱋	kiax	0
+𪽏	kiax	0
 㐕	kiay	4280
 㕀	kiay	5360
 廸	kiay	229000
 邮	kiay	95100000
 𠢮	kiay	0
+𪽏	kiay	0
 㽕	kiaz	4100
 甹	kiaz	30000
 𠃦	kiaz	0
@@ -47347,11 +49167,13 @@ encoder:
 𠔱	kibo	0
 𤲍	kibo	0
 𤳉	kibo	0
+𪽜	kibq	0
 鴨	kibr	9980000
 鸭	kibr	25400000
 𠒛	kibr	0
 𣢗	kibr	0
 𪈦	kibr	0
+𪽊	kibr	0
 𤲜	kibu	0
 𪒕	kibu	0
 田地	kibv	3840000
@@ -47363,6 +49185,7 @@ encoder:
 𤳟	kibz	0
 𡒮	kicb	0
 𣌨	kicb	0
+𪽙	kicb	0
 畴	kicd	1240000
 𡬤	kicd	0
 𣁱	kice	0
@@ -47382,6 +49205,7 @@ encoder:
 𤳘	kicu	0
 迧	kicw	19900
 𤰷	kicy	0
+𪟞	kidm	0
 申批	kidr	84300
 𤰥	kids	0
 𤴃	kidu	0
@@ -47438,6 +49262,7 @@ encoder:
 𨎠	kijf	0
 𤲊	kiji	0
 𧐯	kiji	0
+𪽓	kiji	0
 𤴐	kijk	0
 𦉩	kijk	0
 㨼	kijm	4410
@@ -47445,6 +49270,7 @@ encoder:
 𤲈	kijr	0
 𤲡	kijr	0
 𪅅	kijr	0
+𪽥	kiju	0
 䌎	kijz	5390
 𤳏	kika	0
 壘	kikb	3580000
@@ -47478,6 +49304,7 @@ encoder:
 曥	kikl	116000
 𡾔	kikl	0
 𥃇	kikl	0
+𪽤	kikl	0
 㽮	kikm	4740
 𣀡	kikm	0
 𣰭	kikm	0
@@ -47496,6 +49323,7 @@ encoder:
 𢣲	kiky	0
 𤲶	kiky	0
 𨞽	kiky	0
+𪟧	kiky	0
 㽢	kikz	4470
 纍	kikz	1080000
 𤳍	kikz	0
@@ -47511,6 +49339,7 @@ encoder:
 𧵗	kilo	0
 䴑	kilr	3960
 申购	kilr	4180000
+𪽔	kilr	0
 𤲳	kilz	0
 㽚	kimb	4010
 𤰼	kimb	0
@@ -47533,6 +49362,7 @@ encoder:
 㽯	kinl	4500
 𤳬	kinl	0
 申奥	kinu	1660000
+𪽢	kinu	0
 𤰽	kinx	0
 田鼠	kinz	396000
 𤱝	kiob	0
@@ -47560,6 +49390,7 @@ encoder:
 𤲻	kiou	0
 𤳒	kiou	0
 申令	kiow	33900
+𪽏	kiow	0
 田径	kiox	4630000
 𤰯	kiox	0
 𤰪	kioy	0
@@ -47573,6 +49404,9 @@ encoder:
 𤳚	kiqd	0
 𤱧	kiqf	0
 𠠩	kiqk	0
+𪽇	kiqy	0
+𫑤	kiqy	0
+𪽘	kirb	0
 𠨃	kiri	0
 𧖈	kiri	0
 㽛	kirj	4340
@@ -47585,6 +49419,7 @@ encoder:
 𪉀	kirk	0
 疄	kirm	589000
 𤳩	kirm	0
+𪽑	kirm	0
 畼	kiro	134000
 𤰿	kiro	0
 𤳈	kiro	0
@@ -47606,6 +49441,7 @@ encoder:
 𤳽	kisi	0
 由衷	kisj	5190000
 盢	kisl	205000
+𪽌	kiso	0
 申诉	kisp	14600000
 㽘	kisq	4210
 甲亢	kisq	3140000
@@ -47625,6 +49461,7 @@ encoder:
 𤱦	kiur	0
 𤲩	kiuu	0
 甲烷	kiuw	1510000
+𫆿	kiuw	0
 𤲨	kiuy	0
 塁	kivb	1820000
 𤱩	kivr	0
@@ -47643,6 +49480,7 @@ encoder:
 𤲏	kiwq	0
 申冤	kiwr	523000
 𪃄	kiwr	0
+𫆿	kiwu	0
 𨜐	kiwy	0
 思	kiwz	179000000
 疉	kiwz	81300
@@ -47666,7 +49504,9 @@ encoder:
 㽖	kiym	4390
 男	kiym	516000000
 𣋭	kiym	0
+𪟦	kiyn	0
 申办	kiyo	4440000
+𪽈	kiyo	0
 𤮉	kiys	0
 𤲹	kiyt	0
 𢣢	kiyy	0
@@ -47678,6 +49518,7 @@ encoder:
 𩌺	kize	0
 𤲺	kizg	0
 𩕃	kizg	0
+𪽦	kizh	0
 㚻	kizm	3690
 𤲼	kizm	0
 𤴏	kizn	0
@@ -47685,12 +49526,14 @@ encoder:
 𤰵	kizo	0
 㽙	kizr	4780
 𤲋	kizr	0
+𪽒	kizr	0
 𤰜	kizs	0
 甲级	kizy	4150000
 𤱎	kizy	0
 㽧	kizz	4650
 𤱟	kizz	0
 冔	kjad	43500
+𫀝	kjbb	0
 曮	kjcm	30800
 𣆉	kjed	0
 𢿘	kjix	0
@@ -47746,6 +49589,7 @@ encoder:
 𠦤	kked	0
 曲直	kkel	1430000
 𣌝	kker	0
+𪱆	kker	0
 晃荡	kkev	1280000
 晶莹	kkew	13800000
 𢻅	kkex	0
@@ -47754,6 +49598,7 @@ encoder:
 显露	kkfj	9730000
 晶析	kkfp	62700
 显要	kkfv	673000
+𪱘	kkfz	0
 𣌹	kkga	0
 農	kkgh	17400000
 𣊐	kkgh	0
@@ -47786,6 +49631,7 @@ encoder:
 𣋏	kkkg	0
 𣊫	kkkk	0
 𣊭	kkkk	0
+𪱈	kkkk	0
 曐	kkkm	95400
 𣌱	kkkm	0
 显影	kkks	775000
@@ -47827,7 +49673,9 @@ encoder:
 晹	kkro	105000
 暘	kkro	1370000
 𣣘	kkro	0
+𪴯	kkro	0
 𣈀	kkrr	0
+𪰺	kkrr	0
 暍	kkry	203000
 艶	kkry	6590000
 𪂇	kkrz	0
@@ -47848,6 +49696,7 @@ encoder:
 𤒍	kkuu	0
 豑	kkuy	25300
 鄷	kkuy	29300
+𪩰	kkuy	0
 昌江	kkvb	514000
 曲江	kkvb	1160000
 曲酒	kkvf	594000
@@ -47886,6 +49735,7 @@ encoder:
 晪	kleo	468000
 冒雨	klfv	1760000
 映	klgd	44800000
+𪰔	klgd	0
 𣉗	klgl	0
 𥝂	klgy	0
 𠠡	klik	0
@@ -47976,6 +49826,7 @@ encoder:
 𣈨	kmae	0
 昨天	kmag	112000000
 临武	kmah	335000
+𪱊	kmaj	0
 临夏	kman	2110000
 临死	kmar	3690000
 监考	kmba	1860000
@@ -47992,6 +49843,7 @@ encoder:
 星球	kmcd	29200000
 省长	kmch	10100000
 监理	kmck	14400000
+𪻹	kmcs	0
 监事	kmdj	2880000
 省事	kmdj	6820000
 劣势	kmdq	5070000
@@ -48036,11 +49888,13 @@ encoder:
 省略	kmkr	105000000
 鉴赏	kmkw	14200000
 㫼	kmlk	3950
+𪰮	kmlk	0
 省内	kmlo	14600000
 少见	kmlr	9520000
 𧡶	kmlr	0
 临县	kmlz	406000
 劣等	kmmb	3080000
+𪰟	kmmb	0
 𣉧	kmmg	0
 𣌜	kmmi	0
 劣种	kmmj	48600
@@ -48064,6 +49918,7 @@ encoder:
 劣质	kmpe	5430000
 𣌌	kmpg	0
 临猗	kmqg	761000
+𪱎	kmqk	0
 临朐	kmqr	1200000
 监狱	kmqs	21800000
 少儿	kmrd	30700000
@@ -48118,12 +49973,14 @@ encoder:
 临了	kmyv	357000
 劣绅	kmzk	199000
 少女	kmzm	218000000
+𪱃	kmzm	0
 临终	kmzr	3290000
 晦	kmzy	2670000
 省级	kmzy	20600000
 𣉃	knaz	0
 𣋌	knbz	0
 𣋓	knbz	0
+𪰴	kncq	0
 𣈢	kned	0
 𣊊	knfa	0
 暤	knge	95500
@@ -48137,10 +49994,12 @@ encoder:
 𣆿	knrd	0
 晔	knre	1870000
 𣈙	knrk	0
+𪱔	knrl	0
 曒	knsm	30100
 𣌻	knuf	0
 暭	knve	59300
 曍	knve	23100
+𪱖	knxg	0
 㬋	knxm	4010
 𣉲	knxs	0
 	koaa	0
@@ -48278,6 +50137,7 @@ encoder:
 𣕇	kokf	0
 𠒼	kokg	0
 𠓉	kokg	0
+𪨆	kokh	0
 虩	koki	41300
 𧈅	koki	0
 𧒾	koki	0
@@ -48290,6 +50150,7 @@ encoder:
 揱	kokm	79500
 𡭣	kokm	0
 𡮏	kokm	0
+𪞃	kokm	0
 𠓃	kokn	0
 黋	koko	16500
 㼕	kokp	3930
@@ -48310,6 +50171,7 @@ encoder:
 𠝿	kolk	0
 𣋘	kolk	0
 䚇	koll	3770
+𪨤	koll	0
 敞	kolm	5370000
 𨿰	koln	0
 𩀯	koln	0
@@ -48344,6 +50206,7 @@ encoder:
 毟	komm	152000
 氅	komm	589000
 𦦢	komn	0
+𪨅	komn	0
 䲵	komr	4110
 𣢒	komr	0
 𩵮	komr	0
@@ -48359,13 +50222,16 @@ encoder:
 雀	koni	18200000
 𨾳	koni	0
 𡮂	konk	0
+𪾻	konl	0
 小偷	kono	23000000
 㝸	konr	4170
 𪅓	konr	0
 𤍳	konu	0
 𪕗	konz	0
 小街	koob	1650000
+𪰦	koob	0
 小人	kood	16500000
+𪨃	kooe	0
 𠣇	koof	0
 暰	kooi	88300
 𣋽	kook	0
@@ -48396,6 +50262,7 @@ encoder:
 𨛍	koqy	0
 𡜽	koqz	0
 小儿	kord	22200000
+𪞀	kori	0
 嘗	kork	3150000
 𠓑	kork	0
 𡮀	korl	0
@@ -48453,6 +50320,7 @@ encoder:
 辉	kowh	43700000
 䟫	kowj	3320
 𡭵	kowk	0
+𫆙	kowq	0
 小农	kowr	2090000
 𡭠	kowr	0
 𤇑	kowu	0
@@ -48467,17 +50335,20 @@ encoder:
 𡙪	koxg	0
 𢦢	koxh	0
 晗	koxj	1960000
+𪰻	koxj	0
 㓥	koxk	3820
 𡮷	koxl	0
 𡭩	koxo	0
 𠓇	koxq	0
 小鸡	koxr	5460000
 𣅝	koxs	0
+𪞆	koxu	0
 𡮬	koxw	0
 𡮮	koxw	0
 昐	koyd	64500
 𣌥	koyd	0
 小巴	koyi	1790000
+𪨄	koyl	0
 耀	koyn	33000000
 𦒉	koyn	0
 小队	koyo	3770000
@@ -48505,6 +50376,7 @@ encoder:
 昖	kozs	47400
 𡭲	kozz	0
 𡮍	kozz	0
+𪨀	kozz	0
 暖壶	kpbw	212000
 𧂓	kpeh	0
 暚	kpez	52800
@@ -48521,6 +50393,7 @@ encoder:
 𧞈	kpsr	0
 暖流	kpvs	1900000
 曖	kpwr	907000
+𪰭	kpxb	0
 㬭	kpxd	4200
 㫹	kpxp	3980
 昄	kpxs	68800
@@ -48533,6 +50406,7 @@ encoder:
 𣆎	kqbi	0
 明示	kqbk	5930000
 𣋐	kqbm	0
+𪱂	kqbm	0
 𪒞	kqbu	0
 明理	kqck	1110000
 明珠	kqcm	15900000
@@ -48650,14 +50524,18 @@ encoder:
 略图	krjr	6180000
 煦	krju	2230000
 𤋗	krju	0
+𪱁	krkb	0
 㓭	krkd	4170
 昆明	krkq	52200000
 晩	krkr	13900000
+𪹕	krku	0
 㬇	krlg	4340
 昆山	krll	11800000
 𢒠	krlp	0
+𪱏	krlr	0
 易县	krlz	530000
 曻	krmb	47300
+𪰠	krmb	0
 易手	krmd	1740000
 毼	krmh	57900
 𪙶	krmi	0
@@ -48704,6 +50582,7 @@ encoder:
 鶡	krrz	52900
 鹖	krrz	57500
 𣉵	krrz	0
+𫛂	krrz	0
 晚熟	krsj	541000
 𣍊	krst	0
 㬗	krsu	3720
@@ -48735,7 +50614,9 @@ encoder:
 景泰	ksck	831000
 暗探	ksdw	199000
 暗藏	kseh	4850000
+𪫉	ksep	0
 曩	kser	1420000
+𪱒	kser	0
 𣋩	ksfj	0
 暗想	ksfl	2320000
 影碟	ksge	5550000
@@ -48772,6 +50653,7 @@ encoder:
 𣋚	kskr	0
 𪆣	kskr	0
 暗暗	ksks	19800000
+𪱍	kskw	0
 景山	ksll	1720000
 𡦩	ksly	0
 景县	kslz	431000
@@ -48840,7 +50722,9 @@ encoder:
 昡	kszz	58700
 𣆂	kszz	0
 旷工	ktbi	471000
+𪰍	kted	0
 𣊍	ktff	0
+𪰽	ktfk	0
 旷	ktga	3100000
 曠	ktga	1870000
 𣈔	ktij	0
@@ -48850,6 +50734,7 @@ encoder:
 𣌫	ktrr	0
 旷课	ktsk	837000
 𣋳	ktuo	0
+𪰼	ktxj	0
 昿	ktzs	53000
 𣋟	ktzz	0
 曦	kuaz	5840000
@@ -48879,7 +50764,9 @@ encoder:
 黹	kukl	231000
 业界	kuko	109000000
 𣤞	kukr	0
+𪴨	kuku	0
 黼	kulf	378000
+𪩾	kulf	0
 㬝	kulk	4240
 黹	kulk	231000
 𣉼	kulk	0
@@ -48909,6 +50796,7 @@ encoder:
 業	kuuc	93900000
 菐	kuuc	125000
 對	kuud	187000000
+𪱋	kuuj	0
 𢄁	kuul	0
 㲫	kuum	3920
 晱	kuuo	89500
@@ -48917,11 +50805,14 @@ encoder:
 䴆	kuur	4110
 𣊞	kuur	0
 𤎀	kuuu	0
+𪱓	kuux	0
 𣋥	kuuy	0
 𨞊	kuuy	0
 凿	kuuz	7060000
 䝉	kuwg	5780
 𪓎	kuwl	0
+𪰨	kuwm	0
+𪱌	kuwy	0
 黻	kuxs	393000
 邺	kuya	676000
 㷖	kuyj	4020
@@ -48942,6 +50833,7 @@ encoder:
 水土	kvba	7650000
 水城	kvbh	3800000
 水域	kvbh	5400000
+𪱅	kvbm	0
 水井	kvbn	2710000
 水塘	kvbt	2430000
 水壶	kvbw	4500000
@@ -49006,6 +50898,8 @@ encoder:
 水网	kvlo	1890000
 䳤	kvlr	4340
 𪂟	kvlr	0
+𪶂	kvlr	0
+𫛮	kvlr	0
 水牛	kvmb	6010000
 𡐞	kvmb	0
 𦗥	kvmc	0
@@ -49032,6 +50926,7 @@ encoder:
 鱉	kvmr	404000
 鳖	kvmr	4820000
 鷩	kvmr	44100
+𫜁	kvmr	0
 𣁢	kvms	0
 𤎨	kvmu	0
 憋	kvmw	11500000
@@ -49048,6 +50943,7 @@ encoder:
 㳫	kvnb	4310
 𣹛	kvnc	0
 𣌮	kvnd	0
+𪰢	kvnd	0
 𣻤	kvnf	0
 𣹳	kvnk	0
 水仙	kvnl	4900000
@@ -49062,6 +50958,7 @@ encoder:
 水饺	kvos	1290000
 是个	kvov	133000000
 水分	kvoy	20100000
+𪵮	kvpd	0
 水质	kvpe	7930000
 水银	kvpx	1570000
 𣱻	kvqd	0
@@ -49071,6 +50968,7 @@ encoder:
 晁	kvrd	2130000
 水解	kvrl	2190000
 斃	kvrr	2740000
+𪵼	kvry	0
 𩾼	kvrz	0
 𧩁	kvsk	0
 水产	kvsm	19200000
@@ -49108,6 +51006,7 @@ encoder:
 𣍒	kvzb	0
 水线	kvzh	519000
 凼	kvzi	695000
+𪰤	kvzm	0
 是以	kvzo	62400000
 水能	kvzq	1710000
 𠒳	kvzr	0
@@ -49140,6 +51039,7 @@ encoder:
 𣉐	kwfs	0
 常有	kwgq	7960000
 常态	kwgs	2590000
+𪰧	kwgz	0
 晕	kwhe	94900000
 晖	kwhe	9930000
 党龄	kwio	362000
@@ -49157,6 +51057,7 @@ encoder:
 曢	kwkk	1290000
 𣋪	kwkl	0
 𣊇	kwko	0
+𪱄	kwko	0
 常常	kwkw	61800000
 𤲥	kwlb	0
 𣆹	kwlc	0
@@ -49242,6 +51143,7 @@ encoder:
 思维	kwzn	39900000
 鷃	kwzr	55300
 党纪	kwzy	3830000
+𫑦	kwzy	0
 思乡	kwzz	1470000
 归于	kxad	5510000
 当天	kxag	34200000
@@ -49295,6 +51197,7 @@ encoder:
 曃	kxkw	23900
 当归	kxkx	4050000
 紧紧	kxkx	31500000
+𪰵	kxky	0
 紧盯	kxla	3930000
 归置	kxle	93300
 归罪	kxlk	653000
@@ -49408,6 +51311,7 @@ encoder:
 昲	kynd	45700
 照射	kynd	9730000
 曊	kynl	31300
+𪰶	kynl	0
 邮件	kynm	689000000
 照片	kynx	197000000
 照会	kyob	12300000
@@ -49438,6 +51342,7 @@ encoder:
 昭通	kywx	2050000
 畅通	kywx	12400000
 𣇡	kywz	0
+𪰷	kyxb	0
 男双	kyxx	466000
 邮局	kyxy	50800000
 男子	kyya	128000000
@@ -49450,6 +51355,7 @@ encoder:
 男孩	kyys	49900000
 𤭼	kyys	0
 𦐇	kyyt	0
+𪰣	kyyt	0
 遢	kyyw	3960000
 翡翠	kyyy	16800000
 邮戳	kyyy	973000
@@ -49488,6 +51394,7 @@ encoder:
 电厂	kzgg	5810000
 𣌲	kzgi	0
 𧖙	kzgi	0
+𫎥	kzgl	0
 𩒳	kzgo	0
 𣈬	kzgq	0
 𣈚	kzgs	0
@@ -49529,6 +51436,7 @@ encoder:
 电脑	kzqs	407000000
 累犯	kzqy	360000
 𣅏	kzrd	0
+𪝿	kzrd	0
 电解	kzrl	5060000
 𣆄	kzro	0
 䳛	kzrz	3450
@@ -49622,6 +51530,7 @@ encoder:
 睫	laxi	2960000
 目录	laxk	197000000
 赋予	laxx	17300000
+𪾟	laza	0
 𥆆	lazn	0
 眄	lazy	313000
 𥄆	lazz	0
@@ -49661,6 +51570,7 @@ encoder:
 周围	lbjb	59500000
 𥌆	lbjd	0
 赌咒	lbjj	365000
+𪾼	lbju	0
 周日	lbka	18400000
 𩔠	lbkg	0
 𩴈	lbkn	0
@@ -49805,6 +51715,7 @@ encoder:
 𣌧	ldak	0
 𡸭	ldal	0
 𧷅	ldal	0
+𫆺	ldal	0
 㒷	ldao	4270
 𦋭	ldao	0
 𠕔	ldaq	0
@@ -49852,6 +51763,7 @@ encoder:
 𦌎	ldeb	0
 𦊖	ldej	0
 𦊟	ldej	0
+𪞎	ldej	0
 刪	ldek	7030000
 𣌧	ldek	0
 𦋘	ldel	0
@@ -49859,12 +51771,14 @@ encoder:
 典	ldeo	69400000
 𦍅	ldeo	0
 同期	ldeq	31400000
+𫆸	ldfd	0
 𦋗	ldff	0
 同样	ldfu	112000000
 𤑇	ldfu	0
 财权	ldfx	481000
 𩢥	ldgc	0
 央	ldgd	42100000
+𫊭	ldgi	0
 𦋑	ldgj	0
 盎	ldgl	2820000
 𡘦	ldgl	0
@@ -49877,6 +51791,7 @@ encoder:
 𢘲	ldgw	0
 𪓛	ldgw	0
 㿮	ldgx	6820
+𫆫	ldgx	0
 同感	ldha	14600000
 戙	ldhm	1020000
 㢥	ldhs	3980
@@ -49909,6 +51824,7 @@ encoder:
 鵰	ldjr	1170000
 𦍃	ldjr	0
 𫜸	ldjr	0
+𫛲	ldjr	0
 𧨣	ldjs	0
 週	ldjw	117000000
 𠕡	ldjw	0
@@ -49934,6 +51850,7 @@ encoder:
 𦋚	ldke	0
 𦟦	ldkg	0
 𦙧	ldkm	0
+𪮚	ldkm	0
 𪎼	ldko	0
 𪏎	ldko	0
 同盟	ldkq	27700000
@@ -49946,6 +51863,7 @@ encoder:
 𦌌	ldkz	0
 𦌑	ldkz	0
 𦜽	ldkz	0
+𫜳	ldkz	0
 𦊕	ldlc	0
 𦊨	ldlc	0
 𦊩	ldlc	0
@@ -49989,6 +51907,7 @@ encoder:
 㕯	ldoj	3820
 冏	ldoj	602000
 𣇺	ldok	0
+𪧿	ldok	0
 覥	ldol	29800
 觍	ldol	44600
 𡶬	ldol	0
@@ -50088,6 +52007,7 @@ encoder:
 𦌓	ldum	0
 𦌐	ldun	0
 罔	ldus	2860000
+𫆭	lduw	0
 𦝘	lduy	0
 𠕏	lduz	0
 财源	ldvg	6390000
@@ -50103,6 +52023,7 @@ encoder:
 𦡝	ldwr	0
 同道	ldwu	3330000
 财迷	ldwu	635000
+𫆭	ldwu	0
 𪓙	ldwx	0
 𢘖	ldwy	0
 𦊦	ldwy	0
@@ -50119,6 +52040,7 @@ encoder:
 同屋	ldxh	668000
 羀	ldxk	45300
 𦋔	ldxk	0
+𫆜	ldxr	0
 𠕀	ldxs	0
 𠬸	ldxs	0
 𡱸	ldxs	0
@@ -50127,6 +52049,7 @@ encoder:
 𥀙	ldxx	0
 𦉳	ldxx	0
 𦋖	ldxx	0
+𫅆	ldxz	0
 𦊞	ldyh	0
 𦙢	ldyi	0
 财力	ldym	7120000
@@ -50212,6 +52135,7 @@ encoder:
 瞄准	letn	13100000
 𥃲	levv	0
 矒	lewl	65600
+𪾹	lewl	0
 𥌋	lewr	0
 典礼	lewz	10600000
 𥄏	lexs	0
@@ -50317,6 +52241,7 @@ encoder:
 䀙	lhyd	6130
 𥊱	lhyl	0
 盹	lhzi	1190000
+𪩹	liac	0
 帲	liae	42400
 𢁗	liae	0
 帓	liaf	104000
@@ -50329,6 +52254,7 @@ encoder:
 帢	liaj	96100
 贴画	liak	455000
 帞	lian	192000
+𪩻	lian	0
 𢄅	liau	0
 𢁮	liax	0
 㡢	liay	20900
@@ -50349,6 +52275,7 @@ encoder:
 帏	liby	607000
 㡁	libz	4600
 𢁢	libz	0
+𪩿	libz	0
 帱	licd	86200
 𢁚	licd	0
 𢃈	lice	0
@@ -50374,6 +52301,7 @@ encoder:
 㡒	liel	3910
 幩	liel	38000
 𢃜	liel	0
+𪩸	liel	0
 贴花	lien	532000
 𢂔	lieo	0
 𢂾	lies	0
@@ -50449,6 +52377,7 @@ encoder:
 幝	like	36000
 𢅀	like	0
 𥇍	like	0
+𪩷	like	0
 𢃦	likf	0
 幌	likg	2330000
 幙	likg	183000
@@ -50639,6 +52568,7 @@ encoder:
 贴边	liwy	161000
 𢃙	liwy	0
 贴心	liwz	20000000
+𪩴	lixd	0
 𢁪	lixg	0
 𢾔	lixg	0
 幄	lixh	356000
@@ -50646,9 +52576,11 @@ encoder:
 𢅟	lixi	0
 𥈤	lixi	0
 𢂽	lixj	0
+𪩳	lixj	0
 𢃼	lixl	0
 𢄟	lixl	0
 帿	lixm	89300
+𪾦	lixm	0
 帗	lixs	559000
 𠬥	lixs	0
 𥄎	lixs	238
@@ -50665,11 +52597,13 @@ encoder:
 㼙	liys	4320
 𢁡	liys	0
 𥌯	liys	0
+𪩼	liyu	0
 贴己	liyy	40200
 𢂐	liyy	0
 𢄒	liyy	0
 𢁠	liyz	0
 幉	lizf	536000
+𪩽	lizg	0
 𥍗	lizi	0
 𢄍	lizl	0
 𢅤	lizl	0
@@ -50688,8 +52622,10 @@ encoder:
 瞆	ljal	30000
 瞶	ljal	831000
 𥆰	ljan	0
+𪾥	ljaz	0
 𠹬	ljbr	0
 𥈭	ljbz	0
+𪾨	ljbz	0
 䁒	ljce	5920
 𥍓	ljcm	0
 䫚	ljgo	3360
@@ -50703,8 +52639,10 @@ encoder:
 矂	ljjf	422000
 剮	ljkd	517000
 𠛰	ljkd	0
+𫑌	ljkw	0
 䁚	ljlo	5610
 𥇘	ljmf	0
+𫑑	ljmw	0
 𠕩	ljne	0
 𠧅	ljne	0
 𥆻	ljnj	0
@@ -50713,6 +52651,7 @@ encoder:
 𢢸	ljrw	0
 𥆽	ljsx	0
 𣂄	ljte	0
+𪬋	ljwz	0
 𥇂	ljyk	0
 罒	lkaa	1270000
 䵦	lkad	4870
@@ -50745,8 +52684,10 @@ encoder:
 𪒩	lkak	0
 四百	lkan	7210000
 睤	lkan	26200
+𫅈	lkao	0
 刚烈	lkar	951000
 四列	lkar	413000
+𪾖	lkar	0
 四平	lkau	5490000
 𥁔	lkaw	0
 𦊃	lkax	0
@@ -50765,6 +52706,7 @@ encoder:
 𪒖	lkbb	0
 罻	lkbd	82900
 𡭀	lkbd	0
+𫅌	lkbd	0
 罫	lkbi	377000
 黠	lkbj	867000
 𪒧	lkbj	0
@@ -50785,6 +52727,7 @@ encoder:
 𪑅	lkbz	0
 𪒝	lkbz	0
 𪓂	lkbz	0
+𫅀	lkbz	0
 𪒑	lkcl	0
 𪒆	lkcm	0
 𪒠	lkcm	0
@@ -50822,6 +52765,7 @@ encoder:
 𢻧	lkex	0
 𦌖	lkex	0
 𪔒	lkex	0
+𪯇	lkex	0
 黮	lkez	73800
 䍒	lkfa	6770
 𦊚	lkfa	0
@@ -50834,6 +52778,7 @@ encoder:
 𦊵	lkfq	0
 四楼	lkfu	5980000
 𪒜	lkfw	0
+𫅉	lkfy	0
 𦌋	lkgb	0
 四大	lkgd	48500000
 𦉼	lkgd	0
@@ -50910,6 +52855,7 @@ encoder:
 𥊼	lkjh	0
 𦌭	lkji	0
 𦍈	lkji	0
+𫅊	lkjj	0
 黥	lkjk	408000
 𥋓	lkjk	0
 𥋇	lkjm	0
@@ -50977,6 +52923,7 @@ encoder:
 𦋸	lkkz	0
 𦌁	lkkz	0
 𪒎	lkkz	0
+𫜙	lkkz	0
 四周	lklb	28200000
 罝	lklc	103000
 𦊤	lkld	0
@@ -50993,6 +52940,8 @@ encoder:
 罾	lklk	171000
 𡮨	lklk	0
 𪒟	lklk	0
+𫅋	lklk	0
+𫕾	lklk	0
 䚑	lkll	3630
 黷	lkll	97200
 𡶩	lkll	0
@@ -51025,13 +52974,17 @@ encoder:
 𪓀	lkmi	0
 𪑜	lkmj	0
 𪒦	lkml	0
+𪾜	lkml	0
+𪾱	lkml	0
 𦋋	lkmm	0
 𩙽	lkmn	0
+𫜛	lkmn	0
 𪃦	lkmr	0
 𪃧	lkmr	0
 𪑄	lkmr	0
 𪒓	lkmr	0
 𫜿	lkmr	0
+𫛹	lkmr	0
 眾	lkms	14300000
 四季	lkmy	39700000
 𦊑	lkmy	0
@@ -51049,6 +53002,7 @@ encoder:
 四份	lkno	832000
 四化	lknr	1230000
 𪈰	lknr	0
+𫅁	lknr	0
 四倍	lkns	2170000
 罪魁	lknt	4170000
 邏	lknw	351000
@@ -51089,6 +53043,7 @@ encoder:
 𦊓	lkow	0
 𦌣	lkow	0
 𪐸	lkow	0
+𫜚	lkow	0
 四分	lkoy	9950000
 𪑋	lkpd	0
 𪒐	lkpl	0
@@ -51114,6 +53069,7 @@ encoder:
 四处	lkri	21700000
 四外	lkri	382000
 蜀	lkri	65200000
+𫎚	lkri	0
 罪名	lkrj	6660000
 𦊒	lkrj	0
 𦊲	lkrj	0
@@ -51167,6 +53123,8 @@ encoder:
 罸	lksd	117000
 刚毅	lksg	1760000
 𦉾	lksh	0
+𪴾	lksi	0
+𫅍	lksi	0
 罚	lksk	43000000
 罯	lksk	17600
 罰	lksk	10100000
@@ -51176,6 +53134,7 @@ encoder:
 䁿	lksl	6480
 𥊷	lksl	0
 𪑥	lksl	0
+𫅅	lksn	0
 𪒄	lkso	0
 𪐦	lksq	0
 𦌽	lkss	0
@@ -51251,6 +53210,7 @@ encoder:
 𪐩	lkuu	0
 𪑓	lkuu	0
 䵴	lkuw	4910
+𫜞	lkuw	0
 𦋰	lkux	0
 𪑉	lkux	0
 罤	lkuy	36000
@@ -51264,6 +53224,7 @@ encoder:
 䵝	lkuz	4050
 𦅔	lkuz	0
 四海	lkvm	15600000
+𫅄	lkvr	0
 𪑬	lkwa	0
 罪过	lkwd	5640000
 𪒴	lkwh	0
@@ -51321,6 +53282,8 @@ encoder:
 𡤔	lkzj	0
 𦌟	lkzk	0
 𪑔	lkzk	0
+𪽝	lkzk	0
+𫕾	lkzk	0
 𦋽	lkzl	0
 瞜	lkzm	142000
 䍦	lkzn	4150
@@ -51361,6 +53324,8 @@ encoder:
 𡴵	llai	0
 𡴶	llai	0
 𡶛	llai	0
+𪨢	llai	0
+𪩃	llai	0
 㞹	llaj	4130
 㟃	llaj	4330
 㟢	llaj	4870
@@ -51396,6 +53361,7 @@ encoder:
 𡷧	llax	0
 𡷴	llax	0
 𡼘	llax	0
+𪨺	llax	0
 𡥏	llay	0
 㞻	llaz	3710
 崴	llaz	4000000
@@ -51415,6 +53381,7 @@ encoder:
 嵵	llbd	78100
 嶎	llbd	271000
 𡻄	llbd	0
+𪩙	llbd	0
 嶢	llbg	90400
 嶤	llbg	34500
 𡼔	llbg	0
@@ -51450,6 +53417,7 @@ encoder:
 𡷗	llbr	0
 𣣗	llbr	0
 𪅁	llbr	0
+𫚽	llbr	0
 䁫	llbu	5790
 䁺	llbu	6080
 峡	llbu	9010000
@@ -51498,8 +53466,10 @@ encoder:
 崝	llcq	1160000
 𡸺	llcq	0
 㠡	llcr	5310
+𫛃	llcr	0
 𡸘	llcx	0
 𡸨	llcx	0
+𪩝	llcx	0
 𡷝	llcz	0
 㟛	llde	3780
 𡺵	lldm	0
@@ -51513,10 +53483,12 @@ encoder:
 𡶑	lleb	0
 𡻞	lleb	0
 𡻸	lleb	0
+𪩓	lleb	0
 𡸷	llec	0
 𡽼	llef	0
 𡸳	lleg	0
 𩓤	lleg	0
+𪩔	lleh	0
 岵	llej	169000
 崌	llej	744000
 崓	llej	52900
@@ -51531,10 +53503,12 @@ encoder:
 𡸜	llel	0
 𡸽	llel	0
 𡼝	llel	0
+𪩂	llel	0
 嶻	llen	24600
 𡽱	llen	0
 睓	lleo	24000
 𡶵	lleo	0
+𪩗	llep	0
 𡼼	lleq	0
 㠌	ller	4850
 㠤	ller	5050
@@ -51550,12 +53524,15 @@ encoder:
 嵁	llez	684000
 𡺯	llez	0
 𦉍	llez	0
+𪨲	llez	0
 𡽒	llfa	0
 㟽	llfb	3930
 峬	llfb	28900
 山村	llfd	8480000
 嶟	llfd	28000
 𡷾	llfd	0
+𪩉	llfd	0
+𪩍	llfd	0
 㟳	llff	3970
 山林	llff	7500000
 山麓	llff	2800000
@@ -51593,6 +53570,7 @@ encoder:
 𡊽	llgb	0
 𡶂	llgb	0
 𡾑	llgb	0
+𪨼	llgb	0
 眏	llgd	164000
 𥈀	llgd	0
 㟸	llge	4160
@@ -51610,6 +53588,7 @@ encoder:
 𡾏	llgg	0
 𡾷	llgg	0
 𡷰	llgh	0
+𪨶	llgh	0
 㞸	llgi	4280
 剬	llgk	407000
 𡾡	llgk	0
@@ -51618,6 +53597,7 @@ encoder:
 耑	llgl	133000
 𡼴	llgl	0
 𩨮	llgl	0
+𪨻	llgl	0
 㟌	llgm	3980
 𡶨	llgm	0
 𡺝	llgm	0
@@ -51651,6 +53631,7 @@ encoder:
 𡻑	llgs	0
 𡽣	llgs	0
 𤟮	llgs	0
+𪩘	llgs	0
 𦓣	llgt	0
 炭	llgu	19400000
 𥋭	llgu	0
@@ -51674,6 +53655,7 @@ encoder:
 㟞	llhh	3680
 嶘	llhh	20200
 𡸚	llhh	0
+𪩞	llhh	0
 岈	llhi	761000
 𡵥	llhi	0
 𡶅	llhj	0
@@ -51684,6 +53666,8 @@ encoder:
 𡶔	llhm	0
 𡶙	llhm	0
 𢧮	llhm	0
+𪩈	llhm	0
+𪭓	llhm	0
 山区	llho	23900000
 岖	llho	225000
 𡼠	llho	0
@@ -51695,6 +53679,7 @@ encoder:
 𡷫	llhy	0
 㞽	llhz	4590
 𡶁	llhz	0
+𪨩	llhz	0
 𣦣	llii	0
 𧔮	llii	0
 岾	llij	61300
@@ -51722,6 +53707,7 @@ encoder:
 𡵊	lliy	0
 𡵋	lliy	0
 𡼕	lliy	0
+𪩆	lliy	0
 山口	llja	58800000
 嶹	lljd	31900
 𡼢	lljd	0
@@ -51782,12 +53768,14 @@ encoder:
 𡽡	lljr	0
 𡿢	lljr	0
 𥌡	lljr	0
+𪨸	lljr	0
 㠔	lljs	4490
 䁗	llju	5560
 嵦	llju	37700
 嶝	llju	236000
 豈	llju	3710000
 𡽍	llju	0
+𪩊	lljw	0
 𡷮	lljx	0
 𡸪	lljx	0
 崞	lljy	146000
@@ -51835,10 +53823,12 @@ encoder:
 𡾍	llkk	0
 𡾪	llkk	0
 𣋎	llkk	0
+𪨰	llkk	0
 㠠	llkl	10100
 𡻾	llkl	0
 𡵯	llkm	0
 𡼧	llkm	0
+𪨷	llkm	0
 峺	llko	59700
 峭	llkq	1790000
 𡹌	llkq	0
@@ -51874,6 +53864,8 @@ encoder:
 𡿔	llkz	0
 𡿜	llkz	0
 𥋁	llkz	0
+𪨿	llkz	0
+𪩑	llkz	0
 𡎨	lllb	0
 𡷌	lllb	0
 𡻉	lllb	0
@@ -51909,6 +53901,7 @@ encoder:
 𡾓	lllk	0
 𡾽	lllk	0
 𡿘	lllk	0
+𪩚	lllk	0
 山岗	llll	843000
 屾	llll	2300000
 岀	llll	1170000
@@ -51927,6 +53920,7 @@ encoder:
 𡻗	lllo	0
 𡽆	lllo	0
 𥋻	lllo	0
+𪨹	lllo	0
 𦞄	lllq	0
 山峰	lllr	5180000
 岘	lllr	571000
@@ -51934,6 +53928,7 @@ encoder:
 𡷹	lllr	0
 𪂓	lllr	0
 𪈥	lllr	0
+𪩠	lllt	0
 𡻋	lllw	0
 𡾢	lllw	0
 𡻩	lllx	0
@@ -51949,6 +53944,7 @@ encoder:
 𡾸	lllz	0
 𥌽	lllz	0
 𥍈	lllz	0
+𪩎	lllz	0
 㞺	llma	3680
 𡵜	llmb	0
 𡾬	llmc	0
@@ -51973,6 +53969,7 @@ encoder:
 峼	llmj	25300
 峲	llmk	37300
 𡸉	llmk	0
+𪨴	llmk	0
 𡺗	llml	0
 𡽳	llml	0
 𡽾	llml	0
@@ -51987,6 +53984,7 @@ encoder:
 𥆹	llms	0
 𡺘	llmu	0
 𡻻	llmu	0
+𪩀	llmu	0
 𡶉	llmw	0
 㟹	llmy	3820
 屹	llmy	1720000
@@ -51997,6 +53995,10 @@ encoder:
 𡸬	llmy	0
 𡺇	llmy	0
 𡼅	llmy	0
+𪨣	llmy	0
+𪨦	llmy	0
+𪨫	llmy	0
+𪩟	llmy	0
 崣	llmz	602000
 𡹜	llmz	0
 𡾥	llmz	0
@@ -52005,6 +54007,7 @@ encoder:
 崲	llnc	734000
 𡻇	llnc	0
 𩧚	llnc	0
+𪩅	llnc	0
 山川	llnd	6190000
 𡵅	llnd	0
 崥	llne	650000
@@ -52088,6 +54091,7 @@ encoder:
 峜	lloi	20600
 嵷	lloi	29600
 嵸	lloi	27600
+𪨳	lloi	0
 峪	lloj	3670000
 嵱	lloj	31700
 𡾰	lloj	0
@@ -52105,6 +54109,7 @@ encoder:
 𡵚	llon	0
 𡸻	llon	0
 𥜺	llon	0
+𪩜	llon	0
 山谷	lloo	8960000
 峧	lloo	32500
 峽	lloo	1430000
@@ -52146,15 +54151,18 @@ encoder:
 𡾴	llor	0
 𡿟	llor	0
 𪌨	llor	0
+𪨧	llor	0
 嶦	llos	27200
 𡶍	llos	0
 𡶖	llos	0
 𡷁	llos	0
 𦓗	llos	0
+𪩒	llos	0
 𡺎	llot	0
 𡼶	llou	0
 岭	llow	27200000
 岺	llow	67600
+𪨺	llow	0
 㟟	lloy	3960
 岎	lloy	26100
 𠨤	lloy	0
@@ -52163,6 +54171,7 @@ encoder:
 𡸐	lloy	0
 𡼌	lloy	0
 𢁃	lloy	0
+𪩋	lloy	0
 㟣	lloz	4230
 崧	lloz	1190000
 𡵴	lloz	0
@@ -52192,6 +54201,7 @@ encoder:
 𡸵	llpx	0
 㟊	llpy	4280
 㟎	llpz	4120
+𪨪	llqa	0
 山脚	llqb	2850000
 㞦	llqd	3880
 㞩	llqd	3600
@@ -52219,6 +54229,7 @@ encoder:
 𡴿	llqy	0
 𡺮	llqy	0
 𡻰	llrb	0
+𪨽	llrb	0
 峯	llrc	1410000
 峰	llrc	98100000
 𡷄	llrc	0
@@ -52230,6 +54241,7 @@ encoder:
 㟆	llre	3920
 𡸝	llre	0
 𡸇	llrf	0
+𪩌	llrg	0
 㞴	llrh	4340
 𥋛	llri	0
 㟯	llrj	4060
@@ -52239,6 +54251,7 @@ encoder:
 𡷂	llrj	0
 𡺀	llrj	0
 𡽘	llrj	0
+𪩄	llrj	0
 㟜	llrk	3790
 刿	llrk	256000
 峋	llrk	105000
@@ -52319,6 +54332,7 @@ encoder:
 𡵀	llsh	0
 巃	llsi	80300
 巄	llsi	75800
+𪨨	llsi	0
 㟝	llsj	3730
 𡻓	llsj	0
 峕	llsk	25500
@@ -52366,6 +54380,7 @@ encoder:
 嵊	lltr	847000
 𡾌	lltu	0
 𡼂	lltx	0
+𪩏	lltx	0
 䁼	llub	6070
 嵯	llub	307000
 嵳	llub	32000
@@ -52380,6 +54395,7 @@ encoder:
 𡾛	llue	0
 崷	lluf	759000
 𡺚	lluf	0
+𫂳	lluf	0
 㠗	llug	4190
 嵄	llug	59000
 顗	llug	205000
@@ -52417,12 +54433,14 @@ encoder:
 㟡	lluy	3710
 𡸩	lluy	0
 嵝	lluz	165000
+𪩇	lluz	0
 山河	llva	5460000
 𡷍	llvb	0
 山洪	llve	1420000
 𡼗	llve	0
 𡷉	llvi	0
 山沟	llvr	1370000
+𪨱	llvr	0
 㟈	llvs	4040
 山涧	llvt	987000
 䀠	llvv	9360
@@ -52464,6 +54482,7 @@ encoder:
 㟉	llwm	3930
 𡵘	llwm	0
 𡶮	llwm	0
+𪩐	llwn	0
 岤	llwo	21800
 𡹢	llwp	0
 䳥	llwr	4720
@@ -52476,6 +54495,7 @@ encoder:
 𥌂	llws	0
 𡹨	llwx	0
 𡽑	llwx	0
+𪨾	llwx	0
 㟑	llwy	3630
 崂	llwy	281000
 嶗	llwy	29700
@@ -52562,12 +54582,15 @@ encoder:
 𡴭	llyd	0
 𡴯	llyd	0
 𡸠	llye	0
+𫖮	llyg	0
 岷	llyh	1740000
 𡶗	llyh	0
 岗巴	llyi	103000
 岜	llyi	335000
 𡵟	llyi	0
 𡿖	llyi	0
+𪨥	llyi	0
+𪩛	llyi	0
 岧	llyj	43700
 岹	llyj	26500
 𡶐	llyj	0
@@ -52577,6 +54600,7 @@ encoder:
 𠛕	llyk	0
 𡷘	llyk	0
 觊	llyl	194000
+𪩁	llyl	0
 㞧	llym	3970
 㟼	llym	4060
 㠂	llym	7110
@@ -52587,6 +54611,7 @@ encoder:
 𡸅	llym	0
 𡻎	llym	0
 𡽖	llym	0
+𪾫	llym	0
 㠄	llyn	5860
 㠕	llyn	4070
 岪	llyn	25300
@@ -52596,6 +54621,7 @@ encoder:
 𡽢	llyn	0
 凯	llyq	78000000
 𡿚	llyq	0
+𪩕	llyq	0
 㼘	llys	4290
 㼷	llys	5280
 屻	llys	660000
@@ -52610,6 +54636,7 @@ encoder:
 𤮞	llys	0
 𤮯	llys	0
 𤮰	llys	0
+𪩒	llys	0
 嵶	llyt	37800
 𡺒	llyt	0
 𡷞	llyw	0
@@ -52629,7 +54656,11 @@ encoder:
 𦏿	llyy	0
 𦒀	llyy	0
 𨟎	llyy	0
+𪩖	llyy	0
+𫅥	llyy	0
 𡴰	llyz	0
+𪨭	llyz	0
+𪨮	llyz	0
 乢	llza	56200
 屿	llza	3540000
 𡼺	llzb	0
@@ -52693,7 +54724,9 @@ encoder:
 𡼊	llzz	0
 𡼿	llzz	0
 𡽈	llzz	0
+𪨬	llzz	0
 𥅸	lmai	0
+𪾾	lmaj	0
 败坏	lmbg	4600000
 矄	lmbu	45500
 䀒	lmea	5680
@@ -52713,6 +54746,7 @@ encoder:
 𥊈	lmkf	0
 𥅲	lmko	0
 𥋘	lmkq	0
+𪿄	lmkz	0
 𥅧	lmlk	0
 𥇕	lmlk	0
 峨山	lmll	376000
@@ -52732,6 +54766,7 @@ encoder:
 眣	lmod	49100
 𥌛	lmok	0
 𥃶	lmqd	0
+𪾶	lmrb	0
 巍然	lmrg	1130000
 𥌳	lmrk	0
 𥌇	lmrm	0
@@ -52793,20 +54828,24 @@ encoder:
 瞍	lnxs	114000
 𥅀	lnxt	0
 𥅂	lnyi	0
+𪾷	lnym	0
 𥌝	lnzu	0
 貝	loaa	21100000
 贝	loaa	81800000
 𥊤	load	0
 𧵴	load	0
+𫎏	load	0
 𥄺	loae	0
 内政	loai	4560000
 䀫	loaj	6190
 𧵀	loaj	0
 𧵛	loaj	0
+𫎖	loaj	0
 𧸗	loak	0
 睔	loal	44100
 𧸃	loal	0
 𧸽	loal	0
+𫎕	loal	0
 𥌩	loaw	0
 盻	loaz	161000
 䝽	lobb	3560
@@ -52829,6 +54868,7 @@ encoder:
 賘	lobs	28400
 内地	lobv	40000000
 睑	lobv	1060000
+𫎨	lobv	0
 贝壳	lobw	6310000
 𧷌	lobx	0
 𧷿	loby	0
@@ -52890,9 +54930,11 @@ encoder:
 内存	logi	61100000
 蠈	logi	60400
 䞅	logj	3640
+𫎗	logj	0
 睎	logl	65600
 𥋎	logl	0
 𧶖	logl	0
+𫎦	logm	0
 网页	logo	437000000
 具有	logq	278000000
 内有	logq	11400000
@@ -52952,11 +54994,14 @@ encoder:
 𥌺	lojl	0
 𧹊	lojl	0
 𧶞	lojm	0
+𫎞	lojm	0
 𥇥	lojo	0
 𧵙	lojo	0
 貺	lojr	56800
 贶	lojr	169000
 𥆟	lojr	0
+𫎙	lojr	0
+𪹭	loju	0
 网吧	lojy	41600000
 𧷚	lojz	0
 𥍀	loka	0
@@ -52966,9 +55011,11 @@ encoder:
 則	lokd	84100000
 𡬷	lokd	0
 贉	loke	32600
+𫎫	loke	0
 𧷣	lokf	0
 𧵦	lokg	0
 𧷸	lokg	0
+𫎢	lokg	0
 𧸉	lokh	0
 䞎	lokk	3400
 𧶧	lokk	0
@@ -52995,6 +55042,7 @@ encoder:
 𧵌	lolg	0
 𧶲	lolg	0
 𧹈	lolg	0
+𪥠	lolg	0
 瞺	lolk	39200
 贈	lolk	18600000
 赠	lolk	62800000
@@ -53055,6 +55103,7 @@ encoder:
 𧸜	lomx	0
 䝯	lomy	4320
 𧷆	lomy	0
+𫎐	lomy	0
 𧶅	lomz	0
 网段	lonc	1220000
 𥄍	lond	0
@@ -53074,6 +55123,7 @@ encoder:
 𧸳	loob	0
 賥	looe	115000
 賝	loof	38900
+𫎩	loof	0
 内行	looi	1890000
 瞛	looi	35900
 䀰	looj	7690
@@ -53118,18 +55168,22 @@ encoder:
 𧸳	lorb	0
 𧵄	lorh	0
 内外	lori	68400000
+𫎑	lori	0
 䝭	lorj	3410
 具名	lorj	2490000
 賂	lorj	237000
 赂	lorj	610000
 𧸚	lorj	0
+𫎧	lorj	0
 具备	lork	71600000
 𧵉	lork	0
 𧵣	lork	0
+𫎟	lork	0
 内角	lorl	400000
 𧹏	lorl	0
 𧸍	lorm	0
 𧸮	lorm	0
+𫎝	lorn	0
 賜	loro	5830000
 赐	loro	21800000
 𧶽	loro	0
@@ -53146,6 +55200,7 @@ encoder:
 𧵈	lorz	0
 䝬	losc	3670
 𥆜	losc	0
+𫎪	losf	0
 网站	losi	1530000000
 贚	losi	32300
 内部	losj	133000000
@@ -53163,6 +55218,7 @@ encoder:
 赆	lost	78200
 内详	losu	819000
 𥄯	losx	0
+𫎒	losy	0
 賍	lotb	92400
 赃	lotb	1470000
 𧴼	lote	0
@@ -53200,6 +55256,7 @@ encoder:
 贝宁	lowa	1360000
 贮	lowa	4980000
 𧶺	lowa	0
+𫎓	lowa	0
 内窥	lowb	1040000
 賩	lowb	123000
 𧸵	lowb	0
@@ -53290,6 +55347,7 @@ encoder:
 𥇸	lpll	0
 𥉨	lplr	0
 𥊋	lplr	0
+𪾮	lpmb	0
 贩私	lpmz	188000
 𥉰	lpnb	0
 𥌹	lpnl	0
@@ -53298,6 +55356,7 @@ encoder:
 𥉟	lpqx	0
 眽	lprh	231000
 瞬	lprm	9380000
+𪾯	lpro	0
 𪅚	lprr	0
 瞬间	lptk	56800000
 𥇶	lpvv	0
@@ -53333,6 +55392,7 @@ encoder:
 𧢡	lrcm	0
 䙷	lrds	3500
 䙸	lrds	3700
+𫌢	lrel	0
 𧡝	lreo	0
 𧡉	lrev	0
 𧡷	lrez	0
@@ -53350,6 +55410,7 @@ encoder:
 睌	lrjr	95900
 见图	lrjr	3200000
 𧢊	lrjr	0
+𫌝	lrjr	0
 𥈈	lrju	0
 罗田	lrki	389000
 䀥	lrko	6430
@@ -53385,14 +55446,18 @@ encoder:
 𥋂	lror	0
 瞻	lros	5310000
 𥇰	lrow	0
+𪬊	lrow	0
+𫌧	lrpg	0
 购销	lrpk	7820000
 罗盘	lrpl	1340000
 𧡒	lrpr	0
 𧠘	lrpv	0
 覹	lrqm	30800
+𫌭	lrqm	0
 岁月	lrqv	49800000
 𥆯	lrrb	0
 见外	lrri	1080000
+𫌩	lrrj	0
 罗甸	lrrk	160000
 见解	lrrl	13600000
 𧢤	lrrm	0
@@ -53435,6 +55500,8 @@ encoder:
 觃	lrya	32800
 𥅺	lryi	0
 𥉳	lryk	0
+𫌣	lrzf	0
+𫌜	lrzm	0
 𥌲	lsae	0
 罚款	lsbb	13100000
 赔款	lsbb	1790000
@@ -53460,6 +55527,7 @@ encoder:
 嵩县	lslz	309000
 瞝	lslz	32600
 𥊓	lsmm	0
+𪾰	lsmo	0
 䀮	lsnd	7040
 瞓	lsnd	425000
 赔付	lsnd	4470000
@@ -53498,8 +55566,10 @@ encoder:
 𥊚	ltff	0
 𧡆	ltlr	0
 赃物	ltmr	1100000
+𪿅	ltnr	0
 𥌾	ltnw	0
 𥌬	ltob	0
+𪾪	ltro	0
 𥋨	ltrr	0
 𥌜	ltuo	0
 𥋲	ltux	0
@@ -53518,6 +55588,7 @@ encoder:
 𥌨	lugo	0
 赠品	lujj	8770000
 𥆟	lujr	0
+𪾿	lukk	0
 𥉋	lukv	0
 䁬	lulk	5780
 𥋟	lumh	0
@@ -53589,6 +55660,7 @@ encoder:
 用费	lvyn	424000
 用以	lvzo	9290000
 骬	lwad	20000
+𪾩	lwad	0
 䯎	lwae	3250
 骨干	lwae	30200000
 骭	lwae	71200
@@ -53739,6 +55811,7 @@ encoder:
 𥌷	lwlw	0
 𩪆	lwlw	0
 髃	lwlz	71400
+𪿀	lwlz	0
 崇拜	lwma	19200000
 䯕	lwmb	3310
 𩩙	lwme	0
@@ -53798,6 +55871,7 @@ encoder:
 𩨼	lwpd	0
 𥋺	lwpn	0
 髌	lwpo	348000
+𪾸	lwpo	0
 𩨯	lwps	0
 𩨢	lwpv	0
 𩨩	lwpx	0
@@ -53805,6 +55879,7 @@ encoder:
 𩨺	lwqa	0
 骪	lwqd	19900
 𩨒	lwqd	0
+𫘲	lwqk	0
 骨股	lwqq	21600
 骫	lwqs	45800
 髄	lwqw	835000
@@ -53876,6 +55951,8 @@ encoder:
 𩨭	lwwr	0
 髈	lwws	30700
 崇礼	lwwz	517000
+𫘳	lwxb	0
+𫘴	lwxh	0
 骳	lwxi	64000
 𩩊	lwxj	0
 𩩑	lwxj	0
@@ -53935,6 +56012,7 @@ encoder:
 𥌻	lxfl	0
 䀗	lxgd	5580
 瞩	lxil	584000
+𪾳	lxjm	0
 䁹	lxjs	6180
 眼圈	lxju	7620000
 瞪	lxju	19800000
@@ -53964,9 +56042,11 @@ encoder:
 眼熟	lxsj	2410000
 䁊	lxsl	6130
 𢯲	lxsm	0
+𪾽	lxso	0
 𥄗	lxss	0
 𥄗	lxtd	0
 眼底	lxtr	6730000
+𪾴	lxuf	0
 𤈳	lxuo	0
 眼前	lxuq	53300000
 眼泪	lxvl	49200000
@@ -54060,6 +56140,7 @@ encoder:
 𠟭	lznk	0
 矊	lznl	449000
 鼎	lznx	64400000
+𫜠	lzny	0
 𥊀	lzop	0
 睃	lzor	138000
 悬念	lzos	8930000
@@ -54075,6 +56156,7 @@ encoder:
 𥃤	lzvv	0
 悬空	lzwb	1910000
 贻害	lzwc	627000
+𫜡	lzws	0
 𥆸	lzxg	0
 𪔊	lzxw	0
 𥄉	lzzd	0
@@ -54097,7 +56179,9 @@ encoder:
 筓	maae	32300
 𥏢	maae	0
 𦈨	maae	0
+𫔦	maae	0
 𣔍	maaf	0
+𪥙	maag	0
 𦈢	maai	0
 𦉁	maai	0
 缿	maaj	34700
@@ -54106,6 +56190,8 @@ encoder:
 𥰯	maaj	0
 𠚻	maak	0
 𢆫	maak	0
+𪿊	maak	0
+𪿏	maal	0
 𥏄	maan	0
 𪖬	maan	0
 䍈	maau	4520
@@ -54143,9 +56229,11 @@ encoder:
 𨢮	madf	0
 䵹	madw	4210
 䍋	maeb	3980
+𪿋	maec	0
 午	maed	18800000
 竿	maed	9870000
 𥎧	maed	0
+𫄼	maef	0
 𩑤	maeg	0
 卸载	maeh	9490000
 𦈢	maei	0
@@ -54163,6 +56251,7 @@ encoder:
 𨳱	maex	0
 缶	maez	15400000
 𣫸	maez	0
+𫄾	maez	0
 秤杆	mafa	111000
 缽	mafa	987000
 罇	mafd	39100
@@ -54173,6 +56262,7 @@ encoder:
 𥱄	magi	0
 𦈶	magj	0
 矫	magn	3830000
+𫁲	magr	0
 𥏣	magu	0
 秤砣	magw	135000
 𪓳	magw	0
@@ -54199,6 +56289,7 @@ encoder:
 𦉋	maim	0
 𦉌	maim	0
 𦥲	main	0
+𪩢	main	0
 𩛒	maio	0
 䂑	mair	5020
 欫	mair	17700
@@ -54233,6 +56324,7 @@ encoder:
 𥐓	majn	0
 䇧	majo	3750
 䍉	majo	6290
+𫜈	majo	0
 短跑	majr	995000
 短路	majr	3560000
 𥐐	majr	0
@@ -54263,6 +56355,7 @@ encoder:
 罏	makl	33200
 𣬁	makl	0
 𥏟	makl	0
+𪿉	makm	0
 尓	mako	1350000
 筻	mako	70500
 复	makr	83200000
@@ -54273,6 +56366,7 @@ encoder:
 𥎽	malg	0
 𥫴	mali	0
 矰	malk	79800
+𫂥	mall	0
 𦉎	maln	0
 䇤	malo	4650
 䂓	malr	6120
@@ -54281,7 +56375,9 @@ encoder:
 短短	mama	21900000
 年	mamb	3780000000
 𥏎	mamb	0
+𫄺	mamb	0
 短缺	mame	9590000
+𪿌	mamf	0
 矨	mamg	51000
 竹	mami	95200000
 𥫧	mami	0
@@ -54315,6 +56411,7 @@ encoder:
 𩱢	mana	0
 𥐌	manb	0
 𥬂	mand	0
+𪿎	mand	0
 𥏠	mane	0
 𣜫	manf	0
 雉	mani	2240000
@@ -54354,9 +56451,11 @@ encoder:
 矪	mapy	136000
 𦈴	mapy	0
 𤧧	maqc	0
+𪿐	maqk	0
 䌓	maqz	4730
 𣒧	marf	0
 短处	mari	1280000
+𪟳	mari	0
 𥏍	marj	0
 𥬭	mark	0
 舞	marm	131000000
@@ -54424,6 +56523,7 @@ encoder:
 乞	mayd	5090000
 𨢱	mayf	0
 𩑔	mayg	0
+𫖪	mayg	0
 㐌	mayi	6130
 矧	mayi	506000
 𧆦	mayi	0
@@ -54432,6 +56532,7 @@ encoder:
 刉	mayk	108000
 𥏵	mayk	0
 𦉉	mayk	0
+𪿍	mayk	0
 𧠡	mayl	0
 㩿	maym	4150
 𢼏	maym	0
@@ -54478,6 +56579,7 @@ encoder:
 𥐈	mazm	0
 毓	mazn	5060000
 𦈷	mazn	0
+𫄻	mazn	0
 𦈲	mazo	0
 𩛕	mazo	0
 𨧊	mazp	0
@@ -54515,6 +56617,7 @@ encoder:
 𤜃	mbae	0
 𤘠	mbag	0
 𤙬	mbag	0
+𪞄	mbag	0
 𤘖	mbai	0
 𤙐	mbai	0
 𤚍	mbai	0
@@ -54525,6 +56628,7 @@ encoder:
 㸬	mbal	4700
 𣘈	mbal	0
 𣜱	mbal	0
+𪳓	mbal	0
 特殊	mbar	157000000
 𤘾	mbau	0
 𤘡	mbax	0
@@ -54554,6 +56658,7 @@ encoder:
 𪒷	mbbu	0
 特地	mbbv	11100000
 犍	mbby	364000
+𪴄	mbby	0
 𦉡	mbbz	0
 特长	mbch	13500000
 犗	mbcj	36900
@@ -54603,7 +56708,10 @@ encoder:
 𤚾	mbgd	0
 𤘢	mbgi	0
 𤙅	mbgl	0
+𪺰	mbgl	0
 牻	mbgm	69800
+𪺪	mbgm	0
+𪺭	mbgn	0
 𩑙	mbgo	0
 𩑩	mbgo	0
 特有	mbgq	24400000
@@ -54658,6 +56766,7 @@ encoder:
 𢍎	mbje	0
 𤚮	mbje	0
 𥷂	mbje	0
+𪽀	mbje	0
 特困	mbjf	3630000
 𤚦	mbjf	0
 頶	mbjg	22600
@@ -54672,6 +56781,7 @@ encoder:
 靠	mbjk	140000000
 𠜯	mbjk	0
 𤚛	mbjk	0
+𫂨	mbjk	0
 犒	mbjl	317000
 犞	mbjl	32900
 𡷥	mbjl	0
@@ -54679,6 +56789,7 @@ encoder:
 𧠼	mbjl	0
 𩱕	mbjl	0
 𩱩	mbjl	0
+𪢡	mbjl	0
 𢽍	mbjm	0
 䧼	mbjn	3400
 𤜍	mbjn	0
@@ -54737,6 +56848,7 @@ encoder:
 鼄	mbkw	20400
 𢛁	mbkw	0
 𢢹	mbkw	0
+𪺵	mbkw	0
 𤚈	mbkx	0
 邾	mbky	328000
 㹎	mbkz	4720
@@ -54746,6 +56858,8 @@ encoder:
 𤘼	mblb	0
 𤙉	mblb	0
 𥯿	mblb	0
+𪺱	mblb	0
+𪺲	mblb	0
 犅	mbld	57600
 等同	mbld	14600000
 𤙓	mbld	0
@@ -54788,6 +56902,7 @@ encoder:
 等等	mbmb	124000000
 𤘧	mbmb	0
 牲	mbmc	2810000
+𫘎	mbmc	0
 𤘶	mbmd	0
 牛犊	mbme	1500000
 𨌾	mbmf	0
@@ -54797,6 +56912,7 @@ encoder:
 牦	mbmh	1940000
 犠	mbmh	213000
 𤘛	mbmh	0
+𪺩	mbmh	0
 㸲	mbmi	5450
 特种	mbmj	28200000
 牿	mbmj	71600
@@ -54874,6 +56990,7 @@ encoder:
 𤚠	mbor	0
 𤛵	mbor	0
 𪈓	mbor	0
+𫙦	mbor	0
 𠅐	mbos	0
 𤜈	mbos	0
 𤊘	mbou	0
@@ -54905,6 +57022,7 @@ encoder:
 築	mbqf	27700000
 𥳎	mbqi	0
 𤚎	mbqk	0
+𪺬	mbqk	0
 篫	mbqm	33400
 𢲿	mbqm	0
 丢脸	mbqo	4620000
@@ -54912,6 +57030,7 @@ encoder:
 𥰺	mbqq	0
 𩸡	mbqr	0
 𪈢	mbqr	0
+𫚟	mbqr	0
 䉅	mbqs	5970
 牡丹	mbqs	13300000
 𤘪	mbqs	0
@@ -54936,6 +57055,7 @@ encoder:
 𤄳	mbrk	0
 𤙳	mbrk	0
 𤛃	mbrk	0
+𫂓	mbrk	0
 等角	mbrl	94900
 觕	mbrl	40900
 贊	mbrl	4270000
@@ -54943,6 +57063,7 @@ encoder:
 𤛟	mbrl	0
 𧠺	mbrl	0
 𧤊	mbrl	0
+𫌦	mbrl	0
 㪇	mbrm	3640
 𣭟	mbrm	0
 𣭡	mbrm	0
@@ -55023,6 +57144,7 @@ encoder:
 𤘭	mbuo	0
 𥱩	mbuo	0
 𥰺	mbuq	0
+𪺯	mbuu	0
 特快	mbux	12000000
 𤚇	mbux	0
 𤚔	mbux	0
@@ -55046,6 +57168,7 @@ encoder:
 㹙	mbwl	4420
 犏	mbwl	73400
 𤚢	mbwl	0
+𪺴	mbwl	0
 㹊	mbwn	4570
 特邀	mbwn	4640000
 㸿	mbwq	5650
@@ -55154,6 +57277,7 @@ encoder:
 筹款	mcbb	1130000
 生来	mcbk	3910000
 生动	mcbz	20800000
+𪽃	mccb	0
 𥷨	mccc	0
 𤯨	mcce	0
 生长	mcch	29200000
@@ -55180,26 +57304,32 @@ encoder:
 筹码	mcgx	11800000
 筹划	mchk	13900000
 生成	mchv	57300000
+𪽁	mcid	0
 𤯮	mcih	0
 𥳧	mcii	0
+𪯉	mcix	0
 筹足	mcji	101000
 生日	mcka	107000000
 生辉	mckg	2900000
+𪽄	mckl	0
 𥰚	mckm	0
 生肖	mckq	15900000
 𥵦	mckq	0
+𫂐	mckv	0
 甥	mcky	3000000
 生财	mcld	4420000
 𥵇	mclg	0
 𥶤	mclj	0
 箦	mclo	125000
 簀	mclo	125000
+𫂢	mclo	0
 甡	mcmc	233000
 𥱧	mcmf	0
 𥯪	mcmg	0
 𣬺	mcmh	0
 𤯫	mcmh	0
 𠞏	mcmk	0
+𫂒	mcmk	0
 筹算	mcml	67000
 㽓	mcmm	4190
 𤯛	mcmo	0
@@ -55272,6 +57402,7 @@ encoder:
 手工	mdbi	34900000
 手鼓	mdbj	182000
 𢴝	mdbr	0
+𪮀	mdbr	0
 籜	mdbu	60800
 𥲶	mdcb	0
 𥸓	mdcc	0
@@ -55286,6 +57417,7 @@ encoder:
 手执	mddq	1720000
 手指	mddr	36900000
 箝	mdeb	707000
+𪮍	mdef	0
 簎	mdek	49100
 𢵬	mdeo	0
 手艺	mdey	4710000
@@ -55315,6 +57447,7 @@ encoder:
 𧒎	mdii	0
 𥮠	mdij	0
 䉗	mdjc	3830
+𪿃	mdjd	0
 手足	mdji	18400000
 𢬚	mdjl	0
 𢲤	mdjl	0
@@ -55329,6 +57462,7 @@ encoder:
 𢯣	mdkk	0
 䈰	mdkq	5530
 手掌	mdkw	10500000
+𪮏	mdkw	0
 手电	mdkz	1440000
 簼	mdlb	523000
 𢲱	mdlb	0
@@ -55338,12 +57472,14 @@ encoder:
 𢫶	mdma	0
 𢪒	mdmd	0
 𢩷	mdmh	0
+𪮒	mdml	0
 掱	mdmm	660000
 手稿	mdms	2110000
 𢪳	mdms	0
 𥮁	mdms	0
 手段	mdnc	89500000
 篺	mdne	29400
+𪭩	mdnh	0
 𢫗	mdnk	0
 䉟	mdnx	4150
 𥶪	mdok	0
@@ -55353,6 +57489,7 @@ encoder:
 𢴞	mdoo	0
 手铐	mdpb	3600000
 䇽	mdpd	3660
+𪮽	mdpl	0
 𥱮	mdpz	0
 手脚	mdqb	19800000
 𣓞	mdqf	0
@@ -55373,6 +57510,7 @@ encoder:
 手背	mdtr	3930000
 𢵩	mdug	0
 𥲵	mduk	0
+𪮩	mdul	0
 手法	mdvb	31900000
 𥭑	mdvs	0
 𠂌	mdvv	0
@@ -55385,13 +57523,16 @@ encoder:
 𥴻	mdxj	0
 籒	mdxk	21800
 𢭶	mdxm	0
+𪭳	mdxo	0
 𢩥	mdyd	0
 筢	mdyi	85500
 籀	mdyk	1590000
 劧	mdym	345000
 掰	mdym	6340000
 𥷘	mdyn	0
+𫂅	mdyn	0
 𢲒	mdyy	0
+𫅫	mdyy	0
 手续	mdze	111000000
 手绢	mdzj	1320000
 𢱞	mdzz	0
@@ -55408,6 +57549,7 @@ encoder:
 𠂯	mebi	0
 𠝤	mebk	0
 𠝶	mebk	0
+𪟏	mebk	0
 𨤯	mebl	0
 𥠭	mebm	0
 千赫	mebn	133000
@@ -55464,9 +57606,11 @@ encoder:
 𨜲	mejy	0
 𠚟	mejz	0
 籖	meka	72800
+𫂰	meka	0
 千里	mekb	67400000
 重	mekb	376000000
 𨤶	mekb	0
+𪟕	mekd	0
 𥱹	mekg	0
 濌	mekk	35900
 𠜕	mekk	0
@@ -55544,9 +57688,11 @@ encoder:
 缺欠	mero	258000
 𥳽	mero	0
 𣪜	merq	0
+𪞳	merq	0
 𥶂	merr	0
 𥷀	meru	0
 𥷥	meru	0
+𪜍	merv	0
 㔞	mery	4190
 𦫯	mery	0
 𨛽	mery	0
@@ -55558,6 +57704,7 @@ encoder:
 午夜	mesn	22200000
 垂询	mesr	7360000
 𧜻	mesr	0
+𫂮	mesy	0
 𥪵	mesz	0
 罐装	metb	1410000
 缺席	mete	6730000
@@ -55579,6 +57726,7 @@ encoder:
 勳	meuy	3660000
 𠜫	mevk	0
 千兆	mevr	3360000
+𪜍	mevr	0
 升	mevv	171000000
 𥫠	mevv	0
 升学	mevw	5870000
@@ -55590,14 +57738,18 @@ encoder:
 缺额	mewr	380000
 𥶃	mewr	0
 甜蜜	meww	35100000
+𫂀	mewy	0
 忎	mewz	300000
 𥰼	mewz	0
 𡙇	mexg	0
 簸	mexi	943000
 𦦘	mexi	0
 𨤴	mexi	0
+𫒃	mexr	0
+𫒅	mexx	0
 𠦚	meya	0
 𠡦	meyb	0
+𪥝	meyg	0
 千阳	meyk	253000
 𡼉	meyl	0
 㔓	meym	4240
@@ -55643,6 +57795,7 @@ encoder:
 𥣛	mfag	0
 䅠	mfai	4530
 𣗱	mfai	0
+𫂊	mfai	0
 䭲	mfaj	4090
 秴	mfaj	501000
 𠲆	mfaj	0
@@ -55651,10 +57804,12 @@ encoder:
 𥠆	mfaj	0
 𥠫	mfaj	0
 𥵰	mfaj	0
+𫀱	mfaj	0
 䅉	mfak	5420
 穢	mfak	1450000
 𥡳	mfak	0
 𥡴	mfak	0
+𫁁	mfak	0
 䅪	mfal	4130
 稐	mfal	377000
 穨	mfal	346000
@@ -55675,11 +57830,13 @@ encoder:
 𥣄	mfaz	0
 𪏱	mfaz	0
 䅅	mfbb	7500
+𫗼	mfbb	0
 秲	mfbd	42300
 𥢜	mfbd	0
 穘	mfbg	55400
 𡚕	mfbg	0
 𥞟	mfbi	0
+𫀧	mfbi	0
 秸	mfbj	3480000
 稠	mfbj	7620000
 篻	mfbk	25600
@@ -55693,6 +57850,7 @@ encoder:
 𥡩	mfbq	0
 𥞠	mfbr	0
 𦓌	mfbr	0
+𫀶	mfbr	0
 䆀	mfbu	5800
 䆁	mfbu	4470
 䵩	mfbu	4380
@@ -55713,11 +57871,13 @@ encoder:
 𥢘	mfbz	0
 𥢚	mfbz	0
 𪏳	mfbz	0
+𫁂	mfbz	0
 䭰	mfcb	4480
 𥴇	mfcb	0
 𪐃	mfcb	0
 𩡔	mfcj	0
 積	mfcl	14400000
+𫘁	mfcl	0
 𥡟	mfcn	0
 𥠔	mfco	0
 𥟀	mfcr	0
@@ -55785,6 +57945,7 @@ encoder:
 𥠵	mffd	0
 𥡵	mffd	0
 𥢎	mffd	0
+𫂘	mffd	0
 𥠲	mfff	0
 𥢂	mfff	0
 𪐎	mfff	0
@@ -55796,9 +57957,11 @@ encoder:
 𥤕	mffj	0
 𥱛	mffj	0
 𪐓	mffj	0
+𫂧	mffj	0
 䵔	mffk	5550
 𨋟	mffk	0
 𩠼	mffk	0
+𫂡	mffl	0
 𥢖	mffm	0
 𪅌	mffr	0
 秫	mffs	3080000
@@ -55889,6 +58052,7 @@ encoder:
 𥞘	mfiy	0
 𥝽	mfiz	0
 𥣨	mfiz	0
+𫀵	mfiz	0
 稢	mfja	26000
 稶	mfja	34100
 程	mfjc	343000000
@@ -55922,6 +58086,7 @@ encoder:
 𥵰	mfjl	0
 稛	mfjm	75800
 稦	mfjm	79200
+𫂙	mfjm	0
 𥤊	mfjn	0
 䄼	mfjo	5510
 䅩	mfjo	4320
@@ -55939,6 +58104,7 @@ encoder:
 簌	mfjr	3240000
 𥞏	mfjr	0
 𥡉	mfjr	0
+𫀲	mfjr	0
 𥢍	mfjs	0
 䅱	mfju	3900
 𥣎	mfju	0
@@ -55963,6 +58129,7 @@ encoder:
 𥤐	mfkb	0
 𥷈	mfkb	0
 𪐈	mfkb	0
+𫀴	mfkb	0
 𥟍	mfkc	0
 利	mfkd	429000000
 簟	mfke	995000
@@ -55990,6 +58157,7 @@ encoder:
 𥞁	mfki	0
 𥵉	mfki	0
 𧒁	mfki	0
+𫀪	mfki	0
 𨃾	mfkj	0
 㓿	mfkk	5110
 䅛	mfkk	3710
@@ -56023,8 +58191,10 @@ encoder:
 𥠝	mfkm	0
 𥣲	mfkm	0
 𩡄	mfkm	0
+𫀾	mfkm	0
 𩁄	mfkn	0
 𩁟	mfkn	0
+𫙋	mfkn	0
 稉	mfko	385000
 穔	mfko	26500
 𥣀	mfko	0
@@ -56037,6 +58207,8 @@ encoder:
 稍	mfkq	204000000
 稩	mfkq	20700
 𩡈	mfkq	0
+𫀹	mfkq	0
+𫁄	mfkq	0
 䅥	mfkr	4670
 䱘	mfkr	4300
 稪	mfkr	59200
@@ -56051,6 +58223,7 @@ encoder:
 𪆜	mfkr	0
 𪏶	mfkr	0
 𪐒	mfkr	0
+𫘃	mfkr	0
 𪐖	mfks	0
 穙	mfku	27200
 𤉉	mfku	0
@@ -56071,8 +58244,11 @@ encoder:
 邌	mfkw	25800
 𢤂	mfkw	0
 𥣒	mfkw	0
+𫀼	mfkw	0
+𫁈	mfkw	0
 𥟧	mfkx	0
 𩧸	mfkx	0
+𫀮	mfkx	0
 𠜣	mfky	0
 𠡩	mfky	0
 𡥬	mfky	0
@@ -56127,6 +58303,7 @@ encoder:
 䅐	mflr	7450
 秽	mflr	1890000
 𥡽	mflr	0
+𫀨	mflr	0
 穲	mflt	24000
 𤏤	mflu	0
 𥤎	mflu	0
@@ -56138,6 +58315,8 @@ encoder:
 黐	mflz	295000
 𥣭	mflz	0
 𪐑	mflz	0
+𫀽	mflz	0
+𫗾	mflz	0
 𣫽	mfma	0
 䄵	mfmb	4840
 䅍	mfmb	6090
@@ -56151,6 +58330,7 @@ encoder:
 秊	mfme	323000
 𠦿	mfme	0
 𥟑	mfme	0
+𫀩	mfme	0
 棃	mfmf	499000
 秝	mfmf	87100
 𥠊	mfmf	0
@@ -56180,13 +58360,16 @@ encoder:
 𪏿	mfmk	0
 睝	mfml	39100
 𥡘	mfml	0
+𫁃	mfml	0
 牺牲	mfmm	26000000
 犂	mfmm	86100
 𢮃	mfmm	0
 𣮋	mfmm	0
 𤛿	mfmm	0
+𫀺	mfmm	0
 䅤	mfmn	5080
 𨿯	mfmn	0
+𫗿	mfmn	0
 秩	mfmo	1790000
 𥯍	mfmo	0
 錅	mfmp	18400
@@ -56195,6 +58378,7 @@ encoder:
 鵹	mfmr	21600
 𪁮	mfmr	0
 𪇺	mfmr	0
+𫚞	mfmr	0
 𥝥	mfms	0
 𥠰	mfms	0
 䊍	mfmu	4050
@@ -56219,6 +58403,7 @@ encoder:
 𥟯	mfmz	0
 𥴟	mfmz	0
 𪏾	mfmz	0
+𫂚	mfmz	0
 𥟅	mfnb	0
 䅣	mfnc	4860
 𥞂	mfnd	0
@@ -56226,6 +58411,7 @@ encoder:
 𥴖	mfne	0
 𪐄	mfne	0
 穕	mfnf	58700
+𫘂	mfnf	0
 𥗶	mfng	0
 𥣩	mfnh	0
 稚	mfni	4530000
@@ -56255,6 +58441,7 @@ encoder:
 稑	mfob	745000
 𥢤	mfob	0
 𥵏	mfoc	0
+𫗽	mfoc	0
 秂	mfod	2210000
 稡	mfoe	30800
 𡦧	mfoe	0
@@ -56266,6 +58453,7 @@ encoder:
 穃	mfoj	57800
 𥢑	mfoj	0
 𧯄	mfoj	0
+𫎂	mfoj	0
 㴝	mfok	4580
 黍	mfok	5090000
 黎	mfok	42400000
@@ -56281,12 +58469,14 @@ encoder:
 𥣪	mfol	0
 𥤒	mfol	0
 𥤟	mfol	0
+𫁆	mfol	0
 䄹	mfom	4470
 䅷	mfom	4750
 稌	mfom	38500
 𥠛	mfom	0
 𥣆	mfom	0
 𥷭	mfom	0
+𪺳	mfom	0
 𥝵	mfon	0
 𥞙	mfon	0
 𥠸	mfon	0
@@ -56302,10 +58492,12 @@ encoder:
 𥢰	mfoo	0
 𥤞	mfoo	0
 𩡙	mfoo	0
+𫁉	mfoo	0
 穇	mfop	39600
 穋	mfop	44400
 𥤇	mfop	0
 𥶠	mfop	0
+𫁇	mfop	0
 䴻	mfor	4300
 稄	mfor	48900
 稜	mfor	1770000
@@ -56334,6 +58526,7 @@ encoder:
 𥠱	mfpi	0
 𥢌	mfpk	0
 𥣳	mfpk	0
+𫁉	mfpl	0
 䵚	mfpn	3790
 稻	mfpn	12300000
 𥯈	mfpx	0
@@ -56349,6 +58542,7 @@ encoder:
 颓	mfqg	2010000
 𥟺	mfqg	0
 𥠕	mfqk	0
+𫀯	mfqk	0
 𥞇	mfql	0
 𢵥	mfqm	0
 𢽈	mfqm	0
@@ -56437,6 +58631,7 @@ encoder:
 𪚼	mfrw	0
 𥣾	mfrx	0
 𥤈	mfrx	0
+𫀬	mfrx	0
 𥟶	mfry	0
 𥠈	mfry	0
 𨝄	mfry	0
@@ -56444,8 +58639,10 @@ encoder:
 穒	mfrz	35100
 𥠎	mfrz	0
 𥡚	mfrz	0
+𫚴	mfrz	0
 𥡒	mfsc	0
 𥯸	mfsc	0
+𪝲	mfsc	0
 𥞽	mfse	0
 𥝕	mfsh	0
 䆍	mfsi	3990
@@ -56457,16 +58654,20 @@ encoder:
 𥞑	mfsl	0
 𥞿	mfsl	0
 𥢹	mfsm	0
+𫘀	mfsm	0
 𥡃	mfsn	0
 秔	mfsq	33500
 𥮕	mfsq	0
 𧚩	mfsr	0
+𫌍	mfsr	0
 𥞯	mfsu	0
 𥢯	mfsu	0
+𫀦	mfsv	0
 𥠡	mfsw	0
 𥡥	mfsw	0
 𥵅	mfsw	0
 𪐁	mfsw	0
+𫀷	mfsw	0
 稂	mfsx	105000
 𩠻	mfsx	0
 䄱	mfsy	5470
@@ -56482,6 +58683,7 @@ encoder:
 𥞉	mfua	0
 秚	mfub	28200
 𥣺	mfub	0
+𫆉	mfuc	0
 𥞩	mfue	0
 醔	mfuf	42000
 𥞪	mfuf	0
@@ -56516,6 +58718,7 @@ encoder:
 䵸	mfuw	3700
 愁	mfuw	31500000
 𪔁	mfuw	0
+𫐵	mfuw	0
 䆂	mfux	4420
 稴	mfux	34800
 馦	mfux	24500
@@ -56533,6 +58736,7 @@ encoder:
 䄻	mfvr	4290
 𥰜	mfvr	0
 𩡂	mfvr	0
+𫀰	mfvr	0
 𥟇	mfvs	0
 𥝌	mfvv	0
 𥠣	mfwa	0
@@ -56568,6 +58772,7 @@ encoder:
 𥤓	mfws	0
 𥤚	mfwu	0
 𥷻	mfwu	0
+𪺋	mfwu	0
 馞	mfwy	37600
 𥞳	mfwy	0
 𥟓	mfwy	0
@@ -56575,12 +58780,14 @@ encoder:
 䅴	mfwz	5380
 𢘳	mfwz	0
 𥞬	mfwz	0
+𫂠	mfwz	0
 䵛	mfxb	3720
 秉	mfxb	6990000
 𥞓	mfxb	0
 𥞭	mfxb	0
 𥞰	mfxb	0
 𥴍	mfxb	0
+𫁀	mfxb	0
 穱	mfxd	523000
 𥤏	mfxd	0
 𥝦	mfxe	0
@@ -56608,6 +58815,7 @@ encoder:
 䅏	mfxm	4510
 𥡕	mfxo	0
 𦫌	mfxo	0
+𫀻	mfxo	0
 𩡜	mfxq	0
 秜	mfxr	32000
 馜	mfxr	50000
@@ -56637,6 +58845,7 @@ encoder:
 箱子	mfya	8390000
 𥝔	mfya	0
 𥝎	mfyd	0
+𫂄	mfyd	0
 𥝡	mfye	0
 稧	mfyg	41400
 𥞔	mfyh	0
@@ -56644,6 +58853,7 @@ encoder:
 𥝧	mfyi	0
 𥝼	mfyi	0
 𥝿	mfyj	0
+𫀸	mfyj	0
 籕	mfyk	22200
 𥞲	mfyk	0
 𥠷	mfyk	0
@@ -56652,6 +58862,8 @@ encoder:
 䅎	mfym	6810
 秀	mfym	208000000
 𥟄	mfym	0
+𫀭	mfym	0
+𫘀	mfym	0
 䄶	mfyn	5000
 𥣞	mfyn	0
 䵑	mfys	4130
@@ -56685,6 +58897,7 @@ encoder:
 𩡦	mfzf	0
 䫋	mfzg	3470
 𥟔	mfzg	0
+𫀿	mfzg	0
 𠚉	mfzi	0
 秮	mfzj	417000
 𥞚	mfzj	0
@@ -56696,6 +58909,7 @@ encoder:
 𥠃	mfzl	0
 𩡎	mfzl	0
 𩡤	mfzl	0
+𫘄	mfzl	0
 䄿	mfzm	5350
 委	mfzm	199000000
 魏	mfzn	72100000
@@ -56759,6 +58973,7 @@ encoder:
 𥵐	mgku	0
 𡙶	mgkz	0
 𥯃	mgkz	0
+𫂑	mgkz	0
 𡰘	mglg	0
 笼罩	mgli	11900000
 𠛻	mglk	0
@@ -56803,12 +59018,14 @@ encoder:
 𥮎	mgse	0
 𠛦	mgsk	0
 𠿕	mgsq	0
+𪜎	mgsq	0
 乔装	mgtb	940000
 𠂷	mgub	0
 𥱇	mguo	0
 𥲩	mguo	0
 𪇙	mgur	0
 𡴘	mguz	0
+𪜏	mguz	0
 𥵯	mgxi	0
 叐	mgxs	40900
 笼子	mgya	2600000
@@ -56839,6 +59056,7 @@ encoder:
 𣰼	mhcc	0
 𣭞	mhce	0
 𣭿	mhce	0
+𪵛	mhck	0
 𣭌	mhcn	0
 𣮛	mhcq	0
 𣰜	mhcq	0
@@ -56905,6 +59123,7 @@ encoder:
 𣮑	mhkk	0
 𣮜	mhkl	0
 𣯀	mhkl	0
+𪵢	mhkl	0
 𣮅	mhkm	0
 𣮶	mhkm	0
 𣰔	mhkm	0
@@ -56919,6 +59138,7 @@ encoder:
 𣮼	mhlg	0
 毛巾	mhli	7520000
 𣬢	mhli	0
+𫁹	mhli	0
 𣯿	mhlk	0
 𥰎	mhlk	0
 𥱔	mhlk	0
@@ -56927,6 +59147,7 @@ encoder:
 𣰏	mhln	0
 𣰽	mhln	0
 𣯒	mhlo	0
+𪵠	mhlo	0
 覒	mhlr	24400
 𣮨	mhlz	0
 𣮽	mhlz	0
@@ -56953,6 +59174,7 @@ encoder:
 𣬬	mhms	0
 毛毯	mhmu	2590000
 𥼛	mhmu	0
+𪹮	mhmu	0
 㦌	mhmw	4530
 𣭛	mhmw	0
 𣯘	mhmy	0
@@ -56993,6 +59215,7 @@ encoder:
 𥬗	mhrd	0
 𣭤	mhre	0
 𣭨	mhrj	0
+𪵙	mhrj	0
 毥	mhrk	24000
 氇	mhrk	199000
 氌	mhrk	33500
@@ -57021,11 +59244,14 @@ encoder:
 𣮍	mhsz	0
 毛病	mhta	17200000
 𣬯	mhte	0
+𪵡	mhtx	0
 毩	mhuf	28700
 𣮩	mhuf	0
 𣮺	mhug	0
+𪵜	mhug	0
 𣮹	mhun	0
 𤆬	mhuo	0
+𪵘	mhuo	0
 毛料	mhut	991000
 毯	mhuu	5520000
 毛糙	mhuw	371000
@@ -57043,13 +59269,16 @@ encoder:
 毛皮	mhxi	5240000
 𣬼	mhxi	0
 𣯙	mhxj	0
+𪵞	mhxk	0
 䉯	mhxl	4700
+𪵟	mhxl	0
 𣮣	mhxo	0
 𦥺	mhxo	0
 𣭙	mhxr	0
 毛驴	mhxw	1510000
 𣬥	mhya	0
 𣬞	mhyd	0
+𪵖	mhyd	0
 矩阵	mhyh	12000000
 𣬶	mhyi	0
 𣭋	mhyj	0
@@ -57078,6 +59307,7 @@ encoder:
 毛纺	mhzs	1060000
 𣭇	mhzy	0
 𣭑	mhzz	0
+𪵚	mhzz	0
 𣥋	miaa	0
 𥵂	miag	0
 𦧧	miai	0
@@ -57106,6 +59336,7 @@ encoder:
 𣥋	miib	0
 𦧽	miii	0
 𢼤	miix	0
+𫂜	miix	0
 𥸛	miji	0
 𥭔	mijk	0
 𥱾	mijo	0
@@ -57153,6 +59384,7 @@ encoder:
 𥷳	mimy	0
 𦧓	mimy	0
 怎么	mimz	403000000
+𫕛	mini	0
 憩	minw	3000000
 𦧯	minw	0
 𦧹	miob	0
@@ -57162,8 +59394,10 @@ encoder:
 舚	mios	64400
 𦧔	mips	0
 𥳭	mipy	0
+𫇔	miqd	0
 𨟭	miqy	0
 舐	mirh	1880000
+𫇘	mirl	0
 舓	miro	24000
 𣢯	miro	0
 𥱿	mirq	0
@@ -57174,6 +59408,7 @@ encoder:
 鸹	mirz	133000
 𥲕	mirz	0
 辞	mise	26700000
+𫇖	misj	0
 𥱲	miso	0
 𦧈	misx	0
 𥫪	mitd	0
@@ -57182,6 +59417,7 @@ encoder:
 𧖍	miuc	0
 舕	miuu	29200
 𦧷	miux	0
+𫇗	miux	0
 禹州	mivn	692000
 竹溪	mivp	693000
 䖝	mivv	4170
@@ -57227,6 +59463,7 @@ encoder:
 箿	mjce	29500
 𥭤	mjci	0
 䉷	mjcm	3940
+𫂆	mjcs	0
 积聚	mjcx	3430000
 告捷	mjda	1580000
 靠拢	mjdg	6210000
@@ -57249,6 +59486,7 @@ encoder:
 𥭒	mjhz	0
 𢘗	mjiw	0
 簂	mjja	34800
+𫂛	mjjb	0
 知足	mjji	7680000
 𥭾	mjji	0
 𥰔	mjjj	0
@@ -57259,6 +59497,7 @@ encoder:
 告别	mjjy	25100000
 𥱐	mjkb	0
 簞	mjke	588000
+𫂍	mjke	0
 知晓	mjkh	6910000
 和田	mjki	10900000
 种田	mjki	1900000
@@ -57286,6 +59525,7 @@ encoder:
 𥱅	mjoe	0
 𥭮	mjol	0
 𥸑	mjol	0
+𫂌	mjom	0
 𥶟	mjou	0
 积分	mjoy	446000000
 和风	mjqo	3580000
@@ -57389,6 +59629,7 @@ encoder:
 重要	mkfv	433000000
 重大	mkgd	113000000
 𥭍	mkgd	0
+𫂁	mkgd	0
 𥴵	mkgi	0
 𥰻	mkgj	0
 朱砂	mkgk	786000
@@ -57398,6 +59639,7 @@ encoder:
 𥲸	mkgu	0
 重码	mkgx	292000
 复式	mkhb	8830000
+𫂔	mkhm	0
 笛	mkia	18300000
 笚	mkib	468000
 𥬐	mkic	0
@@ -57462,6 +59704,7 @@ encoder:
 复会	mkob	241000
 朱德	mkoe	1740000
 稍微	mkol	21300000
+𪽐	mkon	0
 𥬽	mkos	0
 重创	mkoy	4600000
 𥭣	mkoz	0
@@ -57617,6 +59860,7 @@ encoder:
 纂	mlgz	1640000
 制式	mlhb	6130000
 𧑬	mlhi	0
+𫂩	mlhi	0
 看到	mlhk	360000000
 簚	mlhl	74200
 𥱡	mlhm	0
@@ -57647,6 +59891,7 @@ encoder:
 𠜄	mlkd	0
 𠟬	mlkd	0
 𥵙	mlke	0
+𫋬	mlke	0
 秧田	mlki	254000
 篎	mlkm	34100
 租界	mlko	1010000
@@ -57716,6 +59961,7 @@ encoder:
 𥶋	mlpk	0
 算盘	mlpl	3740000
 衇	mlpr	21800
+𫁼	mlqd	0
 血肿	mlqj	675000
 血腥	mlqk	4730000
 制胜	mlqm	3870000
@@ -57733,6 +59979,7 @@ encoder:
 箆	mlrr	124000
 𥰕	mlrr	0
 𥶓	mlrr	0
+𫋪	mlrr	0
 箩	mlrs	1150000
 𥸣	mlrs	0
 𧖪	mlrs	0
@@ -57782,6 +60029,7 @@ encoder:
 看过	mlwd	48700000
 𥵒	mlwl	0
 制造	mlwm	203000000
+𫂝	mlwr	0
 血迹	mlws	7710000
 稠密	mlww	1180000
 制退	mlwx	57900
@@ -57842,10 +60090,12 @@ encoder:
 矮柜	mmfh	192000
 年检	mmfo	5110000
 敌机	mmfq	768000
+𫂪	mmfx	0
 笑	mmgd	568000000
 笑靥	mmgg	1390000
 𥮂	mmgj	0
 𡮜	mmgk	0
+𫛎	mmgr	0
 年历	mmgy	4860000
 𥫬	mmhd	0
 年轮	mmho	1940000
@@ -57948,11 +60198,13 @@ encoder:
 敌对	mmxv	4470000
 牧民	mmyh	2610000
 年费	mmyn	1390000
+𫑎	mmyw	0
 年限	mmyx	14000000
 笑纳	mmzl	1340000
 年终	mmzr	19600000
 年级	mmzy	47300000
 年纪	mmzy	38800000
+𫂂	mmzy	0
 𥰉	mnag	0
 𥮆	mnaj	0
 𥰧	mnaj	0
@@ -58002,8 +60254,10 @@ encoder:
 𥵸	mnrl	0
 𥱤	mnrp	0
 篦	mnrr	795000
+𫂇	mnrs	0
 𥮴	mnrt	0
 䉣	mnru	4040
+𫂕	mnsj	0
 籩	mnsw	167000
 䉛	mnug	3830
 𥶵	mnuq	0
@@ -58019,6 +60273,7 @@ encoder:
 篗	mnxs	85500
 𥰞	mnxs	0
 𥸌	mnxx	0
+𫁻	mnya	0
 𥰗	mnyi	0
 攵	moaa	2920000
 𥰊	moai	0
@@ -58123,6 +60378,7 @@ encoder:
 䉠	moqm	208
 𥳴	moqq	0
 黏胶	moqs	76200
+𫂬	morg	0
 签名	morj	166000000
 答疑	morm	70600000
 𥷲	morm	0
@@ -58189,6 +60445,7 @@ encoder:
 稻草	mpek	4690000
 𥳗	mpgo	0
 䈠	mpgx	8620
+𫂖	mpgx	0
 籛	mphh	38300
 篯	mphm	45100
 篪	mpih	251000
@@ -58226,6 +60483,7 @@ encoder:
 䈀	mqak	16600
 𥵍	mqal	0
 𠂸	mqbe	0
+𪽆	mqbi	0
 𥮚	mqbk	0
 竼	mqda	40500
 颓势	mqdq	1430000
@@ -58252,6 +60510,7 @@ encoder:
 𥸫	mquf	0
 籐	mquk	3920000
 𥭳	mquo	0
+𫂭	mqus	0
 籘	mquz	45900
 𣍝	mqvv	0
 𥬅	mqvv	0
@@ -58294,12 +60553,14 @@ encoder:
 稳步	mrik	11700000
 称号	mrja	29100000
 稳固	mrje	5090000
+𫂤	mrjg	0
 物品	mrjj	142000000
 称呼	mrjm	15900000
 𥲾	mrjm	0
 称叹	mrjx	149000
 赞叹	mrjx	6580000
 𥰿	mrkf	0
+𫂎	mrkg	0
 先辈	mrkh	1400000
 𥳩	mrkk	0
 𥬞	mrko	0
@@ -58430,6 +60691,7 @@ encoder:
 𥲰	msgq	0
 笇	msid	104000
 𥱱	msij	0
+𫂯	msiq	0
 辞呈	msjc	713000
 𥯲	msjf	0
 䈞	msjk	4050
@@ -58522,12 +60784,14 @@ encoder:
 简捷	mtda	1650000
 科技	mtde	534000000
 简报	mtdy	12000000
+𫁵	mted	0
 简直	mtel	79200000
 𥱊	mtel	0
 乘警	mter	390000
 䉀	mteu	5850
 𥯖	mtex	0
 科协	mtey	3360000
+𫂟	mtff	0
 简朴	mtfi	1750000
 乘机	mtfq	4960000
 简要	mtfv	14200000
@@ -58555,11 +60819,13 @@ encoder:
 简体	mtnf	121000000
 𥴯	mtnj	0
 简化	mtnr	16700000
+𫁴	mtod	0
 剩余	mtom	46900000
 简介	mton	404000000
 乘坐	mtoo	12400000
 𥵬	mtop	0
 乘船	mtpq	2190000
+𫂃	mtso	0
 简谱	mtsu	711000
 简讯	mtsy	4340000
 简装	mttb	4880000
@@ -58580,6 +60846,8 @@ encoder:
 科室	mtwh	10400000
 乘客	mtwr	13200000
 篖	mtxj	42100
+𫂞	mtxk	0
+𫂈	mtxs	0
 简阳	mtyk	502000
 乘除	mtyo	402000
 䉬	mtyq	4590
@@ -58602,6 +60870,7 @@ encoder:
 𥳰	mufd	0
 𥳢	mufg	0
 𥴅	mufj	0
+𫂏	mufq	0
 秋雨	mufv	6190000
 𥮷	mugj	0
 㸔	mugl	4440
@@ -58641,6 +60910,7 @@ encoder:
 秋色	mury	5150000
 税务	mury	33500000
 𥱑	murz	0
+𫚶	murz	0
 税率	musv	9250000
 𥶑	musx	0
 箭头	mutg	5980000
@@ -58803,12 +61073,15 @@ encoder:
 𥶘	mwru	0
 箢	mwry	80500
 鴔	mwrz	32200
+𫛡	mwrz	0
 篇章	mwsk	11100000
 䈿	mwso	5230
 秘诀	mwsx	17900000
+𫂗	mwuf	0
 𥴦	mwug	0
 𥯴	mwux	0
 乏	mwvv	8690000
+𫂦	mwwb	0
 管家	mwwg	8540000
 𥳥	mwwl	0
 𥸅	mwwl	0
@@ -58882,6 +61155,7 @@ encoder:
 𥬩	mxrr	0
 𥰱	mxsi	0
 簢	mxso	30000
+𫁽	mxso	0
 箳	mxue	196000
 𥵧	mxul	0
 秉性	mxum	1060000
@@ -58890,6 +61164,7 @@ encoder:
 䉍	mxwz	5600
 𥮢	mxxe	0
 𥬖	mxxs	0
+𫁷	mxxs	0
 䈔	mxxx	4400
 𥲝	mxxx	0
 蠞	mxyi	27000
@@ -58909,6 +61184,7 @@ encoder:
 笥	myaj	1170000
 𥰮	myaj	0
 𥴩	myaj	0
+𪵤	myaj	0
 氩	myak	1070000
 師	myal	70500000
 秀丽	myal	7630000
@@ -58950,6 +61226,7 @@ encoder:
 气节	myey	1090000
 𣱪	myfb	0
 𣱯	myfb	0
+𫂫	myfd	0
 氥	myfj	432000
 氭	myfk	1550000
 𣱨	myfl	0
@@ -59005,6 +61282,7 @@ encoder:
 氪	myjr	880000
 𧰥	myju	0
 𥯱	myjw	0
+𫑓	myjw	0
 𣱰	myka	0
 𣱧	mykb	0
 刏	mykd	34800
@@ -59037,6 +61315,8 @@ encoder:
 筵	mymi	3630000
 气血	myml	2900000
 气氛	mymo	35800000
+𪯌	mymo	0
+𫒺	mymp	0
 笈	myms	29900000
 气管	mymw	9890000
 𥴲	mymw	0
@@ -59049,10 +61329,12 @@ encoder:
 𨽴	mymy	0
 𨽵	mymy	0
 𥱖	mymz	0
+𪵥	mymz	0
 氘	mynd	361000
 氚	mynd	692000
 笰	mynd	79100
 气体	mynf	29400000
+𪳦	mynf	0
 气候	myni	19400000
 气魄	mynn	2930000
 气化	mynr	1700000
@@ -59085,6 +61367,7 @@ encoder:
 第九	myqy	35700000
 𥲎	myrb	0
 𥱥	myrf	0
+𪪀	myrf	0
 气象	myrj	30500000
 𥭫	myrk	0
 𥮜	myrk	0
@@ -59101,6 +61384,7 @@ encoder:
 阜新	mysf	3890000
 𥭰	mysf	0
 𥴉	mysk	0
+𪷣	mysk	0
 第六	myso	59600000
 𧜚	mysr	0
 𣱠	mysu	0
@@ -59154,6 +61438,7 @@ encoder:
 气力	myym	2950000
 氖	myym	1570000
 𠡒	myym	0
+𪵧	myym	0
 氟	myyn	15000000
 籊	myyn	38800
 𥱵	myyn	0
@@ -59213,6 +61498,7 @@ encoder:
 𥭱	mzix	0
 䈢	mzjf	4740
 每吨	mzjh	3810000
+𪵔	mzjk	0
 委员	mzjl	31000000
 𥰀	mzjl	0
 𥰪	mzjm	0
@@ -59326,6 +61612,7 @@ encoder:
 便于	naad	21600000
 佰万	naay	310000
 使者	nabm	22500000
+𪝫	nacx	0
 便捷	nada	17700000
 便携	nadn	14500000
 使其	naec	22300000
@@ -59438,6 +61725,7 @@ encoder:
 佤	nays	576000
 𠇐	naza	0
 例如	nazj	135000000
+𪜨	nazm	0
 何以	nazo	11500000
 傿	nazu	38700
 𠈯	nazx	0
@@ -59447,6 +61735,7 @@ encoder:
 𦥦	nbaf	0
 𠑯	nbag	0
 𦦅	nbag	0
+𪡲	nbag	0
 𦦯	nbai	0
 䑔	nbal	6060
 佳丽	nbal	4500000
@@ -59469,6 +61758,7 @@ encoder:
 僥	nbbg	472000
 毁坏	nbbg	3310000
 𪕖	nbbj	0
+𪝦	nbbj	0
 传来	nbbk	30100000
 𧡞	nbbl	0
 𤰁	nbbm	0
@@ -59528,6 +61818,7 @@ encoder:
 𡘑	nbgd	0
 𡘩	nbgd	0
 𦥸	nbge	0
+𪪸	nbge	0
 䢅	nbgh	3910
 𧖥	nbgi	0
 传布	nbgl	440000
@@ -59579,6 +61870,7 @@ encoder:
 𥂤	nbjl	0
 𩱬	nbjl	0
 传呼	nbjm	2370000
+𪡢	nbjn	0
 𪕱	nbjq	0
 仁兄	nbjr	1260000
 传唤	nbjr	985000
@@ -59589,6 +61881,7 @@ encoder:
 𩸔	nbjr	0
 𠊪	nbju	0
 𠍼	nbju	0
+𫜣	nbju	0
 𡡋	nbjz	0
 𪖎	nbka	0
 𦦋	nbkb	0
@@ -59636,6 +61929,8 @@ encoder:
 𠔻	nblo	0
 𦥷	nblo	0
 𦧅	nblo	0
+𪝖	nblo	0
+𫎔	nblo	0
 𨮆	nblp	0
 𨯜	nblp	0
 𧭒	nbls	0
@@ -59659,6 +61954,7 @@ encoder:
 嚳	nbmj	75000
 𧗕	nbml	0
 𦦈	nbmn	0
+𫓓	nbmp	0
 𪕉	nbmu	0
 㐦	nbmy	4430
 𠒍	nbmy	0
@@ -59678,6 +61974,7 @@ encoder:
 𦦚	nbno	0
 𦦪	nbno	0
 𦦲	nbno	0
+𪜻	nbno	0
 𪕨	nbnr	0
 𢤒	nbnw	0
 伍亿	nbny	146000
@@ -59716,6 +62013,7 @@ encoder:
 𦦶	nboh	0
 𦥳	nboi	0
 𪖁	nboi	0
+𪴿	nboi	0
 𠿟	nboj	0
 僣	nbok	127000
 澩	nbok	42400
@@ -59731,6 +62029,7 @@ encoder:
 𥂞	nbol	0
 𧸧	nbol	0
 𪕶	nbol	0
+𪾙	nbol	0
 擧	nbom	378000
 𢸁	nbom	0
 𢹏	nbom	0
@@ -59762,6 +62061,7 @@ encoder:
 𪇬	nbor	0
 𪌲	nbor	0
 𪕞	nbor	0
+𫚃	nbor	0
 譽	nbos	3530000
 𦦦	nbos	0
 𦦭	nbos	0
@@ -59775,6 +62075,7 @@ encoder:
 𠎝	nbow	0
 𢤀	nbow	0
 𪕌	nbow	0
+𫐯	nbow	0
 𥀣	nbox	0
 學	nboy	90300000
 釁	nboy	105000
@@ -59886,6 +62187,7 @@ encoder:
 𠣆	nbuy	0
 𪕧	nbuy	0
 仁慈	nbuz	3570000
+𫇓	nbvf	0
 传染	nbvq	10700000
 𦦬	nbvq	0
 仕	nbvv	38300000
@@ -59920,6 +62222,7 @@ encoder:
 㲣	nbxm	4880
 叟	nbxs	3610000
 鼥	nbxs	25400
+𪠨	nbxs	0
 𪕠	nbxu	0
 遚	nbxw	23700
 𪕰	nbxx	0
@@ -59941,6 +62244,7 @@ encoder:
 𢑅	nbyy	0
 𦑹	nbyy	0
 𨟦	nbyy	0
+𫜢	nbza	0
 𤪭	nbzc	0
 𪕔	nbzc	0
 鼠	nbzd	145000000
@@ -59960,6 +62264,7 @@ encoder:
 𪕍	nbzl	0
 𪕙	nbzl	0
 𪕥	nbzl	0
+𪝙	nbzl	0
 仕女	nbzm	1970000
 仾	nbzm	223000
 佞	nbzm	1110000
@@ -60021,13 +62326,16 @@ encoder:
 身长	ncch	2820000
 躼	ncch	19800
 𨉩	ncco	0
+𪝾	ncco	0
 𨉨	nccq	0
 𨉸	nccu	0
+𪝰	nccu	0
 僵持	ncdb	3250000
 𧎭	ncdi	0
 俦	ncds	546000
 射	ncds	61100000
 𨉠	ncdu	0
+𪧻	ncdu	0
 𨉡	nceb	0
 𨉴	ncec	0
 𨈰	ncej	0
@@ -60070,6 +62378,7 @@ encoder:
 𨉏	ncjr	0
 䠽	ncju	4210
 軆	ncju	233000
+𫏰	ncju	0
 𨊘	ncjw	0
 𨉟	ncjy	0
 䡀	ncka	5390
@@ -60105,6 +62414,7 @@ encoder:
 𨈭	nclb	0
 𨉄	nclb	0
 𨈹	ncld	0
+𫏱	nclk	0
 𨊋	ncll	0
 债	nclo	19900000
 債	nclo	6780000
@@ -60119,6 +62429,7 @@ encoder:
 𣕼	ncmf	0
 𨈥	ncmh	0
 𨉐	ncmh	0
+𫏫	ncmh	0
 𨈸	ncmi	0
 𨊛	ncmi	0
 𨉾	ncml	0
@@ -60132,6 +62443,7 @@ encoder:
 𠌴	ncnb	0
 身段	ncnc	3820000
 𨉤	ncnc	0
+𫏬	ncnc	0
 䠵	ncnd	3940
 身体	ncnf	146000000
 身躯	ncnh	10100000
@@ -60175,6 +62487,8 @@ encoder:
 𨈳	ncrj	0
 𨊌	ncrm	0
 𨊜	ncrm	0
+𫏭	ncrm	0
+𫏯	ncrq	0
 𨈚	ncrr	0
 𨉮	ncrr	0
 𪈬	ncrr	0
@@ -60211,6 +62525,7 @@ encoder:
 𨊏	ncus	0
 身为	ncuv	15700000
 债券	ncuy	22600000
+𫏮	ncuz	0
 䠷	ncvr	4280
 仼	ncvv	251000
 𨉬	ncwa	0
@@ -60256,8 +62571,10 @@ encoder:
 𨈼	nczk	0
 軉	nczl	24400
 𡜟	nczm	0
+𫏭	nczm	0
 䠹	nczo	4490
 𨉒	nczu	0
+𫏮	nczw	0
 𠉩	nczy	0
 𨈶	nczy	0
 䠳	nczz	4040
@@ -60283,6 +62600,7 @@ encoder:
 倳	ndjx	193000
 𠍣	ndkc	0
 𢍖	ndke	0
+𫖦	ndkl	0
 射界	ndko	115000
 射影	ndks	300000
 付账	ndlc	1260000
@@ -60300,6 +62618,7 @@ encoder:
 付诸	ndsb	4170000
 射门	ndtl	3400000
 𩇨	ndtt	0
+𫂱	nduf	0
 川江	ndvb	348000
 射洪	ndve	557000
 川沙	ndvk	717000
@@ -60347,6 +62666,7 @@ encoder:
 做梦	neff	12700000
 供需	nefg	12900000
 儎	nefk	308000
+𪝸	nefs	0
 偌大	negd	3080000
 偌	negj	1300000
 𠐾	nego	0
@@ -60364,8 +62684,11 @@ encoder:
 𠍔	neji	0
 做	nejm	910000000
 儆	nejm	1530000
+𪝍	nejq	0
 估量	neka	3550000
+𪝡	nekg	0
 㑤	neki	4560
+𪝌	neki	0
 傮	nekk	35800
 借鉴	nekm	19000000
 卑劣	nekm	2600000
@@ -60430,6 +62753,7 @@ encoder:
 供词	nesy	148000
 借方	nesy	542000
 𠑦	nesy	0
+𪝆	nesy	0
 借阅	netu	9110000
 供应	netv	400000000
 供养	neun	3490000
@@ -60462,6 +62786,7 @@ encoder:
 体型	nfae	23500000
 体形	nfae	5460000
 𧡊	nfal	0
+𫌠	nfal	0
 体坛	nfbb	27100000
 𠐆	nfbd	0
 僄	nfbk	40800
@@ -60493,6 +62818,7 @@ encoder:
 体态	nfgs	3430000
 僊	nfgy	138000
 𠍍	nfgz	0
+𪝠	nfhm	0
 集成	nfhv	53400000
 休止	nfii	11000000
 𠏹	nfjc	0
@@ -60514,10 +62840,12 @@ encoder:
 体重	nfmk	44300000
 体制	nfml	49900000
 僌	nfmo	36800
+𪝅	nfmo	0
 体委	nfmz	721000
 体系	nfmz	92100000
 集体	nfnf	53300000
 𠐶	nfni	0
+𪝷	nfnr	0
 体倦	nfnu	145000
 休息	nfnw	64400000
 休假	nfnx	8020000
@@ -60528,6 +62856,7 @@ encoder:
 倈	nfoo	40100
 𠍅	nfor	0
 𠏡	nfow	0
+𪝎	nfow	0
 倯	nfoz	103000
 𠌲	nfpd	0
 体质	nfpe	8830000
@@ -60565,6 +62894,7 @@ encoder:
 集安	nfwz	552000
 儊	nfxi	167000
 体验	nfxo	91500000
+𪝺	nfxx	0
 体力	nfym	32500000
 集结	nfzb	34700000
 偠	nfzm	921000
@@ -60583,6 +62913,7 @@ encoder:
 顺境	ngbs	577000
 伏击	ngbz	1900000
 侉	ngbz	174000
+𪝄	ngbz	0
 顺耳	ngce	359000
 优抚	ngda	1040000
 优势	ngdq	106000000
@@ -60593,6 +62924,7 @@ encoder:
 偄	nggd	435000
 𠐞	nggg	0
 优厚	nggk	2680000
+𪝥	nggl	0
 顺致	nghm	102000
 臭虫	ngia	842000
 𠈚	ngib	0
@@ -60609,6 +62941,7 @@ encoder:
 𠏗	ngku	0
 顺当	ngkx	107000
 顺畅	ngky	8610000
+𪝐	ngky	0
 俺	ngkz	132000000
 𠋊	ngld	0
 佈	ngli	14800000
@@ -60632,6 +62965,7 @@ encoder:
 俺们	ngnt	4920000
 优待	ngob	2100000
 顺德	ngoe	11300000
+𪝬	ngoe	0
 𠋙	ngok	0
 俠	ngoo	10600000
 傸	ngoo	24000
@@ -60679,6 +63013,7 @@ encoder:
 躯干	nhae	1150000
 倒下	nhai	8520000
 𠊭	nhaj	0
+𪝏	nhaj	0
 傶	nhak	27400
 𠏺	nhal	0
 𠋘	nhaz	0
@@ -60765,6 +63100,7 @@ encoder:
 𤇰	nhuo	0
 代数	nhuz	2930000
 倒数	nhuz	9590000
+𪝻	nhvf	0
 㒑	nhvn	4570
 代沟	nhvr	1140000
 𠈄	nhvv	0
@@ -60840,6 +63176,8 @@ encoder:
 俶	nikx	1020000
 𧔰	nild	0
 𠌚	nile	0
+𪝽	nilg	0
+𪝇	nilm	0
 侦	nilo	9710000
 偵	nilo	5420000
 𧵰	nilo	0
@@ -60863,12 +63201,14 @@ encoder:
 𠌒	nimo	0
 𩛢	nimo	0
 鋚	nimp	23200
+𫚿	nimr	0
 修辞	nims	2160000
 焂	nimu	29200
 悠	nimw	17100000
 𨾻	nimy	0
 㛜	nimz	3710
 𠧐	nine	0
+𪟻	nine	0
 雧	ninf	20200
 雔	nini	41200
 㘜	ninj	4080
@@ -60892,6 +63232,7 @@ encoder:
 𠏻	niol	0
 修饰	niom	6540000
 𨿇	nioo	0
+𫕚	nioo	0
 𩀗	nipi	0
 𢟅	nipw	0
 𪅭	niqr	0
@@ -60982,6 +63323,7 @@ encoder:
 修建	niyx	18700000
 翛	niyy	122000
 𦐻	niyy	0
+𪝭	nizg	0
 侦缉	nizj	353000
 修缮	nizu	2440000
 修好	nizy	4770000
@@ -61122,6 +63464,7 @@ encoder:
 僤	njke	517000
 𢍘	njke	0
 𩴫	njke	0
+𫙎	njke	0
 䰠	njki	10100
 𩲳	njki	0
 𩴤	njkk	0
@@ -61207,10 +63550,12 @@ encoder:
 䰢	njoi	4850
 魀	njon	31700
 𩳻	njon	0
+𪽐	njon	0
 魉	njoo	766000
 魎	njoo	326000
 𩲻	njoo	0
 𩳳	njoo	0
+𫙉	njoo	0
 𩴑	njop	0
 𩴎	njoq	0
 𠒆	njor	0
@@ -61244,6 +63589,7 @@ encoder:
 𩳉	njpy	0
 𩳎	njpy	0
 𩳕	njpz	0
+𫒀	njpz	0
 促膝	njqf	709000
 𩴰	njqm	0
 鬼脸	njqo	9910000
@@ -61296,6 +63642,7 @@ encoder:
 保康	njtx	601000
 𩲯	njub	0
 𩴴	njub	0
+𫙊	njuc	0
 保单	njuk	2010000
 𣉭	njuk	0
 向着	njul	15900000
@@ -61341,7 +63688,9 @@ encoder:
 保驾	njyj	2060000
 𩲤	njyj	0
 向阳	njyk	5590000
+𫙍	njyl	0
 𩱹	njym	0
+𪜯	njym	0
 𩴹	njyn	0
 保险	njyo	102000000
 㼰	njys	6850
@@ -61390,6 +63739,7 @@ encoder:
 偿	nkbz	8430000
 𤽎	nkbz	0
 𤾼	nkbz	0
+𪾁	nkbz	0
 𤽯	nkcd	0
 𩔇	nkcg	0
 伸长	nkch	2710000
@@ -61481,6 +63831,7 @@ encoder:
 𢿉	nkix	0
 𢿎	nkix	0
 𤽐	nkix	0
+𪾀	nkja	0
 㑽	nkjb	4070
 㿧	nkjd	6590
 但因	nkjd	7020000
@@ -61494,10 +63845,13 @@ encoder:
 償	nkjl	2260000
 皜	nkjl	581000
 𤾘	nkjl	0
+𪾃	nkjm	0
 白喉	nkjn	359000
 傥	nkjr	318000
 𤽪	nkjr	0
 𤾮	nkjr	0
+𪽿	nkjr	0
+𪾂	nkjr	0
 僼	nkju	60200
 皚	nkju	188000
 𤾢	nkju	0
@@ -61512,6 +63866,7 @@ encoder:
 儂	nkkg	1920000
 皝	nkkg	167000
 皩	nkkg	22800
+𪝚	nkkg	0
 畠	nkki	949000
 鼻甲	nkki	172000
 𤽙	nkki	0
@@ -61537,6 +63892,7 @@ encoder:
 倘	nkld	6140000
 帛	nkli	3710000
 𤾥	nklk	0
+𪝑	nklk	0
 𢄗	nkll	0
 𣻮	nkll	0
 僘	nklm	55500
@@ -61544,6 +63900,7 @@ encoder:
 𦧠	nklm	0
 皠	nkln	86600
 𢅬	nklo	0
+𪽾	nklo	0
 𢄝	nklr	0
 𪁼	nklr	0
 僈	nklx	134000
@@ -61598,6 +63955,7 @@ encoder:
 𢅉	nknr	0
 𤾆	nknr	0
 𤾇	nknr	0
+𫛘	nknr	0
 但他	nknv	41400000
 鼻息	nknw	2160000
 𢀎	nknz	0
@@ -61608,6 +63966,7 @@ encoder:
 𤿂	nkoc	0
 白人	nkod	5510000
 儤	nkok	539000
+𪟇	nkok	0
 皎	nkoo	1760000
 舅父	nkoo	485000
 𤽬	nkoo	0
@@ -61624,6 +63983,7 @@ encoder:
 鼻饲	nkoy	282000
 𤽉	nkoy	0
 𣌣	nkoz	0
+𪽽	nkpd	0
 皤	nkpk	235000
 𢿬	nkpm	0
 𥡻	nkpm	0
@@ -61682,6 +64042,7 @@ encoder:
 白族	nksm	1470000
 白话	nksm	1950000
 皦	nksm	76800
+𪽼	nkso	0
 𣪧	nksq	0
 㰾	nksr	16800
 𤽕	nksr	0
@@ -61704,6 +64065,7 @@ encoder:
 白糖	nkut	4710000
 𤎥	nkuu	0
 𤾃	nkuu	0
+𪝧	nkuu	0
 偶数	nkuz	1450000
 白河	nkva	4030000
 偿清	nkvc	151000
@@ -61738,6 +64100,7 @@ encoder:
 伸展	nkxe	5480000
 俏皮	nkxi	5170000
 𤾰	nkxi	0
+𪽧	nkxi	0
 𤾙	nkxj	0
 𤾭	nkxk	0
 𠍦	nkxl	0
@@ -61745,6 +64108,7 @@ encoder:
 𤽶	nkxm	0
 𠙡	nkxq	0
 𠙧	nkxq	0
+𪴭	nkxr	0
 白昼	nkxs	2880000
 但对	nkxv	14900000
 𤽿	nkxw	0
@@ -61760,6 +64124,7 @@ encoder:
 𠡈	nkym	0
 白费	nkyn	5420000
 𤾫	nkyn	0
+𪾄	nkyq	0
 𣣝	nkyr	0
 㼟	nkys	4790
 𤾡	nkyu	0
@@ -61775,6 +64140,7 @@ encoder:
 𤽸	nkzb	0
 皪	nkzf	67000
 𤾾	nkzf	0
+𪾅	nkzh	0
 𠈷	nkzi	0
 𢅞	nkzk	0
 𤽺	nkzk	0
@@ -61783,6 +64149,7 @@ encoder:
 𠈐	nkzm	0
 𠈤	nkzm	0
 𠐍	nkzm	0
+𪜿	nkzm	0
 𣌣	nkzo	0
 𣪕	nkzq	0
 白纸	nkzr	4160000
@@ -61807,6 +64174,7 @@ encoder:
 倶	nlao	807000
 𠔙	nlao	0
 𦥺	nlax	0
+𫀫	nlaz	0
 𪖢	nlbb	0
 𣍝	nlbd	0
 倜	nlbj	330000
@@ -61864,6 +64232,7 @@ encoder:
 齅	nlgs	21800
 𠋬	nlgs	0
 𤠩	nlgs	0
+𫜤	nlgs	0
 𠋌	nlgu	0
 𤒝	nlgu	0
 𦤠	nlgu	0
@@ -61906,6 +64275,7 @@ encoder:
 𣳻	nlkv	0
 𦤓	nlkz	0
 𪖹	nlkz	0
+𫇌	nlkz	0
 𠈕	nlld	0
 䶐	nllk	3830
 𪖾	nlln	0
@@ -61913,6 +64283,7 @@ encoder:
 自用	nllv	9440000
 催眠	nlly	13800000
 自助	nlly	106000000
+𪝼	nllz	0
 自筹	nlmc	1440000
 𡘠	nlmg	0
 𦧗	nlmi	0
@@ -61945,12 +64316,14 @@ encoder:
 𠎺	nlnj	0
 𩳈	nlnj	0
 劓	nlnk	124000
+𫇋	nlnk	0
 儶	nlnl	43200
 皑皑	nlnl	754000
 𪖖	nlnm	0
 𪖴	nlnm	0
 𪖛	nlnp	0
 鼽	nlnq	68700
+𫗅	nlnq	0
 䶌	nlnr	3760
 催化	nlnr	4720000
 𪖗	nlnr	0
@@ -61965,6 +64338,7 @@ encoder:
 佣人	nlod	1560000
 𦤖	nloe	0
 自杀	nlof	22800000
+𪥌	nlog	0
 自行	nloi	120000000
 𦣿	nloi	0
 𪖝	nloj	0
@@ -61991,6 +64365,7 @@ encoder:
 𧠆	nlrd	0
 自然	nlrg	310000000
 㒔	nlri	4420
+𪝱	nlri	0
 齁	nlrj	1320000
 𪖼	nlrk	0
 儩	nlro	63800
@@ -62024,6 +64399,7 @@ encoder:
 𠏩	nlsr	0
 𧚡	nlsr	0
 𧛲	nlsr	0
+𪝢	nlsr	0
 自立	nlsu	11800000
 侺	nlsx	41600
 侧记	nlsy	1450000
@@ -62035,6 +64411,7 @@ encoder:
 自尊	nluf	9350000
 奥	nlug	161000000
 𠏥	nlug	0
+𫇍	nluk	0
 𣀐	nlum	0
 自首	nlun	3320000
 𦤩	nlux	0
@@ -62042,6 +64419,7 @@ encoder:
 𪖦	nluy	0
 自满	nlve	1290000
 臯	nlve	69700
+𪜮	nlvv	0
 自学	nlvw	16600000
 自觉	nlvw	42000000
 自治	nlvz	14100000
@@ -62052,6 +64430,7 @@ encoder:
 𪖰	nlwl	0
 自选	nlwm	17600000
 𦧰	nlwm	0
+𪬤	nlwm	0
 𦤤	nlwn	0
 𪃼	nlwr	0
 𪕿	nlwr	0
@@ -62060,6 +64439,7 @@ encoder:
 𠕫	nlww	0
 𪖧	nlwx	0
 鄎	nlwy	37800
+𫇊	nlwy	0
 息	nlwz	79900000
 䶊	nlxe	3770
 𦤊	nlxe	0
@@ -62075,6 +64455,7 @@ encoder:
 自卫	nlya	3520000
 自强	nlyj	6010000
 𪖠	nlyj	0
+𪜾	nlym	0
 自费	nlyn	4180000
 𠍟	nlyn	0
 甈	nlys	55600
@@ -62084,11 +64465,13 @@ encoder:
 翺	nlyy	73700
 自己	nlyy	962000000
 𦤥	nlyy	0
+𫅱	nlyy	0
 𪖶	nlze	0
 䶑	nlzi	3730
 自如	nlzj	11100000
 𠟲	nlzk	0
 仙女	nlzm	8180000
+𪥴	nlzm	0
 儸	nlzn	627000
 𪖿	nlzn	0
 自给	nlzo	2040000
@@ -62101,6 +64484,7 @@ encoder:
 倂	nmae	165000
 𠍹	nmaj	0
 作恶	nmak	637000
+𪝜	nmal	0
 伤残	nmar	2590000
 仟万	nmay	226000
 𠋐	nmaz	0
@@ -62162,6 +64546,7 @@ encoder:
 𠑥	nmjd	0
 作呕	nmjh	1480000
 作品	nmjj	386000000
+𫖄	nmjk	0
 伤员	nmjl	2150000
 僑	nmjl	6400000
 𠎷	nmka	0
@@ -62178,6 +64563,7 @@ encoder:
 作用	nmlv	192000000
 任县	nmlz	497000
 𠈠	nmmb	0
+𪜼	nmmb	0
 𠐬	nmmg	0
 𠎔	nmmm	0
 作答	nmmo	2850000
@@ -62257,6 +64643,7 @@ encoder:
 𠐉	nmxy	0
 㑧	nmya	4270
 仡	nmyd	757000
+𪜓	nmyd	0
 侨民	nmyh	655000
 𪘗	nmyi	0
 伤	nmym	112000000
@@ -62274,6 +64661,7 @@ encoder:
 𠇓	nmzz	0
 𠏿	nnan	0
 𠋐	nnaz	0
+𪝒	nncq	0
 俾	nned	11800000
 牌楼	nnfu	1240000
 𠌞	nngx	0
@@ -62320,6 +64708,7 @@ encoder:
 㑺	nnym	5250
 𠏙	nnzd	0
 𡠓	nnzm	0
+𪥷	nnzm	0
 伯母	nnzy	1830000
 佮	noaj	115000
 倫	noal	15900000
@@ -62335,6 +64724,7 @@ encoder:
 𪙼	nobi	0
 𩁅	nobn	0
 𠈖	nobo	0
+𪝓	nobq	0
 𧭨	nobs	0
 俭	nobv	4710000
 𨞄	noby	0
@@ -62441,6 +64831,9 @@ encoder:
 份	noyd	240000000
 𠌋	noyg	0
 伦巴	noyi	733000
+𪝕	noyl	0
+𪼽	noys	0
+𪫱	noyw	0
 㒆	noyy	4660
 伧	noyy	234000
 傟	noyy	32700
@@ -62480,6 +64873,7 @@ encoder:
 𠍖	nprs	0
 𠊄	npvv	0
 僾	npwr	892000
+𪝈	npwx	0
 僁	npwz	27800
 𠊻	npxf	0
 𠌀	npxk	0
@@ -62487,6 +64881,7 @@ encoder:
 㒚	npxw	4300
 俘	npya	5230000
 𠈊	npyi	0
+𪝛	npyq	0
 僞	npyu	701000
 傒	npzg	125000
 俀	npzm	103000
@@ -62508,6 +64903,7 @@ encoder:
 㐽	nqos	5350
 佩服	nqqy	25600000
 仇怨	nqry	550000
+𪝝	nqug	0
 𠑇	nqul	0
 仇恨	nqux	40300000
 仴	nqvv	529000
@@ -62584,6 +64980,7 @@ encoder:
 𠊫	nrky	0
 偕同	nrld	655000
 𠊇	nrld	0
+𪝀	nrld	0
 华山	nrll	9500000
 偩	nrlo	448000
 貨	nrlo	52000000
@@ -62599,6 +64996,7 @@ encoder:
 𠏤	nrml	0
 低矮	nrmm	1630000
 货物	nrmr	26200000
+𪝨	nrmu	0
 𠇩	nrmy	0
 化身	nrnc	11200000
 低估	nrne	14300000
@@ -62623,6 +65021,7 @@ encoder:
 倾盆	nroy	1440000
 俢	nrpd	98200
 倾销	nrpk	1980000
+𪝵	nrpk	0
 货舱	nrpo	365000
 货船	nrpq	944000
 你所	nrpv	27900000
@@ -62638,6 +65037,7 @@ encoder:
 𣢉	nrro	0
 仳	nrrr	205000
 𪂄	nrrr	0
+𪜪	nrrr	0
 侈	nrrs	951000
 儳	nrrs	854000
 𠋂	nrrt	0
@@ -62707,16 +65107,19 @@ encoder:
 𠌃	nryk	0
 𠎿	nrym	0
 华阴	nryq	443000
+𪝔	nryw	0
 𠆿	nrza	0
 𠌥	nrza	0
 化纤	nrzm	16100000
 𠈍	nrzm	0
 低能	nrzq	5820000
 华约	nrzr	151000
+𪜩	nrzs	0
 低级	nrzy	7280000
 你好	nrzy	125000000
 您好	nrzy	83200000
 位于	nsad	84100000
+𪝯	nsad	0
 停刊	nsae	823000
 𠎂	nsag	0
 𠋣	nsaj	0
@@ -62770,6 +65173,7 @@ encoder:
 储量	nska	3240000
 儃	nska	44800
 𠑠	nska	0
+𪝂	nska	0
 僮	nskb	1550000
 傽	nske	39200
 僦	nskg	1230000
@@ -62798,6 +65202,7 @@ encoder:
 倣	nsmo	1260000
 偐	nsmp	655000
 位移	nsmr	2090000
+𪝮	nsmr	0
 𠍭	nsms	0
 㑪	nsnd	4290
 侪	nsnd	329000
@@ -62909,6 +65314,7 @@ encoder:
 俯	ntnd	8950000
 㒣	ntnw	4600
 𠏛	ntos	0
+𪝊	ntra	0
 佽	ntro	1750000
 偝	ntrq	771000
 𠉆	ntrr	0
@@ -62937,6 +65343,7 @@ encoder:
 焦虑	nuiw	9200000
 焦距	nujh	7260000
 焦躁	nujj	2590000
+𪝩	nujl	0
 侻	nujr	58800
 𠐹	nukl	0
 伪劣	nukm	5110000
@@ -62951,6 +65358,7 @@ encoder:
 僧侣	nunj	1560000
 焦作	nunm	6160000
 伙伴	nunu	305000000
+𪝞	nuol	0
 伙食	nuox	6180000
 𠐒	nuox	0
 𠉅	nuoy	0
@@ -62996,6 +65404,7 @@ encoder:
 𠊶	nuzm	0
 𠋄	nuzm	0
 𠈼	nuzx	0
+𪝳	nvbo	0
 𠑊	nvcm	0
 他的	nvdv	209000000
 𠍀	nvfk	0
@@ -63018,6 +65427,7 @@ encoder:
 𠎢	nvzw	0
 佇	nwai	779000
 偏下	nwai	347000
+𪝣	nwaj	0
 𠍊	nwan	0
 儙	nway	94300
 倥	nwbi	789000
@@ -63036,8 +65446,10 @@ encoder:
 偏大	nwgd	2120000
 𠉂	nwgd	0
 傢	nwgq	10900000
+𪝘	nwgq	0
 㑦	nwgs	4520
 𠊲	nwgs	0
+𪝴	nwgy	0
 偏转	nwhb	799000
 𠋤	nwhb	0
 偏上	nwiv	538000
@@ -63045,7 +65457,9 @@ encoder:
 𠑅	nwju	0
 𠐟	nwkk	0
 儐	nwkl	607000
+𪝹	nwkm	0
 偏小	nwko	1650000
+𪝤	nwko	0
 儜	nwla	410000
 𠊙	nwlc	0
 偏	nwld	84600000
@@ -63108,6 +65522,7 @@ encoder:
 偏心	nwwz	2560000
 僒	nwxj	40400
 𠌣	nwxj	0
+𪜸	nwya	0
 傓	nwyy	39700
 侒	nwzm	142000
 𠊢	nwzm	0
@@ -63137,18 +65552,21 @@ encoder:
 僻壤	nxbs	157000
 伊吾	nxbx	196000
 健	nxby	86300000
+𪺣	nxcd	0
 𤗮	nxcl	0
 㒈	nxcm	4570
 𠑨	nxcm	0
 伊春	nxco	2390000
 僻静	nxcq	1510000
 侵扰	nxdg	1380000
+𪜫	nxed	0
 𤗥	nxef	0
 假若	nxeg	3490000
 𠌄	nxeh	0
 𧌛	nxei	0
 倨	nxej	708000
 𤖲	nxej	0
+𪺦	nxek	0
 𤗸	nxel	0
 𧡦	nxel	0
 假期	nxeq	25600000
@@ -63341,6 +65759,7 @@ encoder:
 侵犯	nxqy	70500000
 𤗅	nxqz	0
 片儿	nxrd	862000
+𪝪	nxri	0
 假名	nxrj	1420000
 假象	nxrj	3950000
 𤖵	nxrj	0
@@ -63422,7 +65841,9 @@ encoder:
 𧌿	nxxi	0
 牗	nxxl	273000
 片尾	nxxm	1250000
+𪺢	nxxo	0
 𠃆	nxxp	0
+𪺥	nxxw	0
 假	nxxx	214000000
 𤖰	nxxx	0
 𤗜	nxxx	0
@@ -63431,6 +65852,7 @@ encoder:
 侷	nxyj	1260000
 倔强	nxyj	6600000
 牊	nxyj	636000
+𪺤	nxyk	0
 𤗖	nxyl	0
 𠡒	nxym	0
 𤗨	nxyn	0
@@ -63472,6 +65894,7 @@ encoder:
 仍不	nygi	7860000
 仍有	nygq	21200000
 健在	nygv	5430000
+𪜳	nyhd	0
 佛牙	nyhi	148000
 𠊽	nyhk	0
 𠇕	nyia	0
@@ -63480,6 +65903,7 @@ encoder:
 亿吨	nyjh	3670000
 𠎦	nyji	0
 𩎵	nyjm	0
+𪝁	nyjr	0
 伽师	nyka	196000
 佛光	nykg	2680000
 仍是	nykv	26300000
@@ -63490,6 +65914,7 @@ encoder:
 侹	nymb	57900
 㺱	nymc	4320
 佛手	nymd	2130000
+𪜷	nymf	0
 𠈰	nymi	0
 𠋉	nymn	0
 伋	nyms	133000
@@ -63508,6 +65933,7 @@ encoder:
 仍然	nyrg	108000000
 㒊	nysi	4720
 健忘	nysw	2730000
+𪫫	nysw	0
 健壮	nytb	7430000
 佛门	nytl	1810000
 健康	nytx	529000000
@@ -63522,14 +65948,18 @@ encoder:
 𠊩	nyya	0
 㐶	nyyb	8080
 㒛	nyyn	4060
+𪝟	nyyo	0
+𪜹	nyyt	0
 佛陀	nyyw	2870000
 仔细	nyzk	91500000
 仍能	nyzq	4500000
+𪜴	nyzs	0
 佛经	nyzx	3350000
 似无	nzag	1200000
 𠊦	nzai	0
 𠋷	nzai	0
 𠎨	nzaj	0
+𪜺	nzds	0
 似的	nzdv	35800000
 牒	nzef	1750000
 㑬	nzej	4390
@@ -63590,6 +66020,7 @@ encoder:
 𧯚	oaju	0
 命中	oajv	24700000
 命题	oaka	8220000
+𫜜	oakl	0
 合影	oaks	8870000
 合水	oakv	345000
 合同	oald	162000000
@@ -63598,6 +66029,7 @@ encoder:
 惩罚	oals	21100000
 合用	oalv	2660000
 征用	oalv	3020000
+𪟢	oaly	0
 命悬	oalz	726000
 歙县	oalz	1110000
 八千	oame	5430000
@@ -63644,8 +66076,10 @@ encoder:
 征途	oawo	16900000
 命案	oawz	3050000
 合璧	oaxj	1520000
+𪾗	oaxl	0
 合欢	oaxr	4070000
 𠔥	oaxu	0
+𫐡	oaxw	0
 拿骚	oaxx	198000
 盒子	oaya	16500000
 鸽子	oaya	5950000
@@ -63881,6 +66315,7 @@ encoder:
 兦	odaz	56700
 𠆦	odaz	0
 𠋒	odaz	0
+𪞶	odaz	0
 人士	odba	129000000
 𠈘	odbb	0
 𡒟	odbb	0
@@ -63892,6 +66327,7 @@ encoder:
 佘	odbk	3530000
 剉	odbk	292000
 畲	odbk	643000
+𪜬	odbk	0
 𡎬	odbl	0
 𢁭	odbl	0
 𠐸	odbn	0
@@ -63906,16 +66342,20 @@ encoder:
 𨤾	odbu	0
 佥	odbv	450000
 𢚒	odbw	0
+𪠩	odbx	0
 入场	odby	8020000
 𨛏	odby	0
 会	odbz	1300000000
 侌	odbz	30700
 𠆭	odbz	0
 𦣹	odbz	0
+𪼈	odcc	0
+𪼉	odcc	0
 入球	odcd	2400000
 𠑋	odce	0
 𦔴	odce	0
 𠛮	odck	0
+𫗙	odcl	0
 𠑴	odcq	0
 𨛈	odcy	0
 人事	oddj	78400000
@@ -63924,6 +66364,7 @@ encoder:
 㙦	odeb	4320
 仐	oded	81500
 𢨍	odeh	0
+𫅜	odej	0
 侴	odek	27100
 𠜋	odek	0
 𠝢	odek	0
@@ -63961,8 +66402,10 @@ encoder:
 𡬴	odhd	0
 人车	odhe	3150000
 㒪	odhg	4380
+𪽚	odhk	0
 𠌆	odhx	0
 𠓴	odhx	0
+𫗎	odhx	0
 𠆳	odia	0
 𪛍	odia	0
 㒪	odig	4380
@@ -64008,6 +66451,8 @@ encoder:
 畣	odjk	48200
 𠑱	odjk	0
 𣌭	odjk	0
+𫕽	odjk	0
+𫗖	odjk	0
 人员	odjl	313000000
 盒	odjl	124000000
 龠	odjl	226000
@@ -64047,10 +66492,13 @@ encoder:
 𨛣	odjy	0
 𨜾	odjy	0
 𨞡	odjy	0
+𪠁	odjy	0
+𪦻	odjy	0
 韱	odka	63500
 𨤾	odka	0
 𩚃	odka	0
 𡍑	odkb	0
+𪜽	odkb	0
 入时	odkd	1600000
 𠌓	odke	0
 𣡰	odkf	0
@@ -64087,6 +66535,7 @@ encoder:
 入党	odkw	8960000
 愈	odkw	61300000
 逾	odkw	37000000
+𪬪	odkw	0
 𥀟	odkx	0
 鄃	odky	37800
 鄶	odky	32300
@@ -64117,6 +66566,7 @@ encoder:
 𪇝	odlr	0
 𪛓	odlt	0
 𢜒	odlw	0
+𫐮	odlw	0
 𠐗	odlx	0
 𨞅	odly	0
 禽	odlz	28500000
@@ -64130,6 +66580,7 @@ encoder:
 入手	odmd	50200000
 余	odmf	143000000
 舖	odmf	20600000
+𪜱	odmf	0
 𩓱	odmg	0
 𢧅	odmh	0
 舍	odmi	58600000
@@ -64155,6 +66606,7 @@ encoder:
 人物	odmr	224000000
 人称	odmr	13600000
 鵨	odmr	25700
+𫛬	odmr	0
 𠐖	odms	0
 𣁏	odms	0
 入秋	odmu	1260000
@@ -64181,6 +66633,7 @@ encoder:
 𠉼	odnr	0
 𠊊	odnr	0
 𠎍	odnr	0
+𪯰	odnr	0
 入住	odns	18600000
 人们	odnt	190000000
 𢗊	odnw	0
@@ -64195,6 +66648,7 @@ encoder:
 𠓾	odoc	0
 𤫆	odoc	0
 𦗼	odoc	0
+𫗐	odoc	0
 人人	odod	40100000
 仌	odod	69800
 从	odod	683000000
@@ -64263,6 +66717,7 @@ encoder:
 劎	odoy	363000
 𠝏	odoy	0
 𡦸	odoy	0
+𪞇	odoy	0
 𠚄	odoz	0
 𠚕	odoz	0
 𦃚	odoz	0
@@ -64278,6 +66733,7 @@ encoder:
 𨡳	odpq	0
 𠎈	odpx	0
 𠆹	odpz	0
+𫖾	odqb	0
 俞	odqk	24300000
 𠈛	odqk	0
 𠍐	odqp	0
@@ -64292,6 +66748,7 @@ encoder:
 𡎢	odri	0
 𡎦	odri	0
 𧓀	odri	0
+𪫶	odri	0
 人名	odrj	19600000
 𠐂	odrj	0
 𠷜	odrj	0
@@ -64308,6 +66765,7 @@ encoder:
 𠈢	odry	0
 𨚐	odry	0
 入主	odsc	5190000
+𫇕	odsc	0
 人意	odsk	10400000
 韽	odsk	78700
 𠊺	odsk	0
@@ -64387,6 +66845,8 @@ encoder:
 邻	odwy	28700000
 人心	odwz	40500000
 人马	odxa	3010000
+𪣶	odxb	0
+𪣸	odxb	0
 酓	odxf	25900
 𣜈	odxf	0
 𩑟	odxg	0
@@ -64394,6 +66854,7 @@ encoder:
 𦢢	odxh	0
 舒	odxi	45100000
 𧆺	odxi	0
+𪝶	odxi	0
 人群	odxj	45000000
 倉	odxj	9650000
 含	odxj	171000000
@@ -64417,6 +66878,7 @@ encoder:
 𠉞	odxr	0
 𣢝	odxr	0
 𪚕	odxs	0
+𪝃	odxs	0
 念	odxw	93700000
 𠇀	odxx	0
 𨙽	odxy	0
@@ -64434,10 +66896,12 @@ encoder:
 𠑝	odyn	0
 𠟐	odyo	0
 𡦈	odyp	0
+𪵍	odyq	0
 歙	odyr	2020000
 鸧	odyr	50500
 𪂤	odyr	0
 𪅲	odyr	0
+𪴱	odyr	0
 㼨	odys	4780
 㼶	odys	5030
 㽂	odys	5090
@@ -64469,6 +66933,7 @@ encoder:
 𠋔	odzl	0
 𢄕	odzl	0
 𥁧	odzl	0
+𫇙	odzl	0
 㠩	odzn	4780
 𡄬	odzn	0
 𠆹	odzp	0
@@ -64575,6 +67040,7 @@ encoder:
 𢓁	oibi	0
 㣟	oibj	3960
 徟	oibj	25000
+𫋮	oibj	0
 徕	oibk	3350000
 𢓛	oibk	0
 𢖂	oibl	0
@@ -64593,7 +67059,9 @@ encoder:
 㣵	oibu	4520
 𢔛	oibu	0
 𢖛	oibu	0
+𪫙	oibu	0
 𢡹	oibw	0
+𪫍	oibw	0
 徤	oiby	68200
 𢓧	oiby	0
 行动	oibz	102000000
@@ -64636,9 +67104,11 @@ encoder:
 𢔇	oiez	0
 徱	oifb	20400
 𢕰	oifd	0
+𪫖	oifd	0
 㣩	oiff	5670
 䵈	oiff	4030
 𪎓	oiff	0
+𪫛	oifg	0
 徆	oifj	66300
 䡓	oifk	4660
 𠝨	oifk	0
@@ -64659,6 +67129,7 @@ encoder:
 𧲞	oigl	0
 㣸	oigm	7660
 𢖢	oigm	0
+𪫌	oigm	0
 𢓻	oigq	0
 𧗢	oigr	0
 㣖	oigs	3590
@@ -64683,6 +67154,7 @@ encoder:
 衐	oihx	21400
 彻	oihy	9980000
 聳	oiic	1330000
+𫆎	oiic	0
 𢖤	oiig	0
 徙	oiii	1890000
 𢓊	oiii	0
@@ -64696,6 +67168,7 @@ encoder:
 𢔼	oiim	0
 𢖄	oiim	0
 𣯨	oiim	0
+𪫏	oiim	0
 𩀰	oiin	0
 𩞐	oiio	0
 𢔞	oiiq	0
@@ -64714,9 +67187,11 @@ encoder:
 行距	oijh	1280000
 㣡	oiji	7680
 𢖀	oiji	0
+𪫘	oiji	0
 徊	oijj	3010000
 𢕓	oijj	0
 𢔯	oijk	0
+𫋰	oijk	0
 𢔸	oijl	0
 𢔹	oijl	0
 𢕪	oijl	0
@@ -64724,6 +67199,7 @@ encoder:
 徫	oijm	76900
 衛	oijm	17200000
 𢕡	oijm	0
+𪫎	oijm	0
 衚	oijq	106000
 企图	oijr	23800000
 𡕴	oijr	0
@@ -64749,6 +67225,7 @@ encoder:
 𢓥	oikg	0
 𧗯	oikg	0
 𧗰	oikg	0
+𪫑	oikh	0
 㣙	oiki	3580
 𢔒	oikk	0
 徜	oikl	3820000
@@ -64782,6 +67259,7 @@ encoder:
 㣚	oild	3510
 衕	oild	45400
 𢔶	oild	0
+𫋭	oild	0
 𣟉	oilf	0
 行贿	oilg	2670000
 𧗽	oilg	0
@@ -64815,6 +67293,7 @@ encoder:
 𢖘	oilw	0
 𢖠	oilz	0
 𧗼	oilz	0
+𫋱	oilz	0
 𢓐	oimb	0
 𢔉	oimb	0
 徃	oimc	519000
@@ -64825,6 +67304,7 @@ encoder:
 𢓩	oimi	0
 𢖙	oimi	0
 𧘆	oimi	0
+𪫗	oimi	0
 行程	oimj	35700000
 躗	oimj	11700
 𢔊	oimj	0
@@ -64833,6 +67313,7 @@ encoder:
 𥋪	oiml	0
 𧢒	oiml	0
 𧢓	oiml	0
+𪿂	oiml	0
 𢔣	oimn	0
 𢔖	oimo	0
 𢔜	oimp	0
@@ -64852,6 +67333,7 @@ encoder:
 𢖟	oimz	0
 行使	oina	15000000
 徨	oinc	1720000
+𫋯	oinc	0
 𡭑	oind	0
 𧘄	oind	0
 𢔌	oine	0
@@ -64918,6 +67400,8 @@ encoder:
 𢕝	oirc	0
 𢔨	oird	0
 衡	oirg	10900000
+𪫔	oirg	0
+𪫓	oiri	0
 㣘	oirj	3750
 𢓜	oirj	0
 徇	oirk	752000
@@ -64936,6 +67420,7 @@ encoder:
 𢔚	oirs	0
 𢕻	oirs	0
 𢖞	oirs	0
+𪫐	oirs	0
 㣠	oirt	4770
 𢓈	oirt	0
 𢓘	oirt	0
@@ -64954,11 +67439,13 @@ encoder:
 𢕉	oisi	0
 𢕬	oisi	0
 𧗹	oisk	0
+𪩵	oisl	0
 徼	oism	781000
 徾	oism	26900
 𢕟	oism	0
 𥟲	oism	0
 𢓌	oiso	0
+𪫋	oiso	0
 䘕	oisq	3690
 𢓔	oisu	0
 𢕦	oisx	0
@@ -64996,6 +67483,7 @@ encoder:
 徧	oiwl	183000
 㣗	oiwm	3410
 𢖒	oiwr	0
+𪫒	oiwr	0
 徬	oiws	907000
 𢕨	oiws	0
 𢔀	oiwx	0
@@ -65055,6 +67543,8 @@ encoder:
 徽	oizm	14200000
 𢓪	oizm	0
 𢕄	oizm	0
+𪫕	oizm	0
+𪫜	oizm	0
 𢔫	oizq	0
 𢔮	oizq	0
 㣞	oizr	3410
@@ -65220,6 +67710,7 @@ encoder:
 𧮴	ooej	0
 谼	ooeo	30100
 坐落	ooev	7980000
+𪺛	ooez	0
 坐标	oofb	9670000
 丛林	ooff	7690000
 谷雨	oofv	573000
@@ -65242,6 +67733,7 @@ encoder:
 𣴲	oojk	0
 𧮮	oojm	0
 𨿜	oojn	0
+𫎀	oojo	0
 䜪	oojq	3850
 𧮭	oojq	0
 欲	oojr	141000000
@@ -65349,6 +67841,7 @@ encoder:
 𧯎	ooxq	0
 𣢲	ooxr	0
 丛书	ooxy	27300000
+𪺜	ooxy	0
 斧子	ooya	1060000
 父子	ooya	10400000
 谷子	ooya	1920000
@@ -65357,6 +67850,7 @@ encoder:
 𧮬	ooye	0
 爸	ooyi	78000000
 𤭏	ooys	0
+𪼾	ooys	0
 豀	oozg	28600
 𧯗	oozg	0
 𠚁	oozi	0
@@ -65437,6 +67931,7 @@ encoder:
 𣌇	osck	0
 今春	osco	2840000
 往事	osdj	25000000
+𪲽	osdp	0
 含蓄	oses	5690000
 𢺽	osex	0
 贪婪	osff	10100000
@@ -65449,6 +67944,7 @@ encoder:
 𪀣	osfr	0
 𣏂	osfs	0
 𨐖	osfs	0
+𫂿	osfu	0
 𠯌	osgj	0
 希	osgl	70200000
 𢂞	osgl	0
@@ -65507,6 +68003,7 @@ encoder:
 𧠔	osol	0
 𢼂	osom	0
 𢼫	osom	0
+𪺝	osom	0
 彷徨	oson	6130000
 㸚	osoo	4560
 𨌸	osoo	0
@@ -65546,6 +68043,7 @@ encoder:
 念头	ostg	15600000
 含糊	osue	6980000
 含着	osul	6110000
+𪞊	osul	0
 𤉧	osum	0
 含羞	osux	2380000
 贪污	osvb	12800000
@@ -65561,9 +68059,11 @@ encoder:
 𤕟	osxi	0
 𩰠	osxi	0
 閷	osxo	82800
+𪠣	osxs	0
 𠮁	osxx	0
 念书	osxy	2940000
 饺子	osya	5860000
+𪡘	osyb	0
 𠫲	osye	0
 敎	osym	2330000
 𢽌	osym	0
@@ -65661,6 +68161,7 @@ encoder:
 餠	oxae	181000
 𩛧	oxae	0
 𩝂	oxae	0
+𫗞	oxae	0
 䬴	oxaf	6320
 饛	oxag	31900
 𩝬	oxag	0
@@ -65701,6 +68202,7 @@ encoder:
 𩞢	oxbq	0
 𩟆	oxbq	0
 䬧	oxbr	3650
+𫗟	oxbr	0
 䭞	oxbu	3640
 𤏼	oxbu	0
 𩜜	oxbu	0
@@ -65717,8 +68219,10 @@ encoder:
 饵	oxce	4010000
 很长	oxch	25300000
 餦	oxch	46900
+𫗠	oxch	0
 𩝛	oxcj	0
 䭍	oxcl	4270
+𫗙	oxcl	0
 䭛	oxcm	3810
 𩜎	oxcq	0
 𩚽	oxcs	0
@@ -65737,9 +68241,11 @@ encoder:
 䭅	oxej	4300
 𩚩	oxej	0
 𩛶	oxej	0
+𫗡	oxej	0
 𩜅	oxek	0
 饙	oxel	28600
 𩟲	oxel	0
+𫗕	oxel	0
 𩝟	oxen	0
 𩟙	oxen	0
 餀	oxeo	34600
@@ -65748,10 +68254,12 @@ encoder:
 𩛘	oxeo	0
 𩛛	oxeo	0
 𩞫	oxeo	0
+𫗲	oxep	0
 饟	oxer	42300
 饢	oxer	30200
 馕	oxer	515000
 𩟻	oxer	0
+𫗵	oxer	0
 餝	oxes	39000
 𩛲	oxes	0
 䭖	oxeu	3780
@@ -65763,14 +68271,18 @@ encoder:
 𩝒	oxez	0
 䬱	oxfa	3910
 餔	oxfb	179000
+𫗦	oxfb	0
 䭦	oxfd	3930
 餺	oxfd	31300
 馎	oxfd	38900
 𩟛	oxfd	0
 食槽	oxfe	174000
 饝	oxfg	22500
+𫗔	oxfg	0
+𫗜	oxfg	0
 餗	oxfj	54100
 𩞍	oxfj	0
+𫗧	oxfj	0
 䭩	oxfk	4020
 𩜍	oxfk	0
 𩜫	oxfm	0
@@ -65789,6 +68301,7 @@ encoder:
 餪	oxgg	23000
 𩞪	oxgg	0
 𩟬	oxgg	0
+𫗬	oxgg	0
 䬪	oxgi	4220
 很不	oxgi	38100000
 𩛷	oxgj	0
@@ -65799,6 +68312,7 @@ encoder:
 𩜽	oxgp	0
 很有	oxgq	77300000
 餚	oxgq	87400
+𫗏	oxgq	0
 𩚌	oxgr	0
 𩝠	oxgs	0
 餸	oxgw	261000
@@ -65806,6 +68320,7 @@ encoder:
 𩝘	oxgx	0
 𩚚	oxgy	0
 𩛌	oxgz	0
+𫗤	oxgz	0
 䬹	oxhb	4140
 饶	oxhg	16500000
 餞	oxhh	213000
@@ -65819,6 +68334,7 @@ encoder:
 𩜚	oxhr	0
 𩞊	oxhr	0
 𩞞	oxhr	0
+𫗎	oxhx	0
 𩚦	oxhy	0
 𩜮	oxhy	0
 𩝮	oxhy	0
@@ -65846,6 +68362,7 @@ encoder:
 𩞛	oxjf	0
 𩟎	oxjf	0
 𩞧	oxjg	0
+𫗳	oxji	0
 食品	oxjj	317000000
 饇	oxjj	23900
 𩞒	oxjj	0
@@ -65854,12 +68371,16 @@ encoder:
 𩜰	oxjk	0
 𩞮	oxjk	0
 𩟈	oxjk	0
+𫗖	oxjk	0
+𫗛	oxjk	0
 𩝝	oxjl	0
+𫗘	oxjl	0
 𩞦	oxjm	0
 𩟍	oxjm	0
 𩠏	oxjm	0
 䬼	oxjq	3960
 餬	oxjq	86700
+𫗫	oxjq	0
 䬽	oxjr	4060
 𩚶	oxjr	0
 𩛟	oxjr	0
@@ -65880,6 +68401,7 @@ encoder:
 饘	oxka	64200
 馇	oxka	170000
 𩟶	oxka	0
+𫗴	oxka	0
 䭚	oxkb	3600
 䭪	oxkb	3870
 𩞯	oxkb	0
@@ -65890,6 +68412,7 @@ encoder:
 𩟊	oxkg	0
 餵	oxkh	4090000
 𩞡	oxkh	0
+𫗭	oxkh	0
 𩚲	oxki	0
 䭜	oxkk	3720
 𩞄	oxkk	0
@@ -65939,6 +68462,7 @@ encoder:
 𩜃	oxlo	0
 𩝻	oxlo	0
 𩟿	oxlo	0
+𫗩	oxlr	0
 食用	oxlv	28000000
 餶	oxlw	55200
 馉	oxlw	29000
@@ -65965,12 +68489,15 @@ encoder:
 𩚊	oxmh	0
 飵	oxmi	43000
 餂	oxmi	44600
+𫗢	oxmi	0
+𫗓	oxmj	0
 很重	oxmk	6990000
 𩚸	oxmk	0
 飾	oxml	21200000
 饰	oxml	56700000
 𩝳	oxml	0
 𩟺	oxml	0
+𫗝	oxml	0
 𩝟	oxmn	0
 𩝧	oxmp	0
 食物	oxmr	57800000
@@ -65991,10 +68518,13 @@ encoder:
 𩛪	oxmy	0
 𩛵	oxmy	0
 𩠂	oxmy	0
+𫗰	oxmy	0
 很乱	oxmz	2040000
 餧	oxmz	57300
 𩛸	oxmz	0
+𫗪	oxmz	0
 餭	oxnc	33000
+𫗮	oxnc	0
 𩚭	oxnd	0
 𩟦	oxnh	0
 𩜑	oxni	0
@@ -66013,6 +68543,7 @@ encoder:
 𩟓	oxnx	0
 𩛀	oxoa	0
 𩛠	oxob	0
+𫗐	oxoc	0
 飤	oxod	26600
 𩚆	oxod	0
 𩜘	oxoe	0
@@ -66109,6 +68640,7 @@ encoder:
 𩞃	oxro	0
 䬨	oxrq	4240
 𩜧	oxrq	0
+𫗑	oxrq	0
 䬷	oxrr	4210
 餛	oxrr	798000
 馄	oxrr	1710000
@@ -66147,6 +68679,7 @@ encoder:
 𩚕	oxsx	0
 𩛡	oxsx	0
 𩟼	oxsx	0
+𫗨	oxsx	0
 𩚠	oxsy	0
 𩜛	oxsy	0
 𩜭	oxte	0
@@ -66183,6 +68716,7 @@ encoder:
 䭑	oxux	4020
 䭠	oxux	4350
 很快	oxux	84800000
+𫗱	oxux	0
 䬾	oxuy	3990
 𩜇	oxuy	0
 𩠉	oxuy	0
@@ -66198,10 +68732,12 @@ encoder:
 𩞙	oxwf	0
 𩞈	oxwg	0
 𩠅	oxwg	0
+𫗥	oxwh	0
 食补	oxwi	1160000
 䭏	oxwl	4200
 𩟂	oxwl	0
 飶	oxwm	46900
+𫗣	oxwm	0
 食宿	oxwn	4960000
 𩚗	oxwq	0
 𩟞	oxwr	0
@@ -66215,6 +68751,7 @@ encoder:
 𩚬	oxwy	0
 𩛓	oxwy	0
 𩛖	oxwz	0
+𫗒	oxwz	0
 䭈	oxxb	4350
 𩛐	oxxb	0
 饈	oxxe	53200
@@ -66231,8 +68768,11 @@ encoder:
 𩞷	oxxk	0
 𩛤	oxxl	0
 𩞋	oxxl	0
+𪾗	oxxl	0
+𫗗	oxxl	0
 䬿	oxxm	4550
 餱	oxxm	41800
+𫗯	oxxm	0
 很难	oxxn	58700000
 䬶	oxxo	4100
 𩚯	oxxr	0
@@ -66385,6 +68925,7 @@ encoder:
 𠔑	oyoy	0
 分钟	oypj	135000000
 𤫫	oyps	0
+𪟐	oypx	0
 分外	oyri	4940000
 分解	oyrl	24400000
 𣢏	oyro	0
@@ -66412,6 +68953,7 @@ encoder:
 炃	oyuo	36300
 饲料	oyut	21000000
 分为	oyuv	51300000
+𪬲	oyux	0
 分数	oyuz	23700000
 创举	oyva	2730000
 分清	oyvc	6430000
@@ -66431,6 +68973,8 @@ encoder:
 分层	oyxb	3850000
 分居	oyxe	3560000
 𣗰	oyxf	0
+𪬼	oyxl	0
+𫎤	oyxl	0
 分属	oyxm	1180000
 𠬰	oyxs	0
 分局	oyxy	13500000
@@ -66512,6 +69056,7 @@ encoder:
 公斤	ozpd	63800000
 公猪	ozqb	559000
 公猫	ozqe	370000
+𫖻	ozqi	0
 公狗	ozqr	594000
 凶狠	ozqx	3990000
 凶猛	ozqy	5910000
@@ -66631,6 +69176,7 @@ encoder:
 金昌	pakk	2290000
 𨭀	pakl	0
 金星	pakm	9610000
+𫒝	pako	0
 铔	paku	171000
 金堂	pakw	1080000
 𨫍	pakw	0
@@ -66683,6 +69229,7 @@ encoder:
 后悔	paum	35400000
 金粉	pauo	3170000
 錽	paur	46600
+𫓸	paur	0
 鋄	paux	26100
 金湖	pave	1860000
 金沙	pavk	5700000
@@ -66717,7 +69264,9 @@ encoder:
 𨩥	pbbd	0
 鐃	pbbg	93900
 䥗	pbbr	4390
+𫔋	pbbr	0
 𨭸	pbex	0
+𫔐	pbex	0
 𨬰	pbgo	0
 𨮚	pbhj	0
 𨮩	pbhj	0
@@ -66726,6 +69275,7 @@ encoder:
 𨮾	pbjd	0
 鎱	pbjr	572000
 𨯨	pbju	0
+𫒨	pbki	0
 銢	pbkv	36000
 銾	pbkv	22600
 铼	pbkv	1170000
@@ -66738,18 +69288,22 @@ encoder:
 䤲	pbno	4320
 錴	pbob	26400
 鈇	pbod	97900
+𫓧	pbod	0
 𨯉	pbof	0
 鐟	pbok	1270000
 鑚	pbol	566000
 錂	pbor	47400
 𨱋	pbor	0
 𨮕	pbpd	0
+𫓠	pbqc	0
 鈨	pbrd	34500
 𨪌	pbrk	0
+𫒰	pbrm	0
 銠	pbrr	125000
 铑	pbrr	610000
 𨦿	pbsk	0
 﨨	pbub	24400
+𫓄	pbud	0
 𨭎	pbuj	0
 𨪲	pbuk	0
 铗	pbuo	315000
@@ -66759,6 +69313,7 @@ encoder:
 钍	pbvv	327000
 𨰀	pbwf	0
 𨧣	pbwq	0
+𫒸	pbwr	0
 鋕	pbwz	66100
 鐚	pbwz	631000
 鋙	pbxj	55800
@@ -66777,7 +69332,10 @@ encoder:
 铸型	pcae	151000
 𨨯	pcag	0
 𨬩	pcax	0
+𫒩	pcbi	0
 鑷	pccc	828000
+𫓈	pccl	0
+𫓝	pccp	0
 𨫎	pccs	0
 鏏	pccx	26200
 鋳	pcds	712000
@@ -66823,9 +69381,11 @@ encoder:
 𡊣	pdab	0
 𩓥	pdag	0
 𩓭	pdag	0
+𫖵	pdag	0
 后	pdaj	909000000
 𠵲	pdaj	0
 岳	pdal	26600000
+𫘶	pdal	0
 乒	pdam	6700000
 𨖁	pdan	0
 兵	pdao	88600000
@@ -66843,6 +69403,7 @@ encoder:
 𠃘	pday	0
 𨚬	pday	0
 𨛪	pday	0
+𪟘	pday	0
 𡐠	pdbb	0
 𨨲	pdbd	0
 䫇	pdbg	3510
@@ -66851,6 +69412,7 @@ encoder:
 乕	pdbl	138000
 𨦶	pdbo	0
 𪃫	pdbr	0
+𫐳	pdbu	0
 𨑛	pdbz	0
 𤑊	pdcu	0
 𨟈	pddy	0
@@ -66861,6 +69423,7 @@ encoder:
 盾	pdel	41000000
 貭	pdel	85000
 质	pdel	113000000
+𫑇	pdew	0
 𢺼	pdex	0
 𢒏	pdfb	0
 𠪻	pdfd	0
@@ -66870,6 +69433,7 @@ encoder:
 澃	pdgk	122000
 盨	pdgl	34800
 𢄼	pdgl	0
+𪾔	pdgl	0
 須	pdgo	19500000
 頎	pdgo	122000
 须	pdgo	76400000
@@ -66884,6 +69448,7 @@ encoder:
 𧏁	pdib	0
 𨑡	pdib	0
 䫢	pdig	3200
+𫖠	pdig	0
 䖐	pdih	3920
 虒	pdih	49500
 辵	pdii	304000
@@ -66937,6 +69502,7 @@ encoder:
 𧖴	pdml	0
 𧗃	pdml	0
 𨗝	pdml	0
+𪯱	pdmo	0
 𩔾	pdne	0
 𨫻	pdni	0
 𣂝	pdnj	0
@@ -66956,31 +69522,37 @@ encoder:
 乺	pdpy	26200
 豺狼	pdqs	1550000
 慇	pdqw	235000
+𫐺	pdqw	0
 頿	pdrg	20700
 𠂢	pdrh	0
 斶	pdri	29800
 覛	pdrl	24000
 𧠨	pdrl	0
+𫌪	pdrl	0
 欣	pdro	48300000
 𣂥	pdrp	0
 𡖰	pdrr	0
+𫚺	pdrr	0
 𣃅	pdrs	0
 𤊑	pdru	0
 𢜛	pdrw	0
 𨐍	pdse	0
 𩓣	pdsg	0
 𩖕	pdsg	0
+𫖞	pdsg	0
 䟟	pdsj	3350
 𢒷	pdsj	0
 𩿪	pdsr	0
 𪉄	pdsr	0
 𨫨	pdsu	0
 㿭	pdsx	5740
+𪯬	pdte	0
 丘北	pdtr	267000
 𢨛	pduh	0
 𨕪	pduu	0
 𨖤	pduu	0
 𨗬	pduu	0
+𪢈	pduz	0
 銶	pdvs	143000
 𨱇	pdvs	0
 𣂴	pdwa	0
@@ -67003,6 +69575,7 @@ encoder:
 𠂬	pdyi	0
 𠂰	pdyl	0
 𢁺	pdyl	0
+𪠭	pdyl	0
 劤	pdym	285000
 殷	pdyq	12500000
 𠂘	pdys	0
@@ -67010,6 +69583,7 @@ encoder:
 𢀴	pdyy	0
 𡡓	pdzg	0
 𦅨	pdzg	0
+𪠗	pdzj	0
 𨒠	pdzk	0
 𤓰	pdzs	0
 𨕼	pdzx	0
@@ -67042,10 +69616,12 @@ encoder:
 鏵	peeb	218000
 鐷	peef	40500
 鐼	peel	33800
+𫔁	peel	0
 错落	peev	2890000
 𨧾	peex	0
 䥬	pefd	3290
 鑮	pefd	36500
+𫓆	pefd	0
 质朴	pefi	6090000
 钄	pefl	165000
 针刺	pefl	2050000
@@ -67084,6 +69660,7 @@ encoder:
 𨫍	pekw	0
 𨪇	pelb	0
 𨪋	pelb	0
+𫒦	pelc	0
 𨩇	peld	0
 鍈	pelg	66100
 锳	pelg	61200
@@ -67118,6 +69695,7 @@ encoder:
 𨭠	pepd	0
 𨮇	peqi	0
 鏾	peqm	89700
+𫔌	peqm	0
 𨯓	perb	0
 𨫱	perc	0
 错处	peri	279000
@@ -67136,6 +69714,7 @@ encoder:
 错误	pesj	161000000
 错话	pesm	1490000
 质询	pesr	1640000
+𫓑	pesw	0
 质变	pesx	1990000
 錺	pesy	143000
 𨪠	pesy	0
@@ -67154,12 +69733,14 @@ encoder:
 𨪪	pewf	0
 𨯌	pewf	0
 𨯠	pewl	0
+𫒿	pewl	0
 𨮒	pewr	0
 鋍	pewy	41800
 铹	pewy	109000
 错字	pewy	1720000
 鎍	pewz	156000
 错案	pewz	788000
+𫔅	pewz	0
 𨮤	pexj	0
 鈘	pexs	17400
 𨨈	pexs	0
@@ -67168,6 +69749,7 @@ encoder:
 质子	peya	759000
 钳子	peya	1250000
 鍣	peyj	1010000
+𫓀	peym	0
 𨰑	peyn	0
 𨯪	peyy	0
 𨫲	pezb	0
@@ -67185,6 +69767,7 @@ encoder:
 铺开	pfae	2490000
 𨪚	pfae	0
 铺平	pfau	1240000
+𪹸	pfau	0
 𨭭	pfax	0
 鋪	pfba	9640000
 铺	pfba	97400000
@@ -67212,6 +69795,7 @@ encoder:
 彩带	pfew	823000
 彩票	pffb	45800000
 𨭺	pffb	0
+𫓇	pffl	0
 采样	pffu	4030000
 彩霞	pffx	1820000
 采石	pfga	1180000
@@ -67233,6 +69817,7 @@ encoder:
 𢿥	pfix	0
 𨁢	pfji	0
 𨯻	pfjj	0
+𫓞	pfjj	0
 𨫾	pfjm	0
 鏉	pfjr	2190000
 铺路	pfjr	1830000
@@ -67266,6 +69851,7 @@ encoder:
 𨤚	pflb	0
 𨦉	pfld	0
 鍊	pflk	15000000
+𫔀	pflk	0
 采购	pflr	239000000
 采用	pflv	194000000
 𨤞	pflz	0
@@ -67279,6 +69865,7 @@ encoder:
 采伐	pfnh	811000
 䧽	pfni	3180
 𨯟	pfni	0
+𫔓	pfni	0
 铺位	pfns	1010000
 𨤛	pfoj	0
 錸	pfoo	675000
@@ -67336,6 +69923,7 @@ encoder:
 𨨵	pgae	0
 錡	pgaj	1150000
 锜	pgaj	166000
+𫓛	pgan	0
 𨦄	pgax	0
 𨦌	pgay	0
 鍷	pgbb	36600
@@ -67382,6 +69970,7 @@ encoder:
 须留	pgrs	202000
 鈦	pgsa	2400000
 钛	pgsa	9200000
+𫓅	pgse	0
 𨪴	pgsk	0
 𨦄	pgsx	0
 镢头	pgtg	77000
@@ -67428,10 +70017,12 @@ encoder:
 𨫓	phjc	0
 鏂	phjj	3220000
 䥲	phjr	4450
+𫓏	phjw	0
 𨧄	phki	0
 䤷	phkz	4820
 钱财	phld	6620000
 鉔	phli	32200
+𫓬	phli	0
 𨰲	phll	0
 𨧇	phlo	0
 𨰹	phlp	0
@@ -67472,6 +70063,7 @@ encoder:
 𨫴	piaz	0
 𨮣	pibi	0
 钻井	pibn	1520000
+𫓗	pibu	0
 釙	pida	47300
 钋	pida	275000
 钻探	pidw	1870000
@@ -67481,6 +70073,7 @@ encoder:
 钻研	piga	9370000
 鐻	pigq	34800
 钀	pigs	514000
+𫓋	piii	0
 鉆	pija	484000
 钻	pija	46000000
 𨭴	pijm	0
@@ -67522,8 +70115,10 @@ encoder:
 𥂲	pixl	0
 鈙	pixs	28800
 𨮏	pixu	0
+𫓊	pixx	0
 𨩘	piya	0
 𨨍	piym	0
+𫓺	piym	0
 𨰳	pizi	0
 𨮦	pizk	0
 鋘	pjag	98900
@@ -67556,6 +70151,7 @@ encoder:
 鋁	pjja	5490000
 铝	pjja	76400000
 𨫵	pjja	0
+𫓟	pjjc	0
 鐰	pjjf	35300
 鋛	pjji	27900
 𨩗	pjjj	0
@@ -67573,6 +70169,7 @@ encoder:
 鉂	pjos	106000
 钟爱	pjpw	4580000
 鏴	pjrj	169000
+𫒐	pjrr	0
 钟头	pjtg	2650000
 钟情	pjuc	7280000
 锅炉	pjuw	11200000
@@ -67591,6 +70188,7 @@ encoder:
 銲	pkae	134000
 𨨊	pkae	0
 鍉	pkai	73300
+𫔂	pkai	0
 锂	pkba	23100000
 𨫉	pkbd	0
 䥵	pkbg	3900
@@ -67633,10 +70231,13 @@ encoder:
 销路	pkjr	2280000
 镋	pkjr	37100
 𨬋	pkjr	0
+𫓐	pkju	0
 销量	pkka	18600000
 鑸	pkkb	830000
+𫓉	pkkb	0
 𨦈	pkkd	0
 鎤	pkkg	35400
+𫓒	pkkg	0
 鑘	pkkk	26000
 番禺	pkkl	6360000
 𨬚	pkkl	0
@@ -67651,11 +70252,13 @@ encoder:
 鏝	pklx	164000
 镘	pklx	139000
 鍝	pklz	1400000
+𫒱	pkma	0
 𨨌	pkmb	0
 鍟	pkmc	1150000
 𨩛	pkmc	0
 𨧛	pkmg	0
 𨩠	pkml	0
+𫔃	pkml	0
 𨨚	pkmu	0
 𨦒	pkmy	0
 销毁	pknb	5620000
@@ -67689,6 +70292,7 @@ encoder:
 锟	pkrr	2820000
 𨦆	pkrr	0
 鍻	pkry	23200
+𫒹	pkry	0
 翻新	pksf	6200000
 𥃅	pksl	0
 𨩄	pksu	0
@@ -67720,7 +70324,9 @@ encoder:
 鏤	pkzm	308000
 𨧉	pkzm	0
 𨯃	pkzm	0
+𫒗	pkzm	0
 䥪	pkzu	4320
+𫓣	pkzu	0
 錌	plae	50400
 鎠	plai	32000
 𨩡	plar	0
@@ -67730,6 +70336,7 @@ encoder:
 鐸	plbu	1310000
 𨭆	plbu	0
 盘亏	plbz	281000
+𫔆	plbz	0
 钢琴	plcc	17200000
 钢珠	plcm	825000
 𨬠	plcm	0
@@ -67743,6 +70350,7 @@ encoder:
 钢板	plfp	10900000
 铜板	plfp	4390000
 鉠	plgd	38900
+𫓭	plgd	0
 盘面	plgj	3380000
 鍴	plgl	80600
 𨬸	plgq	0
@@ -67759,6 +70367,7 @@ encoder:
 镮	pljr	46100
 鎧	plju	3830000
 盘踞	pljx	1220000
+𫒏	plka	0
 鍘	plkd	1950000
 铡	plkd	2730000
 铠甲	plki	2500000
@@ -67771,6 +70380,7 @@ encoder:
 铜山	plll	711000
 鑺	plln	789000
 𨰃	pllz	0
+𫔉	pllz	0
 盘升	plme	1600000
 盘算	plml	1130000
 钢笔	plmm	3940000
@@ -67782,6 +70392,7 @@ encoder:
 铜臭	plng	392000
 鏙	plni	24900
 鑴	plnl	725000
+𫔔	plnl	0
 铜牌	plnn	2400000
 盘货	plnr	49700
 䦆	plnx	26000
@@ -67818,10 +70429,12 @@ encoder:
 𨰟	plru	0
 钢包	plry	227000
 𪆷	plrz	0
+𫛾	plrz	0
 盘旋	plsm	4550000
 䤫	plsx	5120
 锄头	pltg	2080000
 盘问	pltj	1950000
+𫓡	plum	0
 𨯴	plup	0
 𨬫	pluq	0
 钢塑	pluz	454000
@@ -67831,6 +70444,7 @@ encoder:
 钼	plvv	2870000
 岳池	plvy	321000
 钢梁	plvy	415000
+𫓁	plwb	0
 盘子	plya	4730000
 铜陵	plyb	4700000
 岳阳	plyk	7960000
@@ -67846,7 +70460,9 @@ encoder:
 鑼	plzn	1460000
 钢丝	plzz	6970000
 𨨴	plzz	0
+𫒲	pmac	0
 𨮼	pmaj	0
+𫓌	pmaj	0
 𨫝	pman	0
 乒坛	pmbb	503000
 𨬻	pmbd	0
@@ -67864,19 +70480,23 @@ encoder:
 钎	pmea	2660000
 錘	pmeb	1740000
 锤	pmeb	12500000
+𫒍	pmed	0
 𨪻	pmee	0
 𨮱	pmej	0
 䥷	pmek	4150
 𨰉	pmep	0
 铁芯	pmew	627000
 𨪸	pmez	0
+𫒘	pmez	0
 鏼	pmfl	23900
 铁板	pmfp	2170000
 𨥜	pmgd	0
 𨧐	pmgj	0
+𫓱	pmgn	0
 铁矿	pmgt	2720000
 𨰭	pmgz	0
 䤜	pmhd	3760
+𫒇	pmhd	0
 鋨	pmhm	121000
 锇	pmhm	235000
 铁匠	pmhp	2080000
@@ -67884,6 +70504,7 @@ encoder:
 銛	pmia	190000
 铦	pmia	123000
 鈼	pmid	114000
+𫒳	pmil	0
 𨥦	pmim	0
 鋋	pmiy	61600
 𨨶	pmiy	0
@@ -67893,6 +70514,7 @@ encoder:
 鐈	pmjl	24600
 铁路	pmjr	40500000
 𨫙	pmjr	0
+𫓤	pmka	0
 鍾	pmkb	9100000
 锺	pmkb	2710000
 鋓	pmkd	57600
@@ -67953,6 +70575,8 @@ encoder:
 懖	pmwz	378000
 𨧺	pmxb	0
 𨬾	pmxb	0
+𫒡	pmxi	0
+𫓷	pmxi	0
 𨰝	pmxk	0
 𨰓	pmxq	0
 锤子	pmya	1990000
@@ -68017,6 +70641,7 @@ encoder:
 𨯰	pnoy	0
 𨭾	pnqk	0
 𨥐	pnqy	0
+𫒪	pnrd	0
 铧	pnre	522000
 𨫖	pnro	0
 鎀	pnrp	49800
@@ -68024,7 +70649,10 @@ encoder:
 鈋	pnrr	33800
 鎞	pnrr	45000
 𨱂	pnrr	0
+𫒬	pnrr	0
+𫔇	pnrr	0
 𨦱	pnrs	0
+𫒫	pnrs	0
 鏓	pnrw	26400
 𨦪	pnry	0
 䥞	pnsm	3590
@@ -68054,9 +70682,11 @@ encoder:
 铪	poaj	329000
 錀	poal	69700
 𨥟	poaz	0
+𫓫	poaz	0
 兵士	poba	3460000
 𨦓	pobs	0
 铃声	pobx	107000000
+𫒑	pobz	0
 銓	poca	2080000
 铨	poca	967000
 釞	poda	36100
@@ -68070,19 +70700,24 @@ encoder:
 兵器	pojj	19200000
 鑰	pojl	1840000
 𨫸	pojl	0
+𫓂	pojl	0
 鎿	pojm	198000
 镎	pojm	41700
 銳	pojr	3010000
 鑯	poka	41100
 鉩	poko	48900
+𫓍	pokr	0
 𨮋	pokw	0
 𨭗	polk	0
+𫒟	pomf	0
 𨨝	pomi	0
 兵种	pomj	2050000
+𫒌	pond	0
 舱位	pons	638000
 銼	poob	170000
 锉	poob	908000
 𨥎	pood	0
+𫓩	pood	0
 鏦	pooi	73600
 鋊	pooj	72000
 䥘	pook	4290
@@ -68111,11 +70746,13 @@ encoder:
 𨪯	pouw	0
 兵法	povb	7200000
 釟	povv	51800
+𫓥	povv	0
 鈴	powa	27600000
 兵马	poxa	1900000
 鋡	poxj	42500
 鎗	poxj	1290000
 錜	poxw	29400
+𫓻	poxw	0
 𨯣	poyb	0
 鈖	poyd	89000
 锉刀	poyd	394000
@@ -68126,6 +70763,7 @@ encoder:
 𨥍	pozi	0
 𨦣	pozr	0
 鈆	pozs	50200
+𫓪	pozs	0
 𨨟	pozw	0
 銗	ppaj	111000
 𨧌	ppax	0
@@ -68133,6 +70771,7 @@ encoder:
 𨦜	ppaz	0
 𨧑	ppbi	0
 𨰪	ppbu	0
+𫒒	ppda	0
 鋝	ppds	62200
 锊	ppds	101000
 鍎	ppel	2370000
@@ -68144,6 +70783,7 @@ encoder:
 𨪉	ppih	0
 𨪾	ppio	0
 鐇	ppki	48000
+𫔍	ppki	0
 䤾	ppnb	4200
 𨧌	ppow	0
 𨐃	pppf	0
@@ -68187,6 +70827,7 @@ encoder:
 船夫	pqbo	594000
 𧼌	pqbo	0
 𧲦	pqbr	0
+𫎍	pqbr	0
 𧴔	pqbu	0
 㦟	pqbw	3780
 船壳	pqbw	116000
@@ -68217,6 +70858,7 @@ encoder:
 𧳐	pqgl	0
 𧳑	pqgm	0
 䫉	pqgo	3750
+𫎋	pqgq	0
 𧲶	pqgs	0
 𧳂	pqgs	0
 𢤧	pqgw	0
@@ -68224,6 +70866,7 @@ encoder:
 𧳗	pqgy	0
 𧳲	pqhg	0
 䝙	pqho	3650
+𫎊	pqhs	0
 𧲽	pqhx	0
 𧴘	pqig	0
 䝞	pqih	3450
@@ -68358,6 +71001,7 @@ encoder:
 𧳋	pquy	0
 𧳼	pquy	0
 𧴉	pquy	0
+𫎌	pquz	0
 䝥	pqve	3890
 铅油	pqvk	36300
 鈅	pqvv	985000
@@ -68418,6 +71062,7 @@ encoder:
 𨩀	prgm	0
 𨫫	prgo	0
 䤥	prgy	5410
+𫒓	prid	0
 𦘉	prjc	0
 鐌	prjg	82500
 𨅠	prji	0
@@ -68454,6 +71099,7 @@ encoder:
 钓鱼	prra	16500000
 𨪭	prrc	0
 欣然	prrg	6280000
+𪾘	prrl	0
 鍇	prrn	98800
 锴	prrn	994000
 鈚	prrr	52200
@@ -68477,6 +71123,7 @@ encoder:
 欣慰	prxb	9590000
 錚	prxb	951000
 铮	prxb	3210000
+𫓮	prxb	0
 𨨽	prxm	0
 豹子	prya	3290000
 钩子	prya	1840000
@@ -68502,7 +71149,9 @@ encoder:
 航天	psag	27300000
 𨪆	psaj	0
 𤫸	psbz	0
+𫒜	psbz	0
 𤬅	psch	0
+𪼴	psch	0
 𤫬	psci	0
 斥责	pscl	896000
 航班	pscu	20400000
@@ -68521,6 +71170,7 @@ encoder:
 航校	psfs	204000
 舷梯	psfu	260000
 航权	psfx	411000
+𪼳	psgd	0
 瓥	psgi	477000
 𥂻	psgl	0
 𨭢	psgs	0
@@ -68548,6 +71198,7 @@ encoder:
 𨧤	psjy	0
 𨭖	pska	0
 𨰸	pska	0
+𫔑	pska	0
 鐘	pskb	45000000
 𠛒	pskd	0
 鏱	pske	12200
@@ -68557,9 +71208,11 @@ encoder:
 鏡	pskr	34200000
 镜	pskr	122000000
 𨮈	pskr	0
+𫓜	psku	0
 鐿	pskw	102000
 镱	pskw	410000
 𨬧	psla	0
+𫓕	psla	0
 镶嵌	psle	6030000
 鈰	psli	88200
 铈	psli	444000
@@ -68578,6 +71231,7 @@ encoder:
 鍦	psmy	1390000
 𤫺	psmz	0
 航向	psnj	1230000
+𫒚	psno	0
 䤳	psnr	4490
 镜像	psnr	65100000
 镜片	psnx	3400000
@@ -68630,11 +71284,13 @@ encoder:
 𤬊	pswl	0
 𤬎	pswl	0
 鏲	pswm	35200
+𫒻	pswm	0
 㼉	pswr	4450
 𨩎	pswr	0
 鎊	psws	439000
 镑	psws	2040000
 航道	pswu	7430000
+𫒥	pswz	0
 鏇	psxi	1820000
 镟	psxi	251000
 鋃	psxo	97500
@@ -68645,12 +71301,14 @@ encoder:
 瓜子	psya	4810000
 铲子	psya	616000
 镜子	psya	15000000
+𫒤	psya	0
 鐓	psym	2040000
 镦	psym	600000
 𤫰	psyn	0
 铲除	psyo	5300000
 䥋	psyu	4150
 𨬤	psyu	0
+𫒜	pszb	0
 𨫏	psze	0
 𨧲	pszf	0
 航线	pszh	7660000
@@ -68664,6 +71322,7 @@ encoder:
 䤤	pszo	9520
 錥	pszq	41400
 𨯤	pszq	0
+𫓾	pszq	0
 銃	pszr	7330000
 铳	pszr	454000
 鉉	pszz	1750000
@@ -68682,6 +71341,7 @@ encoder:
 𨫆	ptmb	0
 𨫈	ptob	0
 𨮻	ptob	0
+𫓘	ptoo	0
 𨮛	ptop	0
 镀金	ptpa	3190000
 𨪙	ptpd	0
@@ -68734,6 +71394,7 @@ encoder:
 鐠	pukk	1090000
 镨	pukk	436000
 鏳	pulk	20700
+𫓔	pumh	0
 锐利	pumk	5140000
 锐气	pumy	1490000
 锐敏	pumz	127000
@@ -68748,8 +71409,11 @@ encoder:
 锐角	purl	366000
 鏻	purm	55100
 𨨢	puro	0
+𫓿	puro	0
 𨪢	purz	0
+𫒵	purz	0
 𨰥	pusg	0
+𫔕	pusg	0
 锐意	pusk	2940000
 锐减	puth	2100000
 𨬢	putr	0
@@ -68758,6 +71422,7 @@ encoder:
 	puuj	0
 錟	puuo	81500
 锬	puuo	167000
+𫒽	puuo	0
 镂空	puwb	3920000
 𨯗	puwc	0
 鑅	puwf	42400
@@ -68772,7 +71437,9 @@ encoder:
 𨩍	puzm	0
 𨩐	puzm	0
 鎙	puzq	127000
+𫔈	puzq	0
 𨭨	puzw	0
+𫒼	puzw	0
 鎡	puzz	76700
 镃	puzz	49300
 𨪢	puzz	0
@@ -68790,11 +71457,14 @@ encoder:
 𤔘	pvbb	0
 𩔋	pvbg	0
 𨮟	pvbo	0
+𪺗	pvbr	0
 𤔌	pvbx	0
 𨩾	pvby	0
 鍅	pvbz	102000
 𤔧	pvbz	0
 所长	pvch	12000000
+𪺑	pvch	0
+𪺐	pvcx	0
 頱	pvdg	22600
 𩕖	pvdg	0
 虢	pvdi	1350000
@@ -68820,9 +71490,11 @@ encoder:
 𡗮	pvgd	0
 䫣	pvgg	3360
 𥂼	pvgl	0
+𪜛	pvgl	0
 𥡙	pvgm	0
 雞	pvgn	20700000
 所有	pvgq	2270000000
+𪺏	pvgq	0
 㰿	pvgr	5360
 鷄	pvgr	617000
 𪅊	pvgr	0
@@ -68858,6 +71530,7 @@ encoder:
 𤕈	pvjn	0
 𩀓	pvjn	0
 𤔓	pvjr	0
+𪺎	pvjr	0
 𠭖	pvjx	0
 𤕆	pvjy	0
 𠃭	pvjz	0
@@ -68865,11 +71538,14 @@ encoder:
 𠄉	pvkb	0
 𡦢	pvkb	0
 𤔉	pvki	0
+𪽋	pvki	0
 𤔱	pvkk	0
 𤕌	pvkk	0
 𤴋	pvkk	0
 𤴎	pvkk	0
 䤬	pvkm	8640
+𪺙	pvks	0
+𪺖	pvla	0
 爯	pvlb	48500
 𤔈	pvlc	0
 𡬳	pvld	0
@@ -68880,6 +71556,7 @@ encoder:
 覓	pvlr	2460000
 觅	pvlr	5470000
 𧠙	pvlr	0
+𪺒	pvlr	0
 辭	pvls	5620000
 𨐲	pvls	0
 𤕉	pvlu	0
@@ -68901,6 +71578,7 @@ encoder:
 繇	pvmz	751000
 𤔞	pvmz	0
 𨪍	pvmz	0
+𪺓	pvna	0
 舀	pvnb	2200000
 𤔘	pvnb	0
 𦥝	pvnb	0
@@ -68913,6 +71591,7 @@ encoder:
 𢅁	pvnl	0
 𧢉	pvnl	0
 𪅎	pvnr	0
+𪹗	pvnu	0
 㸕	pvnx	4420
 𤔣	pvnx	0
 𠚘	pvnz	0
@@ -68928,6 +71607,7 @@ encoder:
 𠙙	pvoq	0
 鶏	pvor	9630000
 𤓼	pvoy	0
+𫑲	pvoy	0
 𤨽	pvpc	0
 𤕁	pvpi	0
 𡚘	pvpk	0
@@ -68947,11 +71627,13 @@ encoder:
 所处	pvri	12600000
 嗠	pvrj	38100
 𠄇	pvrj	0
+𪺔	pvrl	0
 舜	pvrm	8500000
 鐋	pvro	21700
 𤔰	pvro	0
 𣩖	pvrr	0
 𪇈	pvrr	0
+𪺚	pvrr	0
 𤓵	pvrs	0
 𤓶	pvrx	0
 𩰣	pvrx	0
@@ -68964,11 +71646,13 @@ encoder:
 𦨁	pvsc	0
 𤔢	pvsi	0
 所谓	pvsk	78200000
+𪥣	pvsn	0
 𣁝	pvsp	0
 所说	pvsv	33000000
 𦫑	pvsx	0
 𧧞	pvsx	0
 𨩾	pvsy	0
+𫑞	pvsy	0
 𣁷	pvte	0
 𤓺	pvte	0
 𡐼	pvub	0
@@ -68976,6 +71660,7 @@ encoder:
 𤳿	pvuk	0
 𢅌	pvul	0
 𢮣	pvum	0
+𫛔	pvur	0
 𤏜	pvuu	0
 𤑀	pvuu	0
 𤔵	pvuu	0
@@ -68999,6 +71684,7 @@ encoder:
 𤕀	pvwz	0
 爭	pvxb	17000000
 𤔯	pvxb	0
+𪺍	pvxb	0
 爵	pvxd	9520000
 𤔸	pvxd	0
 𤓽	pvxf	0
@@ -69016,6 +71702,7 @@ encoder:
 𠬪	pvxs	0
 㥯	pvxw	4510
 𢚩	pvxw	0
+𫐭	pvxw	0
 𨛰	pvxy	0
 𨛶	pvxy	0
 亂	pvxz	43600000
@@ -69031,6 +71718,7 @@ encoder:
 𨦥	pvyi	0
 𠹾	pvyj	0
 𦦌	pvyj	0
+𪨁	pvyk	0
 𧠾	pvyl	0
 㲗	pvym	3570
 𢾢	pvym	0
@@ -69088,15 +71776,20 @@ encoder:
 𤔞	pvzz	0
 𦃟	pvzz	0
 𦆩	pvzz	0
+𪺕	pvzz	0
 𨦦	pwad	0
+𫒢	pwae	0
 䥂	pwag	5370
 𨯯	pwal	0
 鏥	pwan	28100
+𫔊	pwan	0
+𫓃	pwao	0
 鑓	pway	177000
 铵盐	pwbi	316000
 𨨀	pwbi	0
 錝	pwbk	90800
 鍹	pwbk	36300
+𫓽	pwbk	0
 䥦	pwbq	6160
 鋎	pwbr	36100
 鐽	pwbu	45900
@@ -69105,6 +71798,7 @@ encoder:
 鎋	pwcj	33900
 受理	pwck	28100000
 受聘	pwck	1830000
+𫒭	pwcs	0
 爱抚	pwda	3320000
 锭	pwda	3870000
 受损	pwdj	9080000
@@ -69112,6 +71806,7 @@ encoder:
 受挫	pwdo	3680000
 受热	pwdq	1570000
 链接	pwds	627000000
+𫒙	pwds	0
 爱护	pwdw	19800000
 受苦	pwee	4280000
 爱慕	pwek	6360000
@@ -69187,6 +71882,7 @@ encoder:
 𨩶	pwrd	0
 链条	pwrf	5780000
 𨨥	pwrf	0
+𫒴	pwrj	0
 𨫕	pwrm	0
 鉈	pwrr	672000
 铊	pwrr	662000
@@ -69213,6 +71909,7 @@ encoder:
 𨬄	pwuu	0
 䤹	pwux	6060
 𨮄	pwux	0
+𫒼	pwuz	0
 受害	pwwc	17100000
 受灾	pwwu	3390000
 悉心	pwwz	3230000
@@ -69223,12 +71920,14 @@ encoder:
 受骗	pwxw	9640000
 链子	pwya	2690000
 锭子	pwya	299000
+𫒛	pwya	0
 爱民	pwyh	2640000
 受阻	pwyl	5940000
 䥇	pwyy	20200
 䦂	pwyy	15600
 	pwyy	0
 	pwyy	0
+𫒮	pwyz	0
 䥾	pwza	3440
 𨰰	pwzl	0
 銨	pwzm	691000
@@ -69270,6 +71969,7 @@ encoder:
 反而	pxgl	61100000
 银灰	pxgu	1610000
 反感	pxha	10700000
+𫒷	pxhb	0
 殷切	pxhy	2060000
 鈹	pxia	1150000
 铍	pxia	585000
@@ -69303,10 +72003,12 @@ encoder:
 𨧵	pxmb	0
 反手	pxmd	3010000
 鍒	pxmf	3150000
+𫔄	pxmf	0
 𨪅	pxmh	0
 𨥨	pxmi	0
 反复	pxmk	34800000
 鐍	pxml	46100
+𫔎	pxml	0
 𨩺	pxmm	0
 银税	pxmu	35800
 反射	pxnd	32300000
@@ -69367,6 +72069,7 @@ encoder:
 反弹	pxyu	21500000
 𨬖	pxyy	0
 𨰏	pxyy	0
+𫔏	pxyy	0
 𨰎	pxzo	0
 银婚	pxzr	206000
 𨧱	pxzz	0
@@ -69394,6 +72097,7 @@ encoder:
 𦨫	pyau	0
 𦨽	pyax	0
 𦩬	pyaz	0
+𫇢	pyaz	0
 𦪛	pybg	0
 舡	pybi	99000
 𦩍	pybj	0
@@ -69430,12 +72134,14 @@ encoder:
 䒈	pyel	5100
 舼	pyeo	27400
 鐉	pyeo	27000
+𫓢	pyeo	0
 艔	pyex	19700
 𦨟	pyex	0
 𦩾	pyez	0
 𦪚	pyfd	0
 键槽	pyfe	155000
 舾	pyfj	267000
+𫇡	pyfl	0
 𦩚	pyfm	0
 艝	pyfx	77500
 乳酸	pyfz	5270000
@@ -69445,6 +72151,7 @@ encoder:
 𦩎	pyge	0
 𦪶	pygi	0
 𨇐	pygj	0
+𫇜	pygj	0
 𥂏	pygl	0
 𦨩	pygm	0
 䑢	pygr	4190
@@ -69469,6 +72176,8 @@ encoder:
 爬上	pyiv	7530000
 舻	pyix	360000
 𦨗	pyix	0
+𫇛	pyiy	0
+𫇠	pyjd	0
 𦩪	pyjf	0
 𩕎	pyjg	0
 舯	pyji	135000
@@ -69518,6 +72227,7 @@ encoder:
 𦩥	pykr	0
 乳业	pyku	2590000
 𦩭	pykw	0
+𫇟	pykw	0
 𦩇	pykx	0
 艣	pyky	29900
 艛	pykz	25600
@@ -69534,16 +72244,19 @@ encoder:
 䚀	pylr	4910
 舰	pylr	5140000
 𦪻	pyls	0
+𫇞	pylx	0
 𥎻	pyma	0
 艇	pymb	7930000
 鋌	pymb	125000
 铤	pymb	239000
 𦪅	pymb	0
 𦪵	pyme	0
+𫇚	pyme	0
 𨦃	pymf	0
 艤	pymh	82100
 𦨎	pymh	0
 𦩆	pymh	0
+𫇣	pymh	0
 舴	pymi	270000
 鋋	pymi	61600
 𦨯	pymi	0
@@ -69585,10 +72298,12 @@ encoder:
 艧	pynx	30700
 艭	pynx	28800
 𦫇	pynx	0
+𫓎	pyny	0
 𦪂	pyob	0
 钖	pyod	169000
 键入	pyod	1980000
 𦨈	pyod	0
+𫓚	pyoe	0
 𦩺	pyof	0
 爬行	pyoi	12900000
 𦨵	pyoi	0
@@ -69608,6 +72323,7 @@ encoder:
 𥃑	pyor	0
 𦪁	pyor	0
 𨫭	pyor	0
+𪾝	pyor	0
 𧭔	pyos	0
 𦪜	pyou	0
 舲	pyow	91600
@@ -69622,6 +72338,7 @@ encoder:
 𦩹	pypn	0
 舨	pypx	141000
 艀	pypy	66700
+𪤈	pyqb	0
 舤	pyqd	61300
 鞶	pyqe	43100
 䑮	pyqf	3790
@@ -69736,6 +72453,7 @@ encoder:
 釕	pyvv	202000
 鈻	pyvv	463000
 钌	pyvv	520000
+𫒉	pyvv	0
 𦨲	pyvy	0
 䑸	pywb	4150
 𦩘	pywd	0
@@ -69767,6 +72485,8 @@ encoder:
 䑡	pyxs	5030
 𦪫	pyxu	0
 艌	pyxw	47800
+𫇝	pyxx	0
+𫒶	pyxz	0
 釲	pyyb	20300
 舠	pyyd	62400
 𦨇	pyyd	0
@@ -69776,6 +72496,7 @@ encoder:
 艋	pyyl	749000
 𦨋	pyym	0
 𦪔	pyym	0
+𫇣	pyym	0
 䒁	pyyn	4310
 鑃	pyyn	19200
 𦨡	pyyn	0
@@ -69795,6 +72516,7 @@ encoder:
 𦩄	pyzb	0
 艓	pyzf	24900
 𦩶	pyzg	0
+𫇢	pyzh	0
 𦩈	pyzm	0
 艈	pyzn	19300
 𦪘	pyzr	0
@@ -69817,18 +72539,22 @@ encoder:
 錙	pzki	77700
 锱	pzki	136000
 𨪮	pzkq	0
+𫒯	pzkr	0
 錄	pzkv	38000000
 妥当	pzkx	8510000
 鎻	pzlo	973000
 鏆	pzlo	851000
 𨦖	pzlo	0
 𨱌	pzlo	0
+𫒾	pzlo	0
 𨨴	pzlz	0
 釹	pzma	988000
 钕	pzma	714000
 𨧚	pzma	0
 鉾	pzmb	550000
+𫓴	pzmb	0
 𨰺	pzmo	0
+𫓙	pzni	0
 𨮨	pznl	0
 鉯	pzod	50800
 鏒	pzop	49200
@@ -69839,6 +72565,7 @@ encoder:
 鈗	pzrd	44100
 鏘	pzrd	856000
 𨮳	pzru	0
+𫔒	pzru	0
 𨰽	pzrz	0
 妥善	pzuu	26700000
 釓	pzvv	67400
@@ -69854,6 +72581,7 @@ encoder:
 肝	qaed	46300000
 𦣘	qaer	0
 夙愿	qagn	973000
+𫆘	qaid	0
 𦙫	qaii	0
 肺虚	qaik	210000
 腷	qajk	55500
@@ -69868,11 +72596,13 @@ encoder:
 𦛍	qalb	0
 肺	qali	25000000
 𣍪	qalo	0
+𫇃	qalt	0
 𣍠	qand	0
 脜	qanl	268000
 脼	qaoo	101000
 𦢈	qaoo	0
 𦜒	qaor	0
+𫆯	qaor	0
 肝胆	qaqk	3400000
 肝脏	qaqt	5030000
 𦘵	qaqy	0
@@ -69888,6 +72618,7 @@ encoder:
 𦙻	qauo	0
 肝炎	qauu	14800000
 𦞃	qauu	0
+𪱠	qaux	0
 肺泡	qavr	449000
 𦠖	qawr	0
 脻	qaxi	98000
@@ -70005,6 +72736,7 @@ encoder:
 狂怒	qczx	1320000
 𠘧	qdaa	0
 𠘨	qdaa	0
+𫖼	qdaf	0
 几天	qdag	72700000
 凬	qdak	52900
 𠙒	qdal	0
@@ -70022,6 +72754,7 @@ encoder:
 凨	qdbz	139000
 𠘾	qdbz	0
 𠙣	qdbz	0
+𫗉	qdcb	0
 𩙧	qdcd	0
 𠱰	qdcj	0
 𠙲	qdck	0
@@ -70031,6 +72764,7 @@ encoder:
 𠙈	qdez	0
 剁	qdfk	6010000
 几枚	qdfm	613000
+𪞵	qdfx	0
 𠙗	qdgh	0
 𩑏	qdgo	0
 𢒝	qdhp	0
@@ -70038,6 +72772,7 @@ encoder:
 凪	qdii	2000000
 几点	qdij	24800000
 飐	qdij	67000
+𪞲	qdij	0
 𩙰	qdjf	0
 𩙮	qdjl	0
 𠙂	qdjo	0
@@ -70048,6 +72783,8 @@ encoder:
 𦢟	qdku	0
 凡是	qdkv	21700000
 飔	qdkw	93400
+𫗃	qdkw	0
+𫗄	qdkw	0
 𠙘	qdlb	0
 凧	qdli	1440000
 𠘳	qdll	0
@@ -70061,6 +72798,7 @@ encoder:
 几笔	qdmm	899000
 几乎	qdmu	202000000
 𠙄	qdmz	0
+𫗀	qdmz	0
 几何	qdna	22400000
 几例	qdna	543000
 𠙔	qdnb	0
@@ -70070,11 +72808,13 @@ encoder:
 几位	qdns	16800000
 几倍	qdns	3040000
 飕	qdnx	785000
+𫗇	qdok	0
 𩙦	qdon	0
 飑	qdor	462000
 风	qdos	312000000
 𠘰	qdos	0
 几个	qdov	170000000
+𫖽	qdox	0
 几分	qdoy	26900000
 䏳	qdpd	3700
 𠘱	qdpd	0
@@ -70087,22 +72827,31 @@ encoder:
 𡖆	qdrs	0
 鳯	qdrz	287000
 𧦔	qdse	0
+𪞴	qdse	0
 𩙫	qdsi	0
+𫗊	qdsk	0
 𠙅	qdsu	0
 𠙤	qdsz	0
 几次	qdtr	40000000
 𠙌	qduc	0
+𫖿	qdug	0
 㶡	qduo	4090
 飚	qduu	9450000
 𩙪	qduu	0
 凲	qdux	27100
 𠘵	qduz	0
 脙	qdvs	437000
+𫗋	qdwm	0
+𫗁	qdwx	0
+𫗂	qdwx	0
+𫗈	qdwy	0
 𩙭	qdwz	0
 凤	qdxs	41700000
 𠘫	qdxs	0
 𡬰	qdxs	0
 𩙥	qdxs	0
+𫗁	qdxw	0
+𫗂	qdxw	0
 飗	qdyk	62600
 飏	qdyo	336000
 𤬾	qdys	0
@@ -70118,9 +72867,11 @@ encoder:
 𦟫	qebo	0
 𦢃	qebs	0
 𣎰	qebu	0
+𫆹	qeck	0
 猎取	qecx	1030000
 𦠜	qeeb	0
 膹	qeel	34800
+𪱥	qeel	0
 猎获	qeeq	326000
 𣎢	qeeq	0
 𦢲	qeeu	0
@@ -70155,6 +72906,7 @@ encoder:
 膵	qeoe	531000
 𦣎	qeon	0
 䐽	qeoo	4200
+𫆾	qeos	0
 𦠭	qepd	0
 𦟵	qepy	0
 朦胧	qeqg	2000000
@@ -70176,9 +72928,11 @@ encoder:
 𦢧	qewl	0
 䑅	qewr	7830
 𣎙	qews	0
+𫆼	qews	0
 𦢬	qeww	0
 脖	qewy	3460000
 𦛨	qewy	0
+𫆲	qewy	0
 𦡐	qexb	0
 𦢁	qexj	0
 𦢩	qexn	0
@@ -70188,6 +72942,7 @@ encoder:
 䐑	qezf	4850
 臟	qezh	1390000
 𦟍	qezo	0
+𫆱	qfay	0
 膘	qfbk	2280000
 𦣕	qfbq	0
 杂志	qfbw	148000000
@@ -70227,6 +72982,7 @@ encoder:
 膝盖	qful	5280000
 杂粮	qfus	1770000
 𦙣	qfvv	0
+𫆵	qfwz	0
 膤	qfxb	79600
 杂费	qfyn	3110000
 𦟊	qfyy	0
@@ -70259,6 +73015,7 @@ encoder:
 𦞴	qgkz	0
 𧱔	qgli	0
 𦞑	qglk	0
+𫇀	qgmi	0
 𦝐	qgmy	0
 𦟩	qgnz	0
 𦡀	qgok	0
@@ -70561,6 +73318,7 @@ encoder:
 𩙚	qixn	0
 𩖹	qixr	0
 颰	qixs	23300
+𫗆	qixw	0
 䫸	qiyd	3580
 𦘸	qiyd	0
 𩖜	qiye	0
@@ -70591,6 +73349,7 @@ encoder:
 䐕	qjce	4190
 𦠾	qjch	0
 腘	qjcs	118000
+𫆣	qjej	0
 𣎫	qjfd	0
 肿大	qjgd	1620000
 𦞢	qjgq	0
@@ -70598,6 +73357,7 @@ encoder:
 𦡵	qjgw	0
 𦠾	qjhc	0
 𦜦	qjiw	0
+𫆩	qjiy	0
 膕	qjja	388000
 𦢷	qjjc	0
 臊	qjjf	1150000
@@ -70637,6 +73397,7 @@ encoder:
 𦝈	qkgo	0
 胱	qkgr	1610000
 𦣃	qkgu	0
+𫆚	qkia	0
 胛	qkib	433000
 胂	qkic	1310000
 𦜉	qkie	0
@@ -70653,10 +73414,12 @@ encoder:
 𦛭	qkli	0
 腽	qklk	77700
 䐝	qklo	3940
+𫆳	qklx	0
 腢	qklz	65100
 腥	qkmc	9570000
 𣍺	qkmc	0
 𦜉	qkme	0
+𫆦	qkml	0
 胆管	qkmw	779000
 𦚤	qkod	0
 𦢊	qkok	0
@@ -70668,6 +73431,7 @@ encoder:
 腸	qkro	9000000
 䐊	qkrr	4900
 𦚢	qkrr	0
+𫆪	qkrr	0
 𦜄	qkrs	0
 𣎅	qkry	0
 𦝲	qkry	0
@@ -70678,6 +73442,7 @@ encoder:
 𦢂	qkug	0
 胆汁	qkve	1580000
 胆寒	qkwe	1170000
+𫆟	qkwy	0
 腮	qkwz	5790000
 胆敢	qkxc	3110000
 狮子	qkya	14100000
@@ -70748,6 +73513,7 @@ encoder:
 𤠄	qmaj	0
 𤠙	qmaj	0
 𤠟	qmaj	0
+𪻇	qmaj	0
 獩	qmak	474000
 𤠽	qmak	0
 犻	qmal	1470000
@@ -70763,6 +73529,7 @@ encoder:
 𤡌	qmay	0
 𤝐	qmaz	0
 𤞇	qmbb	0
+𪺾	qmbb	0
 橥	qmbf	275000
 獟	qmbg	124000
 狤	qmbj	142000
@@ -70792,6 +73559,7 @@ encoder:
 腹地	qmbv	5620000
 𢟆	qmbw	0
 𦜙	qmbw	0
+𪻊	qmbx	0
 㹲	qmby	6840
 脡	qmby	237000
 𤠃	qmby	0
@@ -70818,6 +73586,7 @@ encoder:
 猜	qmcq	47100000
 鵟	qmcr	91700
 𩷬	qmcr	0
+𫛭	qmcr	0
 獁	qmcu	41200
 㤮	qmcw	5750
 逛	qmcw	99600000
@@ -70826,10 +73595,12 @@ encoder:
 𤢘	qmcz	0
 犲	qmdm	2140000
 𤝦	qmdm	0
+𪺺	qmdm	0
 狾	qmdp	86300
 𤜮	qmds	0
 腄	qmeb	87500
 𤠺	qmeb	0
+𪣪	qmeb	0
 猉	qmec	21800
 㬳	qmed	7930
 𤠇	qmee	0
@@ -70841,6 +73612,7 @@ encoder:
 峱	qmel	58500
 獖	qmel	24400
 𤣡	qmel	0
+𪻂	qmel	0
 猠	qmeo	83800
 𤞒	qmeo	0
 玂	qmep	207000
@@ -70875,6 +73647,7 @@ encoder:
 𤟦	qmgg	0
 𤡤	qmgg	0
 𤢿	qmgg	0
+𪺼	qmgh	0
 腹面	qmgj	449000
 𤞜	qmgj	0
 㺆	qmgl	4190
@@ -70927,6 +73700,7 @@ encoder:
 𤠧	qmik	0
 𤡣	qmik	0
 𤡼	qmik	0
+𪱢	qmik	0
 𤟝	qmil	0
 𦞇	qmil	0
 胏	qmim	36300
@@ -70985,6 +73759,7 @@ encoder:
 𤡬	qmju	0
 𤢈	qmju	0
 𤣁	qmju	0
+𫑁	qmjw	0
 㺤	qmka	3760
 狚	qmka	48800
 猹	qmka	86100
@@ -71141,6 +73916,7 @@ encoder:
 㹯	qmnf	4100
 𦠱	qmnh	0
 猚	qmni	25300
+𪻆	qmnj	0
 狛	qmnk	282000
 獂	qmnk	62500
 𤝼	qmnl	0
@@ -71170,12 +73946,14 @@ encoder:
 猝	qmoe	1230000
 𤡶	qmoe	0
 𤣜	qmog	0
+𪻀	qmoh	0
 𤡆	qmoi	0
 𤣝	qmoi	0
 𤞞	qmoj	0
 𤝝	qmok	0
 𤡅	qmok	0
 𤢾	qmok	0
+𪻌	qmok	0
 獈	qmol	27200
 狳	qmom	123000
 猞	qmom	260000
@@ -71196,12 +73974,14 @@ encoder:
 猣	qmor	11400
 獿	qmor	28900
 𤠎	qmor	0
+𫇁	qmor	0
 𤝜	qmos	0
 㺀	qmow	5500
 狑	qmow	30100
 𤟋	qmoy	0
 𤟳	qmoy	0
 𤣌	qmoy	0
+𪺷	qmoy	0
 獵	qmoz	4700000
 𤝅	qmoz	0
 㹞	qmpd	4160
@@ -71282,6 +74062,7 @@ encoder:
 𤠞	qmrr	0
 𤢔	qmrr	0
 𦙋	qmrr	0
+𫛖	qmrr	0
 㺥	qmrs	4090
 犳	qmrs	1650000
 𤝇	qmrs	0
@@ -71293,6 +74074,7 @@ encoder:
 𤜼	qmrt	0
 㹼	qmru	4880
 狰	qmrx	6740000
+𪺸	qmrx	0
 狍	qmry	244000
 𤟊	qmry	0
 𤣚	qmry	0
@@ -71315,6 +74097,7 @@ encoder:
 獥	qmsm	497000
 𤠤	qmsn	0
 𩁓	qmsn	0
+𪻉	qmsn	0
 猽	qmso	42200
 𤜥	qmso	0
 𤝋	qmso	0
@@ -71336,12 +74119,15 @@ encoder:
 𤝪	qmub	0
 𤠝	qmub	0
 𦍕	qmuc	0
+𪻋	qmud	0
 𤝴	qmue	0
 猶	qmuf	4360000
 𤝸	qmuf	0
+𪻄	qmug	0
 㺣	qmuh	4840
 𤢀	qmuj	0
 𤣋	qmuk	0
+𪻁	qmuk	0
 𤠻	qmul	0
 𤢼	qmul	0
 𤠁	qmun	0
@@ -71386,6 +74172,7 @@ encoder:
 獶	qmwr	133000
 𤜴	qmwr	0
 𤝛	qmwr	0
+𪺻	qmwr	0
 𤡖	qmws	0
 𤡧	qmww	0
 𤟗	qmwx	0
@@ -71397,6 +74184,8 @@ encoder:
 𤝽	qmxb	0
 𤠿	qmxb	0
 𤢇	qmxb	0
+𪻃	qmxb	0
+𪺿	qmxd	0
 狃	qmxe	158000
 𤞎	qmxf	0
 𤡦	qmxf	0
@@ -71468,11 +74257,13 @@ encoder:
 𤝲	qmzg	0
 𤠓	qmzg	0
 𤜟	qmzi	0
+𪻈	qmzi	0
 𤠂	qmzj	0
 𤠕	qmzk	0
 㺙	qmzl	4800
 𤝾	qmzl	0
 𤠡	qmzl	0
+𪻅	qmzl	0
 㹭	qmzm	5200
 腇	qmzm	40600
 𤠱	qmzm	0
@@ -71489,6 +74280,7 @@ encoder:
 𤢒	qmzu	0
 𤢧	qmzu	0
 𤣆	qmzu	0
+𪺹	qmzx	0
 狕	qmzy	18800
 脢	qmzy	374000
 𤝕	qmzy	0
@@ -71509,6 +74301,7 @@ encoder:
 脾	qned	6950000
 𦞠	qned	0
 𦞵	qnge	0
+𫆛	qnhs	0
 脾虚	qnik	472000
 䑂	qnio	4960
 臇	qniy	35900
@@ -71548,6 +74341,7 @@ encoder:
 风趣	qobc	8150000
 𦞒	qobd	0
 𦣗	qobg	0
+𪱡	qobk	0
 脸颊	qobu	7120000
 脸	qobv	233000000
 风声	qobx	6320000
@@ -71610,6 +74404,7 @@ encoder:
 𦙐	qorr	0
 脸色	qory	21000000
 风衣	qosr	3480000
+𫌎	qosr	0
 肣	qosx	71900
 风靡	qotf	7530000
 脸庞	qotg	1990000
@@ -71628,6 +74423,7 @@ encoder:
 风速	qowf	3490000
 风灾	qowu	318000
 风扇	qowy	11200000
+𫆧	qoxb	0
 脸皮	qoxi	5270000
 𦛜	qoxj	0
 𦞛	qoxj	0
@@ -71657,6 +74453,7 @@ encoder:
 狐疑	qprm	709000
 𦜓	qpro	0
 𪃻	qprr	0
+𫆤	qpvv	0
 𦣅	qpxd	0
 𦞿	qpxm	0
 𦙀	qpxs	0
@@ -71670,6 +74467,7 @@ encoder:
 𩒄	qqag	0
 删	qqak	60900000
 𣆑	qqak	0
+𫚷	qqar	0
 𠛹	qqbk	0
 股长	qqch	767000
 䏎	qqda	3460
@@ -71713,6 +74511,7 @@ encoder:
 𠡮	qqym	0
 删除	qqyo	330000000
 胸无	qrag	742000
+𫆻	qrbr	0
 䏺	qrci	3720
 膖	qrcw	34100
 胸花	qren	1240000
@@ -71778,6 +74577,7 @@ encoder:
 胶囊	qsaj	12500000
 猝死	qsar	2650000
 脑壳	qsbw	1180000
+𫆷	qsby	0
 丹青	qscq	2840000
 丹麦	qscr	11600000
 脉搏	qsdf	6700000
@@ -71806,9 +74606,11 @@ encoder:
 䵊	qsko	4000
 𠂄	qskr	0
 臆	qskw	1690000
+𪱨	qskz	0
 狡黠	qslb	2240000
 膪	qslj	43100
 𡵕	qsll	0
+𪱩	qslz	0
 䐮	qsmm	5120
 𦜍	qsmo	0
 𦞎	qsmp	0
@@ -71852,6 +74654,7 @@ encoder:
 𠣝	qsrt	0
 䳮	qsrz	3480
 鴅	qsrz	35900
+𫛝	qsrz	0
 𪚘	qssi	0
 狡诈	qssm	1730000
 狡辩	qsss	1430000
@@ -71860,6 +74663,7 @@ encoder:
 脑浆	qstr	676000
 䐱	qsul	4590
 胶着	qsul	919000
+𪱭	qsur	0
 胶卷	qsuy	2880000
 脉数	qsuz	119000
 脑海	qsvm	13500000
@@ -71872,6 +74676,7 @@ encoder:
 丹寨	qswe	204000
 腋窝	qswj	473000
 腣	qswl	38500
+𪱧	qswr	0
 膀	qsws	2180000
 丹心	qswz	1910000
 𢜑	qswz	0
@@ -71897,6 +74702,7 @@ encoder:
 胘	qszz	39800
 褹	qtbq	34200
 𦡻	qtcq	0
+𫆝	qtdm	0
 𦟉	qteb	0
 𦙒	qted	0
 𦟟	qtff	0
@@ -71935,6 +74741,7 @@ encoder:
 𨃗	quji	0
 脱	qujr	82300000
 𦝇	quka	0
+𫆠	qukd	0
 𦞔	qukg	0
 𣎒	quki	0
 𦡮	qukk	0
@@ -71946,6 +74753,7 @@ encoder:
 幐	quli	459000
 𦚿	quli	0
 𦠇	qulk	0
+𪾕	qulk	0
 賸	qulo	942000
 𦠀	qulp	0
 脱手	qumd	1860000
@@ -71961,6 +74769,7 @@ encoder:
 脱贫	quoy	2540000
 脱销	qupk	1020000
 脱钩	qupr	1980000
+𫆨	quqk	0
 脱脂	quqr	1700000
 腾腾	ququ	3460000
 膦	qurm	891000
@@ -71974,6 +74783,7 @@ encoder:
 𦣍	quug	0
 膳	quuj	8900000
 腅	quuo	23500
+𪱪	quuo	0
 脱粒	quus	312000
 滕州	quvn	1600000
 腾空	quwb	2940000
@@ -72003,6 +74813,7 @@ encoder:
 月薪	qves	19400000
 月中	qvjv	8390000
 月光	qvkg	32100000
+𪱬	qvmb	0
 𦡤	qvne	0
 月份	qvno	105000000
 𦟸	qvnr	0
@@ -72135,6 +74946,7 @@ encoder:
 𦙷	qxqy	0
 𦢨	qxrn	0
 胒	qxrr	29900
+𪵌	qxrr	0
 𦞣	qxsi	0
 𢮗	qxsm	0
 凤庆	qxtg	353000
@@ -72164,8 +74976,10 @@ encoder:
 𪖒	qyan	0
 九列	qyar	36900
 猛烈	qyar	11800000
+𫕣	qyax	0
 九万	qyay	1090000
 奿	qyaz	66000
+𫆮	qyaz	0
 肥城	qybh	825000
 犯规	qybo	3380000
 𦢪	qybq	0
@@ -72201,12 +75015,15 @@ encoder:
 𦚺	qyii	0
 𧓖	qyii	0
 九点	qyij	6010000
+𪜗	qyja	0
 膙	qyji	54100
+𫆩	qyji	0
 猛跌	qyjm	370000
 𠃳	qyjn	0
 𤰙	qyki	0
 𤰚	qyki	0
 𣉑	qykk	0
+𪜔	qykk	0
 肠胃	qykq	5810000
 肥水	qykv	1540000
 犯罪	qylk	80600000
@@ -72219,6 +75036,7 @@ encoder:
 脡	qymb	237000
 九千	qyme	2350000
 肥缺	qyme	254000
+𪜙	qyme	0
 脠	qymi	237000
 䏜	qyms	3490
 𥹛	qymu	0
@@ -72292,6 +75110,7 @@ encoder:
 鵩	qyxr	50400
 𪂖	qyxr	0
 𫜹	qyxr	0
+𫛳	qyxr	0
 服	qyxs	733000000
 𠬚	qyxs	0
 肠子	qyya	1830000
@@ -72310,6 +75129,7 @@ encoder:
 厹	qyzs	95200
 肥乡	qyzz	293000
 𦞲	qzai	0
+𫆞	qzbi	0
 腞	qzgq	80300
 𦢍	qzhk	0
 𦠄	qzho	0
@@ -72370,6 +75190,7 @@ encoder:
 鱼网	ralo	2780000
 𩶁	ralo	0
 𩺂	ralo	0
+𫚎	ralo	0
 鱺	ralt	67500
 鱼骨	ralw	621000
 鱼种	ramj	791000
@@ -72394,6 +75215,8 @@ encoder:
 𩸸	raxz	0
 印张	rayc	5020000
 𩶏	rays	0
+𫚈	raza	0
+𫙢	razf	0
 印台	razj	515000
 鱼台	razj	2170000
 印发	razv	11200000
@@ -72424,6 +75247,7 @@ encoder:
 𧏤	rboi	0
 䲋	rbok	3760
 䲅	rbol	3880
+𫚜	rbol	0
 鯪	rbor	89000
 鲮	rbor	304000
 𧏤	rbqi	0
@@ -72437,6 +75261,7 @@ encoder:
 𧏤	rbui	0
 鱚	rbuj	332000
 𩻬	rbup	0
+𫚩	rbup	0
 𠢴	rbuy	0
 𩵘	rbvv	0
 𩵚	rbvv	0
@@ -72447,6 +75272,7 @@ encoder:
 鰪	rbzl	19100
 魱	rbzm	20500
 魼	rbzs	60200
+𫚋	rbzs	0
 𩹀	rcag	0
 𩸮	rcbi	0
 𩽪	rccc	0
@@ -72487,6 +75313,7 @@ encoder:
 儿媳	rdzn	2430000
 胤	rdzq	3550000
 𦚯	rdzq	0
+𫙡	rdzz	0
 𩼛	reae	0
 𩺗	reaj	0
 𩼘	reaj	0
@@ -72512,6 +75339,7 @@ encoder:
 𩻧	rekf	0
 𩻁	rekg	0
 鰽	rekk	28000
+𫚧	rekk	0
 𩸌	rekm	0
 𩺳	rekm	0
 鱑	reko	22700
@@ -72520,10 +75348,13 @@ encoder:
 𩹞	reld	0
 𩹅	relg	0
 𩺘	relo	0
+𫙽	relz	0
 𢍸	reme	0
 𩸚	remh	0
 𩽭	reml	0
 𩽡	remm	0
+𫙱	remy	0
+𫚂	reni	0
 𩸽	renr	0
 鱯	renx	22700
 鳠	renx	41600
@@ -72537,6 +75368,7 @@ encoder:
 𩷶	resh	0
 𩹩	resl	0
 𩺊	resn	0
+𫙐	revv	0
 䲛	rewl	3670
 𩺌	rewl	0
 𩷚	rewy	0
@@ -72584,6 +75416,7 @@ encoder:
 𩹿	rfrj	0
 䲚	rfrl	3830
 条文	rfso	5650000
+𫙤	rfsq	0
 𩺹	rfsy	0
 𩵦	rfvv	0
 𩻕	rfwr	0
@@ -72615,8 +75448,10 @@ encoder:
 𣀁	rgix	0
 𩹠	rgjk	0
 𩺙	rgjl	0
+𫙓	rgjo	0
 𤑰	rgju	0
 䱳	rgkb	25700
+𫚆	rgkg	0
 𩻻	rgkk	0
 𩸆	rgkz	0
 鮞	rgla	58500
@@ -72639,6 +75474,7 @@ encoder:
 𠨢	rgor	0
 詹	rgos	12400000
 𧩏	rgos	0
+𫙭	rgot	0
 𧫹	rgow	0
 𩻆	rgow	0
 然后	rgpa	381000000
@@ -72658,6 +75494,7 @@ encoder:
 𪆻	rgsr	0
 𩺚	rgub	0
 𩽦	rgub	0
+𫙫	rgur	0
 鮖	rgvv	62600
 危害	rgwc	70100000
 危房	rgws	1650000
@@ -72751,6 +75588,7 @@ encoder:
 𥀓	rhkx	0
 鰋	rhkz	32000
 𡝪	rhkz	0
+𫚢	rhkz	0
 𡑘	rhlb	0
 帋	rhli	62000
 贕	rhll	32800
@@ -72765,6 +75603,8 @@ encoder:
 𢑏	rhmx	0
 卯	rhmy	11400000
 𠨥	rhmy	0
+𫑗	rhmy	0
+𫑙	rhmy	0
 𤦨	rhnc	0
 𨾛	rhni	0
 劉	rhpk	27700000
@@ -72776,6 +75616,7 @@ encoder:
 𩵪	rhrd	0
 𣆾	rhrk	0
 𩻛	rhrk	0
+𫎛	rhrl	0
 𣢎	rhro	0
 䲭	rhrz	4850
 𣱒	rhsb	0
@@ -72817,6 +75658,7 @@ encoder:
 𥁚	rhyl	0
 𩛁	rhyo	0
 𨥫	rhyp	0
+𫚵	rhyr	0
 卵	rhys	42100000
 𤬵	rhys	0
 迎	rhyw	83200000
@@ -72850,6 +75692,7 @@ encoder:
 外面	rigj	49600000
 处在	rigv	23600000
 外在	rigv	8320000
+𫙜	rihz	0
 𩻩	riii	0
 外号	rija	2650000
 外围	rijb	8490000
@@ -72898,6 +75741,7 @@ encoder:
 鲈鱼	rira	763000
 处处	riri	19500000
 外角	rirl	340000
+𫙾	rirl	0
 𩶆	rirr	0
 外贸	rirs	87900000
 外务	riry	1160000
@@ -72930,6 +75774,7 @@ encoder:
 外边	riwy	7100000
 外观	rixl	37500000
 鲈	rixm	1380000
+𫙔	rixm	0
 𩽐	rixo	0
 𩼇	rixu	0
 外加	riyj	15100000
@@ -72937,11 +75782,13 @@ encoder:
 𩽶	rizi	0
 处女	rizm	22900000
 处以	rizo	5480000
+𪥯	rizx	0
 处级	rizy	2380000
 外出	rizz	34700000
 免于	rjad	2390000
 名画	rjak	7710000
 𩺅	rjak	0
+𫙷	rjal	0
 名列	rjar	8580000
 𩶭	rjas	0
 𩶍	rjaz	0
@@ -72953,6 +75800,7 @@ encoder:
 鰐	rjbz	309000
 鳄	rjbz	3780000
 𩹫	rjce	0
+𫙺	rjch	0
 免职	rjcj	2120000
 𩽴	rjcm	0
 各班	rjcu	2360000
@@ -72984,6 +75832,7 @@ encoder:
 句号	rjja	3340000
 各国	rjjc	44200000
 鱢	rjjf	21800
+𫚫	rjjf	0
 名贵	rjji	4990000
 𩻂	rjjj	0
 𪛃	rjjj	0
@@ -73000,6 +75849,7 @@ encoder:
 𪛉	rjjz	0
 名师	rjka	17000000
 鱓	rjke	52600
+𪞂	rjke	0
 各省	rjkm	20200000
 名鉴	rjkm	38100
 𡮿	rjkm	0
@@ -73049,6 +75899,8 @@ encoder:
 各处	rjri	4550000
 𣆶	rjrk	0
 𥇅	rjrl	0
+𪾐	rjrl	0
+𪱫	rjrq	0
 㲋	rjrr	4210
 兔	rjrs	47800000
 毚	rjrs	120000
@@ -73059,6 +75911,7 @@ encoder:
 勉	rjry	8080000
 各色	rjry	6800000
 𨞭	rjry	0
+𪞁	rjrz	0
 名言	rjsa	17100000
 𩖌	rjsg	0
 𧇢	rjsi	0
@@ -73125,6 +75978,7 @@ encoder:
 乐于	rkad	8380000
 鯷	rkai	52800
 鳀	rkai	43500
+𫚕	rkal	0
 龟裂	rkar	1150000
 乐平	rkau	1100000
 乐土	rkba	1430000
@@ -73149,6 +76003,7 @@ encoder:
 刨花	rken	250000
 备荒	rkes	206000
 备查	rkfk	2290000
+𫚄	rkfk	0
 备有	rkgq	4040000
 𩶸	rkgr	0
 旨在	rkgv	3110000
@@ -73166,6 +76021,7 @@ encoder:
 乐器	rkjj	28600000
 𩻱	rkjk	0
 𩼉	rkjk	0
+𫙲	rkjl	0
 𩻰	rkjm	0
 𣬔	rkjo	0
 鱧	rkju	364000
@@ -73173,6 +76029,7 @@ encoder:
 鯧	rkka	95900
 鲳	rkka	906000
 𨤰	rkkb	0
+𫒂	rkkb	0
 𩼅	rkkg	0
 𩸛	rkki	0
 乐昌	rkkk	739000
@@ -73180,6 +76037,7 @@ encoder:
 昏暗	rkks	5190000
 亀	rkkz	13100000
 𩸁	rkld	0
+𫙥	rkld	0
 鰛	rklk	29100
 鳁	rklk	32800
 乐山	rkll	6720000
@@ -73187,6 +76045,7 @@ encoder:
 𩹳	rklo	0
 覙	rklr	26900
 𡕳	rklr	0
+𫌨	rklr	0
 𩻠	rkls	0
 备用	rklv	11400000
 鰻	rklx	3780000
@@ -73284,6 +76143,7 @@ encoder:
 负起	rlby	1970000
 触动	rlbz	13500000
 𩺩	rlbz	0
+𫌮	rlbz	0
 𧥄	rlch	0
 解职	rlcj	1130000
 解聘	rlck	1720000
@@ -73319,11 +76179,14 @@ encoder:
 䱀	rlgd	16400
 奂	rlgd	2100000
 奐	rlgd	944000
+𫚐	rlgd	0
 𧣨	rlgh	0
 负面	rlgj	14200000
 𧤮	rlgj	0
 𧣩	rlgl	0
+𫙬	rlgl	0
 触礁	rlgn	635000
+𫌯	rlgn	0
 𩓅	rlgo	0
 负有	rlgq	7180000
 𧰼	rlgq	0
@@ -73339,6 +76202,7 @@ encoder:
 𧤡	rlhm	0
 𧢾	rlhr	0
 𧣒	rlhx	0
+𪩨	rlhx	0
 𧣾	rlih	0
 𧤫	rlio	0
 𧤧	rliq	0
@@ -73360,6 +76224,7 @@ encoder:
 䚩	rljl	3920
 𧤜	rljl	0
 𧤦	rljl	0
+𫌱	rljm	0
 䚭	rljn	3430
 𧣕	rljo	0
 𧤉	rljq	0
@@ -73468,6 +76333,7 @@ encoder:
 觚	rlps	323000
 解释	rlpx	93900000
 角膜	rlqe	2700000
+𫙹	rlqi	0
 解脱	rlqu	11500000
 𧣇	rlqx	0
 触犯	rlqy	5840000
@@ -73486,6 +76352,7 @@ encoder:
 鰴	rlrm	31400
 觴	rlro	1150000
 𠤀	rlro	0
+𫌰	rlro	0
 䚠	rlrr	3900
 𡕫	rlrr	0
 𣬋	rlrr	0
@@ -73499,6 +76366,7 @@ encoder:
 𧣏	rlrt	0
 觾	rlru	21100
 𤊱	rlru	0
+𪹌	rlru	0
 𧥕	rlrw	0
 角色	rlry	66900000
 𠢒	rlry	0
@@ -73623,6 +76491,7 @@ encoder:
 鯯	rmlk	35400
 𩶫	rmlk	0
 𩻳	rmmf	0
+𫙳	rmnd	0
 孵化	rmnr	5330000
 𩽕	rmnx	0
 疑似	rmnz	6920000
@@ -73680,12 +76549,14 @@ encoder:
 鲌	rnka	58400
 𠜼	rnkd	0
 鯾	rnko	39400
+𫚣	rnko	0
 鰁	rnkv	36000
 鳈	rnkv	22900
 𩻖	rnkz	0
 𩸊	rnli	0
 𩽬	rnlu	0
 𢽶	rnmo	0
+𫙯	rnmp	0
 㷺	rnmu	14600
 兜售	rnnj	2460000
 𩽧	rnnx	0
@@ -73697,9 +76568,11 @@ encoder:
 兜儿	rnrd	55700
 鯢	rnrd	147000
 鲵	rnrd	350000
+𫚘	rnre	0
 鰷	rnrf	41200
 𦥵	rnrj	0
 欿	rnro	31700
+𫙯	rnrp	0
 魤	rnrr	39800
 𩹻	rnrr	0
 鵮	rnrz	20200
@@ -73712,11 +76585,13 @@ encoder:
 𩺟	rnxm	0
 䱸	rnxs	12000
 𩹹	rnxs	0
+𫙨	rnxx	0
 𩺫	rnym	0
 𩼾	rnzu	0
 𩸵	roai	0
 𩹑	roai	0
 鮯	roaj	28400
+𫚗	roaj	0
 鯩	roal	29900
 欠款	robb	3240000
 𩽸	robg	0
@@ -73771,6 +76646,7 @@ encoder:
 鯰	roxw	845000
 鲶	roxw	871000
 魵	royd	91400
+𫚍	royd	0
 𩸂	royw	0
 䱵	royy	4210
 䲝	royy	3960
@@ -73812,6 +76688,7 @@ encoder:
 𠤨	rrae	0
 𣬂	rrae	0
 𣬊	rrae	0
+𪟩	rrag	0
 比武	rrah	5280000
 㔭	rrai	5000
 𠤧	rrai	0
@@ -73884,24 +76761,29 @@ encoder:
 眞	rrlo	6770000
 𠤤	rrlo	0
 𧴦	rrlo	0
+𫙿	rrlx	0
 𨜭	rrly	0
 𠤑	rrma	0
 𠤕	rrma	0
 𩷄	rrmb	0
 毕生	rrmc	3680000
+𫙮	rrmf	0
 穎	rrmg	9300000
 颖	rrmg	18900000
 𩓙	rrmg	0
 比重	rrmk	18700000
+𪵊	rrmm	0
 欵	rrmr	66500
 𠤗	rrmr	0
 𣣅	rrmr	0
 𩺶	rrmr	0
 𪁬	rrmr	0
+𪴬	rrmr	0
 𩻫	rrmu	0
 𥏶	rrmz	0
 比例	rrna	74900000
 䱤	rrnb	4450
+𪟫	rrnc	0
 比值	rrne	1840000
 𡙊	rrng	0
 𩀊	rrnn	0
@@ -73935,11 +76817,14 @@ encoder:
 毕	rrre	22300000
 枈	rrrf	67300
 𨋅	rrrf	0
+𫙰	rrrf	0
 𡗬	rrrg	0
+𫖝	rrrg	0
 𧔻	rrri	0
 𣅜	rrrk	0
 觺	rrrl	30800
 𧣅	rrrl	0
+𪵕	rrrl	0
 毞	rrrm	919000
 𢻹	rrrm	0
 𤘤	rrrm	0
@@ -73951,6 +76836,7 @@ encoder:
 魮	rrrr	47100
 𣢋	rrrr	0
 𣬅	rrrr	0
+𫚰	rrrr	0
 𥏑	rrrs	0
 𩶰	rrrs	0
 𩸃	rrrs	0
@@ -73958,6 +76844,7 @@ encoder:
 𩽿	rrrs	0
 𩾅	rrrs	0
 粊	rrru	466000
+𪫠	rrrw	0
 㿫	rrrx	5640
 𤿎	rrrx	0
 𠨒	rrry	0
@@ -73990,20 +76877,24 @@ encoder:
 𠤞	rrxa	0
 䱢	rrxb	3920
 肄	rrxb	801000
+𫆔	rrxb	0
 疑	rrxi	74500000
 𩼨	rrxi	0
 𨽹	rrxk	0
 𨽻	rrxk	0
+𫕙	rrxk	0
 𥏚	rrxl	0
 𥻊	rrxu	0
 比对	rrxv	2810000
 鮑	rrya	2710000
 鲍	rrya	22100000
+𫙙	rryi	0
 鰡	rryk	68800
 𩺜	rryk	0
 𥛤	rryl	0
 䲒	rrym	3910
 𣤃	rrym	0
+𪟟	rrym	0
 㽈	rrys	5020
 𤭧	rrys	0
 𦐳	rryy	0
@@ -74040,16 +76931,19 @@ encoder:
 𩼆	rsbr	0
 𨝋	rsby	0
 𡖮	rsbz	0
+𪠞	rsbz	0
 夆	rsci	605000
 𡕗	rsci	0
 𧋴	rsci	0
 留职	rscj	423000
 㶻	rscu	3800
 逢	rscw	63000000
+𪧶	rsds	0
 㚈	rsed	3830
 𠥾	rsed	0
 頯	rseg	24900
 𡖻	rsel	0
+𪤾	rseq	0
 𡕛	rseu	0
 𤍙	rseu	0
 㩼	rsex	3810
@@ -74057,6 +76951,7 @@ encoder:
 𡖯	rsfj	0
 𦠁	rsfj	0
 𤒗	rsfl	0
+𫚀	rsfp	0
 留校	rsfs	1140000
 𩁼	rsfv	0
 𡖠	rsgb	0
@@ -74085,6 +76980,7 @@ encoder:
 迯	rsiw	92000
 𡖄	rsix	0
 𢼛	rsix	0
+𪤺	rsiy	0
 頟	rsjg	36400
 𠧨	rsji	0
 𡒒	rsji	0
@@ -74119,9 +77015,13 @@ encoder:
 𨚷	rsjy	0
 𨝠	rsjy	0
 𩻗	rsjy	0
+𪟚	rsjy	0
+𫚨	rsjy	0
+𪤵	rsjz	0
 鱣	rska	45900
 鳣	rska	41400
 𩻡	rskb	0
+𪤿	rskb	0
 𡭫	rskd	0
 鱆	rske	68300
 㚌	rskf	4360
@@ -74151,6 +77051,7 @@ encoder:
 𦓟	rslg	0
 𢁙	rsli	0
 𢁟	rsli	0
+𪤷	rsli	0
 𠞚	rslk	0
 𡖕	rsll	0
 𡵁	rsll	0
@@ -74229,7 +77130,9 @@ encoder:
 𡖾	rsre	0
 䫂	rsrg	3410
 贸然	rsrg	3470000
+𫖰	rsrg	0
 𡖧	rsrh	0
+𪤸	rsri	0
 夠	rsrj	23100000
 𠛫	rsrk	0
 𡖿	rsrl	0
@@ -74252,6 +77155,7 @@ encoder:
 𦠹	rsru	0
 迻	rsrw	82700
 𪚪	rsrw	0
+𪤻	rsrx	0
 卶	rsry	27900
 𡖎	rsry	0
 𡖐	rsry	0
@@ -74286,6 +77190,7 @@ encoder:
 𧯭	rsue	0
 夈	rsuf	318000
 粂	rsuf	169000
+𪤹	rsuf	0
 留美	rsug	2540000
 𠞎	rsuk	0
 𡮫	rsuk	0
@@ -74333,6 +77238,7 @@ encoder:
 䱶	rsxy	3890
 𡖖	rsxy	0
 𡖥	rsxy	0
+𪤼	rsxy	0
 勺子	rsya	3180000
 𡕕	rsya	0
 𡖊	rsyb	0
@@ -74347,6 +77253,7 @@ encoder:
 盌	rsyl	49300
 眢	rsyl	618000
 𧵍	rsyl	0
+𪾎	rsyl	0
 务	rsym	263000000
 𢪸	rsym	0
 𩚴	rsyo	0
@@ -74356,6 +77263,7 @@ encoder:
 鴛	rsyr	357000
 鸳	rsyr	1890000
 𪀈	rsyr	0
+𫚹	rsyr	0
 㼝	rsys	4380
 𡖉	rsys	0
 𤮘	rsys	0
@@ -74376,6 +77284,7 @@ encoder:
 𡚮	rszm	0
 𡚰	rszm	0
 𡛹	rszm	0
+𫙜	rszm	0
 鯍	rszn	17800
 𡗌	rszn	0
 㚊	rszo	4190
@@ -74406,10 +77315,13 @@ encoder:
 𩸅	rtnd	0
 𩽉	rtnx	0
 𩼼	rtob	0
+𫙴	rtoo	0
 冬令	rtow	1210000
 冬瓜	rtps	5040000
 𩼼	rtrb	0
 鳉	rtrd	73500
+𫙩	rtrj	0
+𫚁	rtrl	0
 鯳	rtrs	42600
 冬训	rtsn	395000
 冬装	rttb	5200000
@@ -74438,6 +77350,7 @@ encoder:
 	rufd	0
 𩺧	ruhb	0
 鮵	rujr	27600
+𫚛	rujr	0
 鲜果	rukf	5100000
 䲕	rukk	3840
 鲜明	rukq	18600000
@@ -74469,12 +77382,14 @@ encoder:
 鳒	ruxk	34300
 𩷼	ruym	0
 䱧	ruyy	4070
+𫚠	ruyy	0
 鮷	ruyz	22400
 鲜红	ruzb	4980000
 鲜嫩	ruzf	1350000
 𩹖	ruzm	0
 𩹦	ruzs	0
 鰦	ruzz	74800
+𫚤	ruzz	0
 多于	rvad	15000000
 多哥	rvaj	1730000
 多万	rvay	23600000
@@ -74554,6 +77469,7 @@ encoder:
 鲢	rwhe	978000
 𩽼	rwhe	0
 𩸘	rwix	0
+𫙻	rwjk	0
 鰰	rwki	215000
 𩼧	rwkl	0
 𪚳	rwlb	0
@@ -74563,13 +77479,17 @@ encoder:
 𩼣	rwlj	0
 𩶱	rwmh	0
 𩽽	rwmh	0
+𫙵	rwmi	0
 𩺬	rwmy	0
 𩺬	rwnx	0
 鰫	rwoj	34000
 𩽜	rwoj	0
+𫚦	rwoj	0
 𩼶	rwop	0
+𫚬	rwop	0
 𩼵	rwor	0
 𪚺	rwpd	0
+𫙧	rwpd	0
 𩵨	rwqd	0
 魫	rwrd	22400
 𡙟	rwrg	0
@@ -74598,12 +77518,14 @@ encoder:
 𩽾	rwzm	0
 急于	rxad	11800000
 雏形	rxae	3020000
+𫙸	rxae	0
 𣝖	rxaf	0
 𡙝	rxag	0
 𩹍	rxag	0
 邹平	rxau	723000
 䲁	rxbd	4320
 鳚	rxbd	52800
+𫙟	rxbd	0
 鰎	rxby	165000
 急聘	rxck	1890000
 䲎	rxcm	3720
@@ -74619,6 +77541,7 @@ encoder:
 争相	rxfl	4850000
 𩽥	rxfl	0
 争夺	rxgd	20200000
+𫙞	rxgx	0
 𩷃	rxgz	0
 𢎍	rxhb	0
 煞车	rxhe	470000
@@ -74626,6 +77549,7 @@ encoder:
 鮍	rxia	41000
 鲏	rxia	37900
 争战	rxij	607000
+𪺘	rxil	0
 𩶒	rxim	0
 䱬	rxiq	5570
 𩾊	rxiq	0
@@ -74637,6 +77561,7 @@ encoder:
 𩺠	rxjo	0
 争鸣	rxjr	4010000
 𩼎	rxjs	0
+𫙼	rxju	0
 𩺐	rxjy	0
 𩻽	rxka	0
 𩽙	rxka	0
@@ -74655,6 +77580,7 @@ encoder:
 𠹨	rxmi	0
 鱊	rxml	27700
 𡺧	rxml	0
+𫚪	rxml	0
 争先	rxmr	2370000
 煞	rxmu	16300000
 𢞀	rxmw	0
@@ -74667,14 +77593,18 @@ encoder:
 𩻎	rxno	0
 争创	rxoy	2690000
 𠈽	rxqo	0
+𪹉	rxqu	0
 𩸿	rxqx	0
 鲫鱼	rxra	1830000
 𠑾	rxrd	0
+𫚇	rxri	0
+𫙖	rxrr	0
 𤍹	rxru	0
 𠜧	rxry	0
 𩿿	rxrz	0
 鰠	rxsi	30300
 鳋	rxsi	59200
+𪬽	rxsj	0
 争端	rxsl	4770000
 争论	rxso	16700000
 急诊	rxso	5020000
@@ -74692,9 +77622,11 @@ encoder:
 急流	rxvs	1390000
 急速	rxwf	16400000
 鯞	rxwl	31100
+𫚡	rxwl	0
 急迫	rxwn	1730000
 𪂺	rxwr	0
 鮼	rxwx	19500
+𪬎	rxwy	0
 急	rxwz	149000000
 急骤	rxxc	466000
 急剧	rxxe	8470000
@@ -74704,6 +77636,7 @@ encoder:
 皱眉	rxxl	6350000
 鰕	rxxx	118000
 𩸯	rxxx	0
+𫚥	rxxx	0
 𩷐	rxyj	0
 争办	rxyo	112000
 𢏻	rxyo	0
@@ -74768,6 +77701,7 @@ encoder:
 𪅞	rygr	0
 𠣥	rygs	0
 𠣮	rygu	0
+𫙗	ryhd	0
 包车	ryhe	1970000
 𠣹	ryhr	0
 䰾	ryia	4780
@@ -74828,8 +77762,10 @@ encoder:
 郇	ryky	582000
 𠡪	ryky	0
 𢏔	ryky	0
+𪽕	ryky	0
 匎	rykz	48300
 鸳鸯	rylg	7440000
+𫙪	rylg	0
 㬟	rylk	3730
 鯭	rylk	98500
 𣍐	rylk	0
@@ -74858,6 +77794,7 @@ encoder:
 务川	rynd	173000
 鮄	rynd	24800
 𩷺	rynd	0
+𫚒	rynd	0
 𦫖	rynk	0
 𠅱	rynr	0
 匑	ryny	24000
@@ -74865,10 +77802,12 @@ encoder:
 勽	ryod	24400
 勿	ryod	215000000
 𠓨	ryod	0
+𫚊	ryod	0
 𨍂	ryof	0
 䝆	ryog	4360
 𩑮	ryog	0
 𠤈	ryoi	0
+𪴵	ryoi	0
 𠯳	ryoj	0
 㫚	ryok	3690
 刎	ryok	578000
@@ -74948,9 +77887,11 @@ encoder:
 怨恨	ryux	9210000
 𠤆	ryvb	0
 𩵌	ryvv	0
+𫑨	ryvv	0
 色泽	ryvx	15000000
 色达	rywg	306000
 务必	rywm	25100000
+𪯏	rywm	0
 包袱	rywn	13000000
 包容	rywo	6070000
 务农	rywr	1240000
@@ -74996,15 +77937,19 @@ encoder:
 勾	ryzs	65800000
 𤌉	ryzu	0
 𤌽	ryzu	0
+𫐻	ryzw	0
+𫑂	ryzw	0
 皺	ryzx	6480000
 鄒	ryzy	1970000
 𨝁	ryzy	0
+𪥸	ryzy	0
 𠣎	ryzz	0
 𠣖	ryzz	0
 烏	rzaa	13500000
 𩾝	rzae	0
 䴌	rzag	4130
 𪃆	rzag	0
+𫖤	rzag	0
 𣦑	rzai	0
 𩺉	rzai	0
 𪁯	rzai	0
@@ -75022,6 +77967,7 @@ encoder:
 𡷊	rzal	0
 𩿐	rzal	0
 𠂶	rzam	0
+𫕜	rzan	0
 歍	rzar	41700
 𤑎	rzar	0
 邬	rzay	1860000
@@ -75041,6 +77987,7 @@ encoder:
 鷌	rzcu	25500
 䳖	rzcz	3370
 勾搭	rzde	1080000
+𫛓	rzeb	0
 鶀	rzec	25400
 𩿵	rzej	0
 𪂯	rzej	0
@@ -75060,6 +78007,7 @@ encoder:
 鯵	rzgp	1560000
 鲹	rzgp	43700
 䱲	rzgq	5760
+𫚸	rzgq	0
 𩿁	rzgs	0
 𩹧	rzgu	0
 𪈫	rzgu	0
@@ -75076,6 +78024,7 @@ encoder:
 𪆧	rzhz	0
 𣦘	rzii	0
 𩽵	rzii	0
+𫚳	rzij	0
 𪇷	rzis	0
 䳹	rzix	3980
 𪆳	rziy	0
@@ -75086,7 +78035,9 @@ encoder:
 𪈩	rzjn	0
 䳅	rzjo	3590
 𩸠	rzjq	0
+𫚼	rzjq	0
 䴋	rzjr	3780
+𫜅	rzjr	0
 𪇊	rzjs	0
 𪆖	rzju	0
 郺	rzjy	21700
@@ -75105,6 +78056,7 @@ encoder:
 𩿼	rzki	0
 𪀋	rzki	0
 𪀌	rzki	0
+𫙶	rzki	0
 𪈒	rzkl	0
 𪃐	rzkm	0
 𩶚	rzko	0
@@ -75174,6 +78126,7 @@ encoder:
 𠝷	rzoy	0
 𩿉	rzoy	0
 鱲	rzoz	166000
+𫚭	rzoz	0
 乌金	rzpa	371000
 鷈	rzpi	28900
 凫	rzqd	840000
@@ -75215,6 +78168,7 @@ encoder:
 𪄝	rzrz	0
 𪄞	rzrz	0
 𪅝	rzrz	0
+𫚱	rzrz	0
 𣁓	rzso	0
 䙚	rzsr	5720
 袅	rzsr	996000
@@ -75236,10 +78190,12 @@ encoder:
 𪀤	rzvb	0
 𪇨	rzvf	0
 乌海	rzvm	1800000
+𫚅	rzvr	0
 䰲	rzvv	5940
 𪂋	rzwl	0
 𪇍	rzwl	0
 鴥	rzwo	38400
+𫛣	rzwo	0
 鴕	rzwr	77300
 鸵	rzwr	400000
 𪂊	rzwr	0
@@ -75248,9 +78204,11 @@ encoder:
 𪀴	rzxb	0
 𪆫	rzxf	0
 鴃	rzxg	157000
+𫛞	rzxg	0
 鵦	rzxk	21600
 𪅟	rzxl	0
 䳧	rzxm	3820
+𫛺	rzxm	0
 𪆭	rzxn	0
 䳁	rzxs	3620
 𩷅	rzxs	0
@@ -75262,6 +78220,7 @@ encoder:
 鷻	rzym	27500
 𩾖	rzym	0
 𩾜	rzym	0
+𫛈	rzyp	0
 𪇷	rzys	0
 𪈙	rzys	0
 𩿴	rzyt	0
@@ -75367,6 +78326,7 @@ encoder:
 评剧	saxe	465000
 誱	saxi	21800
 证书	saxy	72500000
+𫌿	saxz	0
 订费	sayn	25100
 𧧀	says	0
 订婚	sazr	2790000
@@ -75401,6 +78361,7 @@ encoder:
 𧫘	sbjr	0
 𧬇	sbju	0
 讲师	sbka	16700000
+𫍧	sbkv	0
 讲堂	sbkw	6600000
 𧥛	sbld	0
 讀	sbll	75600000
@@ -75480,6 +78441,7 @@ encoder:
 𧜍	sbzr	0
 詓	sbzs	151000
 𧥼	sbzs	0
+𫍜	sbzs	0
 请于	scad	4930000
 主干	scae	5480000
 𧩻	scag	0
@@ -75509,6 +78471,7 @@ encoder:
 𩒊	scgo	0
 主顾	scgy	591000
 主轴	schk	1840000
+𪜋	schm	0
 𧏼	scii	0
 𧬼	scjc	0
 讍	scjj	21600
@@ -75580,6 +78543,7 @@ encoder:
 𧩶	scyg	0
 主力	scym	36100000
 謸	scym	96400
+𫍵	scym	0
 主办	scyo	122000000
 主婚	sczr	408000
 主编	sczw	57500000
@@ -75631,6 +78595,8 @@ encoder:
 读本	sefa	4580000
 辣	sefj	69900000
 𨐤	sefl	0
+𫐛	sefl	0
+𫐚	sefy	0
 𧬔	segf	0
 𩕺	segg	0
 諾	segj	18400000
@@ -75712,6 +78678,7 @@ encoder:
 𧭝	serb	0
 䜦	serk	3430
 𧭽	sers	0
+𫍍	sers	0
 䜩	seru	17300
 讌	seru	229000
 	seru	0
@@ -75736,6 +78703,7 @@ encoder:
 辬	sess	25000
 辯	sess	2300000
 𢣑	sesw	0
+𪭀	sesw	0
 读	setg	266000000
 𠦑	sets	0
 谨慎	seue	43700000
@@ -75746,6 +78714,7 @@ encoder:
 𥆳	sevl	0
 㵷	sevs	5310
 𢌮	sevv	0
+𫌲	sevv	0
 读写	sewa	21300000
 谋害	sewc	794000
 𧫚	sewl	0
@@ -75770,9 +78739,11 @@ encoder:
 𧮚	sezi	0
 𨐎	sezm	0
 𨐮	sezo	0
+𫐝	sezo	0
 𨐑	sezr	0
 辫	sezs	2410000
 辮	sezs	517000
+𫐜	sezw	0
 新型	sfae	55800000
 新政	sfai	7360000
 新款	sfbb	31200000
@@ -75796,6 +78767,7 @@ encoder:
 新药	sfez	22000000
 新村	sffd	13600000
 辣椒	sffi	14200000
+𫍉	sffq	0
 𧝺	sffr	0
 新奇	sfga	13800000
 譳	sfgl	22100
@@ -75906,6 +78878,7 @@ encoder:
 䜍	sgkk	3650
 𧩚	sgkv	0
 䛳	sgkz	3390
+𫍫	sgkz	0
 䛔	sgla	3560
 𧦞	sgli	0
 𧭡	sglz	0
@@ -75938,10 +78911,12 @@ encoder:
 𠅒	shaf	0
 諴	shaj	99000
 讴歌	shaj	1040000
+𫍯	shaj	0
 𧫳	shak	0
 試	shbi	48700000
 誙	shbi	22800
 试	shbi	407000000
+𪱮	shbl	0
 𧪖	shbo	0
 𡑤	shbq	0
 誆	shca	89200
@@ -75960,6 +78935,7 @@ encoder:
 𨏩	shfq	0
 试样	shfu	904000
 𨛌	shfy	0
+𫍢	shgr	0
 諓	shhm	34000
 訝	shia	1650000
 讶	shia	4070000
@@ -75969,18 +78945,22 @@ encoder:
 试点	shij	39800000
 蠃	shiq	701000
 𧥯	shis	0
+𫍁	shji	0
 謳	shjj	1190000
 𠅽	shjk	0
 𠅳	shjl	0
+𪬳	shjl	0
 𠅻	shjq	0
 试图	shjr	27800000
 𧭻	shjs	0
 䜗	shjw	3470
 𧭶	shjz	0
 试题	shka	35900000
+𪦍	shkg	0
 𤰡	shki	0
 朚	shkq	70700
 𦣖	shkq	0
+𪱯	shkz	0
 𧦏	shld	0
 㠵	shli	7670
 𥁃	shlk	0
@@ -76000,6 +78980,7 @@ encoder:
 𠅼	shmo	0
 𢻬	shmo	0
 𧩼	shmo	0
+𫍶	shmo	0
 𥢵	shmq	0
 𦏞	shmt	0
 试管	shmw	2570000
@@ -76053,6 +79034,7 @@ encoder:
 詎	shxa	150000
 讵	shxa	366000
 𧩆	shxb	0
+𫍊	shxb	0
 试验	shxo	85000000
 𦫋	shxo	0
 𡳴	shxq	0
@@ -76068,6 +79050,7 @@ encoder:
 𣱅	shyh	0
 𧦩	shyi	0
 试办	shyo	521000
+𫍝	shyo	0
 𤭉	shys	0
 试飞	shyt	1040000
 訰	shzi	55800
@@ -76113,6 +79096,7 @@ encoder:
 諔	sikx	32500
 让贤	sikx	367000
 謯	silc	30300
+𫍹	silc	0
 𪚑	sili	0
 站岗	sill	1050000
 𡾩	sill	0
@@ -76151,6 +79135,7 @@ encoder:
 𪚥	siss	0
 站立	sisu	8700000
 𪚛	site	0
+𫍔	siuh	0
 𧥞	sivv	0
 让它	siwr	16900000
 𢤲	siwz	0
@@ -76223,8 +79208,10 @@ encoder:
 諤	sjbz	187000
 谔	sjbz	545000
 颤动	sjbz	6430000
+𪜟	sjbz	0
 諿	sjce	28400
 部长	sjch	38700000
+𫍎	sjch	0
 就职	sjcj	9400000
 襄理	sjck	148000
 讝	sjcm	21100
@@ -76288,10 +79275,12 @@ encoder:
 识破	sjgx	3320000
 高雄	sjgz	59300000
 就医	sjhm	11800000
+𪯒	sjhm	0
 高雅	sjhn	11800000
 误区	sjho	15400000
 𣄵	sjhr	0
 𢀮	sjhx	0
+𪩧	sjhx	0
 𩫨	sjhy	0
 㝄	sjhz	4380
 𧓂	sjii	0
@@ -76320,14 +79309,17 @@ encoder:
 𩫏	sjje	0
 譟	sjjf	133000
 髞	sjjf	42800
+𪲪	sjjf	0
 𠅧	sjjg	0
 高喊	sjjh	3470000
+𪜥	sjjh	0
 高贵	sjji	16700000
 𩫗	sjji	0
 𧬌	sjjl	0
 𩫣	sjjl	0
 稟	sjjm	1700000
 高呼	sjjm	3410000
+𫖎	sjjm	0
 敲响	sjjn	3670000
 膏	sjjq	17100000
 𩫘	sjjq	0
@@ -76349,6 +79341,7 @@ encoder:
 亶	sjka	639000
 竞日	sjka	19300
 𠆞	sjka	0
+𪧃	sjkb	0
 𡬱	sjkd	0
 䯬	sjke	3330
 亸	sjke	312000
@@ -76356,6 +79349,7 @@ encoder:
 譂	sjke	72000
 𡅄	sjke	0
 𩫜	sjke	0
+𫘷	sjke	0
 亮光	sjkg	6190000
 就	sjkg	1720000000
 𡰔	sjkg	0
@@ -76404,6 +79398,7 @@ encoder:
 𩫍	sjlm	0
 𩫙	sjln	0
 𧪼	sjlo	0
+𫍩	sjlo	0
 毃	sjlq	39200
 𩪿	sjlq	0
 歊	sjlr	41400
@@ -76416,6 +79411,7 @@ encoder:
 𩫋	sjlx	0
 䯩	sjly	3390
 鄗	sjly	54800
+𫘵	sjly	0
 高县	sjlz	818000
 墪	sjmb	57600
 高等	sjmb	57200000
@@ -76558,6 +79554,7 @@ encoder:
 熟	sjsu	80000000
 𤍨	sjsu	0
 𤒆	sjsu	0
+𪹱	sjsu	0
 识记	sjsy	494000
 𩫄	sjte	0
 京广	sjtg	1770000
@@ -76575,6 +79572,7 @@ encoder:
 高烧	sjuh	3310000
 哀悼	sjui	4960000
 高爆	sjuk	379000
+𪯜	sjum	0
 敦煌	sjun	6750000
 部首	sjun	2830000
 𩁛	sjun	0
@@ -76655,6 +79653,7 @@ encoder:
 襄阳	sjyk	2820000
 高阳	sjyk	1270000
 𧧸	sjyk	0
+𪜦	sjyk	0
 𥂣	sjyl	0
 敦	sjym	13700000
 𣮢	sjym	0
@@ -76670,6 +79669,7 @@ encoder:
 𤮩	sjys	0
 熟习	sjyt	488000
 烹	sjyu	6040000
+𪸿	sjyu	0
 譴	sjyw	1150000
 谴	sjyw	509000
 𢚟	sjyw	0
@@ -76771,6 +79771,7 @@ encoder:
 讄	skkk	21700
 𣉣	skkk	0
 亰	skko	371000
+𪨂	skko	0
 竟是	skkv	14600000
 意思	skkw	104000000
 课堂	skkw	45400000
@@ -76797,6 +79798,7 @@ encoder:
 章程	skmj	19900000
 课程	skmj	67400000
 𩡑	skmk	0
+𫍂	skml	0
 永年	skmm	1980000
 童年	skmm	19000000
 音符	skmn	12200000
@@ -76821,6 +79823,7 @@ encoder:
 课余	skom	2860000
 䛺	skon	3340
 脔	skoo	174000
+𪢓	skoo	0
 謖	skor	89400
 谡	skor	599000
 䛕	skos	3470
@@ -76910,6 +79913,7 @@ encoder:
 童心	skwz	5220000
 諰	skwz	43700
 𠅤	skwz	0
+𫍰	skwz	0
 永登	skxa	437000
 竟敢	skxc	3440000
 𧩍	skxg	0
@@ -76965,6 +79969,7 @@ encoder:
 端面	slgj	779000
 諯	slgl	33400
 𧪪	slgl	0
+𫍱	slgl	0
 𧭬	slgn	0
 𧬳	slgu	0
 调转	slhb	982000
@@ -76981,6 +79986,7 @@ encoder:
 𥂬	sljl	0
 譞	sljr	39000
 𧭴	sljr	0
+𫍽	sljr	0
 𧪚	slju	0
 调唆	sljz	38000
 褱	slkr	35100
@@ -77089,8 +80095,10 @@ encoder:
 产权	smfx	60600000
 放大	smgd	41400000
 訞	smgd	181000
+𫍚	smgd	0
 颜面	smgj	2900000
 许愿	smgn	17900000
+𫍤	smgn	0
 放在	smgv	116000000
 旋转	smhb	44700000
 託	smhd	8790000
@@ -77115,6 +80123,7 @@ encoder:
 话别	smjy	500000
 产量	smka	33400000
 諥	smkb	47100
+𫍳	smkb	0
 誗	smkd	25500
 许昌	smkk	5350000
 放映	smkl	14900000
@@ -77192,6 +80201,7 @@ encoder:
 旅店	smti	3760000
 𧪝	smtr	0
 𧦝	smua	0
+𫍞	smua	0
 放羊	smuc	1100000
 放慢	smuk	4870000
 放养	smun	1220000
@@ -77216,6 +80226,7 @@ encoder:
 𧫸	smxi	0
 诈骗	smxw	11700000
 诱骗	smxw	1570000
+𫍆	smxw	0
 旗子	smya	1130000
 訖	smyd	286000
 讫	smyd	1080000
@@ -77223,6 +80234,7 @@ encoder:
 𧥷	smyd	87
 𧨮	smye	0
 𧦧	smyi	0
+𫍟	smyi	0
 施加	smyj	5610000
 𧭀	smyk	0
 誘	smym	15100000
@@ -77292,6 +80304,7 @@ encoder:
 讹传	snnb	248000
 齐集	snnf	1890000
 𧮓	snni	0
+𪜤	snni	0
 𠅯	snno	0
 𠆠	snnu	0
 亦会	snob	1530000
@@ -77331,6 +80344,7 @@ encoder:
 𧚤	snrr	0
 𧩀	snrr	0
 𧪫	snrr	0
+𫍺	snrr	0
 夜	snrs	395000000
 謥	snrw	58800
 夜色	snry	12900000
@@ -77357,6 +80371,7 @@ encoder:
 𧩨	snxm	0
 謏	snxs	56800
 謢	snxs	646000
+𫍲	snxs	0
 谁也	snyi	17500000
 𧦭	snyi	0
 𧥰	snym	0
@@ -77369,6 +80384,7 @@ encoder:
 交融	soaj	7530000
 詥	soaj	73600
 认可	soaj	34000000
+𪯤	soaj	0
 𣦮	soak	0
 論	soal	48300000
 𧨦	soal	0
@@ -77404,6 +80420,7 @@ encoder:
 交接	sods	6200000
 対	sods	21600000
 文摘	sods	71100000
+𪫼	sodw	0
 论据	sodx	3090000
 文莱	soeb	1820000
 论著	soeb	2450000
@@ -77413,10 +80430,13 @@ encoder:
 𩓉	soeg	0
 𠲩	soej	0
 𡮇	soek	0
+𫀥	soek	0
 文献	soel	67800000
 认真	soel	107000000
 㲞	soem	4290
 𨿼	soen	0
+𪟼	soeo	0
+𪯦	soeo	0
 离散	soeq	2610000
 㐮	soer	6890
 㰵	soer	4900
@@ -77467,6 +80487,7 @@ encoder:
 𢒶	sojg	0
 讑	sojl	23200
 𧭆	sojl	0
+𪯪	sojl	0
 文史	sojo	11800000
 𠓬	sojo	0
 䘱	sojr	4660
@@ -77484,6 +80505,7 @@ encoder:
 刘	sokd	390000000
 𣁌	soke	0
 效果	sokf	223000000
+𪞽	sokg	0
 交由	soki	4280000
 文昌	sokk	5580000
 交界	soko	6150000
@@ -77502,6 +80524,7 @@ encoder:
 𣁘	solj	0
 譮	solk	205000
 认罪	solk	3430000
+𪯣	solk	0
 文山	soll	8110000
 斖	soll	36100
 𡵡	soll	0
@@ -77519,6 +80542,7 @@ encoder:
 𣁄	somb	0
 交手	somd	4560000
 六千	some	5180000
+𪞸	some	0
 𣓰	somf	0
 𧧶	somf	0
 文告	somj	1290000
@@ -77537,6 +80561,7 @@ encoder:
 交付	sond	16800000
 斉	sond	2190000
 齐	sond	123000000
+𪯠	sond	0
 交集	sonf	4280000
 文体	sonf	20400000
 文集	sonf	86000000
@@ -77544,6 +80569,7 @@ encoder:
 𣠛	sonf	0
 𥗱	song	0
 交代	sonh	18900000
+𪜣	sonh	0
 交售	sonj	272000
 剂	sonk	57400000
 剤	sonk	26000000
@@ -77559,6 +80585,7 @@ encoder:
 效仿	sons	3910000
 𢥗	sonw	0
 﨎	sonx	31500
+𪯩	sonx	0
 认命	sooa	1920000
 交待	soob	7420000
 𧨀	soob	0
@@ -77602,6 +80629,7 @@ encoder:
 文采	sopf	4500000
 顏	sopg	12900000
 𠷗	sopj	0
+𪵏	sopq	0
 交锋	sopr	6450000
 𪃛	sopr	0
 诊所	sopv	12000000
@@ -77615,6 +80643,7 @@ encoder:
 六月	soqv	39900000
 论处	sori	785000
 郊外	sori	8910000
+𪡍	sori	0
 𠞬	sork	0
 离解	sorl	130000
 𩘍	sorq	0
@@ -77640,7 +80669,9 @@ encoder:
 论调	sosl	2100000
 义诊	soso	2200000
 论文	soso	163000000
+𪯢	soso	0
 𡖍	sosr	0
+𫋴	sosr	0
 𣁕	soss	0
 交谈	sosu	23200000
 离谱	sosu	4470000
@@ -77649,6 +80680,7 @@ encoder:
 斏	sosx	21500
 訡	sosx	17800
 𣂂	sote	0
+𪞼	sotr	0
 效应	sotv	31000000
 诊疗	soty	5430000
 交差	soub	2730000
@@ -77686,6 +80718,7 @@ encoder:
 交通	sowx	309000000
 𪓖	sowx	0
 文字	sowy	364000000
+𪯨	sowy	0
 六安	sowz	3960000
 忞	sowz	136000
 文安	sowz	647000
@@ -77711,6 +80744,7 @@ encoder:
 交际	soyb	8230000
 㐎	soyd	4540
 訜	soyd	81700
+𫍛	soyd	0
 离异	soye	6100000
 交加	soyj	5180000
 效力	soym	12900000
@@ -77724,6 +80758,7 @@ encoder:
 𦑋	soyy	0
 𧬈	soyy	0
 𩕝	sozg	0
+𪞻	sozg	0
 㐫	sozi	4660
 㓙	sozi	3910
 訩	sozi	23900
@@ -77778,6 +80813,7 @@ encoder:
 𢒲	spii	0
 譒	spki	31900
 𧭕	spll	0
+𫍗	spls	0
 謟	spnb	31900
 谣传	spnb	1180000
 䜠	sppl	7950
@@ -77787,12 +80823,15 @@ encoder:
 𧞚	spsr	0
 诉说	spsv	10400000
 诉状	sptg	1500000
+𫍻	spuj	0
 𧝢	spur	0
+𫍀	spvv	0
 䛵	spwx	3410
 䛀	spxs	4150
 譌	spyu	267000
 𩑁	spyu	0
 謑	spzg	52100
+𫌽	spzm	0
 𧩒	spzy	0
 𧫈	sqaj	0
 𧩠	sqan	0
@@ -77800,6 +80839,7 @@ encoder:
 望都	sqby	1180000
 𠅪	sqcc	0
 訉	sqda	79800
+𪜠	sqda	0
 讽刺	sqfl	9380000
 设想	sqfl	14500000
 望奎	sqgb	226000
@@ -77942,6 +80982,7 @@ encoder:
 衣料	srut	5320000
 𢽯	srvm	0
 衣襟	srwf	2860000
+𪫳	srwz	0
 諍	srxb	244000
 诌	srxb	534000
 诤	srxb	1020000
@@ -77952,6 +80993,7 @@ encoder:
 𧪭	sryk	0
 𧩷	sryw	0
 䛄	sryy	3380
+𫍠	sryy	0
 𧪛	srza	0
 𧦷	srzo	0
 𧝾	srzr	0
@@ -77959,7 +81001,9 @@ encoder:
 𧭫	ssae	0
 𧭺	ssae	0
 𠆖	ssaj	0
+𫍓	ssax	0
 该项	ssbg	2910000
+𪤜	ssbs	0
 议长	ssch	1340000
 议事	ssdj	27700000
 辩护	ssdw	6310000
@@ -77977,6 +81021,7 @@ encoder:
 譠	sska	1040000
 议题	sska	5740000
 𧬤	sskb	0
+𫍼	sskb	0
 𧫱	sske	0
 𧫾	sskg	0
 識	sskh	14300000
@@ -78045,6 +81090,7 @@ encoder:
 𧧄	sszm	0
 𧨐	sszm	0
 𧩕	sszm	0
+𫍭	sszm	0
 𧨆	sszn	0
 𧮛	sszn	0
 該	sszo	93400000
@@ -78063,6 +81109,7 @@ encoder:
 𧪠	stma	0
 𧧉	stmh	0
 𧮠	stmk	0
+𫍑	stnn	0
 𧨱	stra	0
 𧜫	strh	0
 𧋲	stri	0
@@ -78080,6 +81127,7 @@ encoder:
 𧫨	stzl	0
 𧜍	stzr	0
 立于	suad	3640000
+𫁢	suad	0
 𥫉	suae	0
 谈天	suag	2640000
 竒	suaj	319000
@@ -78088,6 +81136,7 @@ encoder:
 𥪼	suaj	0
 𨶼	suaj	0
 𩐥	suaj	0
+𪷹	suaj	0
 𥩬	suak	0
 𩐡	suak	0
 韴	sual	25700
@@ -78101,6 +81150,7 @@ encoder:
 𥩳	subd	0
 𥩸	subd	0
 𥪸	subd	0
+𫁧	subd	0
 立项	subg	5860000
 𥪯	subg	0
 𩕉	subg	0
@@ -78116,12 +81166,14 @@ encoder:
 赣	subl	17800000
 𩐵	subl	0
 𩑅	subl	0
+𫎬	subl	0
 氃	subm	28100
 𥪤	subm	0
 𤗔	subn	0
 𥪢	subo	0
 𥪹	subq	0
 䴀	subr	16200
+𫛅	subr	0
 𥩺	subu	0
 立志	subw	8710000
 勭	suby	1140000
@@ -78142,12 +81194,14 @@ encoder:
 𥪏	sucx	0
 𥪳	sucx	0
 𥩩	sueb	0
+𫖛	sueb	0
 𥪓	suec	0
 竍	sued	37500
 𧫵	suee	0
 𩐷	suef	0
 𩕆	sueg	0
 𥩪	suej	0
+𫁦	suej	0
 䇎	suek	3750
 商朝	suek	729000
 商南	suel	305000
@@ -78157,6 +81211,7 @@ encoder:
 𩐠	sueo	0
 彰	suep	16500000
 𪅂	suer	0
+𫜂	suer	0
 遧	suew	32400
 𢥺	suew	0
 攱	suex	243000
@@ -78225,9 +81280,11 @@ encoder:
 商战	suij	2920000
 站	suij	2410000000
 𠶷	suij	0
+𫁥	suij	0
 谦虚	suik	13300000
 竬	suil	23700
 𥫇	suil	0
+𫖙	suil	0
 𢡃	suiw	0
 㪗	suix	3930
 𢾑	suix	0
@@ -78237,6 +81294,7 @@ encoder:
 帝国	sujc	47700000
 𢨅	sujc	0
 䫓	sujg	3580
+𪥘	sujg	0
 𢧂	sujh	0
 䇍	suji	3690
 立足	suji	20400000
@@ -78252,6 +81310,8 @@ encoder:
 𥫀	sujl	0
 𧷞	sujl	0
 敨	sujm	80100
+𪯙	sujm	0
+𫁨	sujm	0
 𨿦	sujn	0
 旁听	sujp	4610000
 𤬃	sujp	0
@@ -78277,6 +81337,7 @@ encoder:
 辨别	sujy	9120000
 部	sujy	966000000
 郶	sujy	19600
+𫁯	sujz	0
 商量	suka	32000000
 䪦	sukb	3650
 童	sukb	55200000
@@ -78304,9 +81365,12 @@ encoder:
 𩐲	sukl	0
 竗	sukm	23000
 𢾚	sukm	0
+𪵦	sukm	0
 商界	suko	9830000
+𫖚	suko	0
 𣂺	sukp	0
 𩐙	sukp	0
+𫖜	sukp	0
 䇌	sukq	3770
 𩐯	sukq	0
 歆	sukr	3530000
@@ -78329,12 +81393,14 @@ encoder:
 䪧	suky	3520
 謭	suky	25500
 谫	suky	97700
+𪟠	suky	0
 竜	sukz	13300000
 𡔕	sulb	0
 𥩢	sulc	0
 商	suld	677000000
 啇	suld	96900
 𠹧	suld	0
+𪪶	sule	0
 䫕	sulg	3610
 端	sulg	128000000
 韺	sulg	80800
@@ -78349,6 +81415,8 @@ encoder:
 𧷮	sull	0
 敵	sulm	20300000
 𣯵	sulm	0
+𪯐	sulm	0
+𪯔	sulm	0
 𥪞	sulo	0
 𥪧	sulo	0
 商贩	sulp	5030000
@@ -78369,6 +81437,7 @@ encoder:
 𢥮	sulw	0
 𢥿	sulw	0
 𥫒	sulw	0
+𪬥	sulw	0
 𠢗	suly	0
 𢁆	suly	0
 𨝗	suly	0
@@ -78392,6 +81461,8 @@ encoder:
 𥫔	suml	0
 𧗛	suml	0
 𧗜	suml	0
+𪱐	suml	0
+𪿁	suml	0
 産	summ	34200000
 谈笑	summ	3910000
 彦	sump	11800000
@@ -78457,13 +81528,16 @@ encoder:
 𢣪	supw	0
 㜪	supz	4230
 𡣎	supz	0
+𫁠	suqa	0
 竌	suqd	20800
 𥩕	suqd	0
 𩔍	suqg	0
 颯	suqi	804000
 𧪈	suqk	0
+𪟍	suqk	0
 𥃚	suql	0
 飒	suqo	506000
+𪭂	suqw	0
 竐	suqx	18400
 𥩘	sura	0
 𡎿	surb	0
@@ -78473,17 +81547,22 @@ encoder:
 𡙴	surg	0
 𤇯	surh	0
 𩑂	suri	0
+𪬫	suri	0
+𫁞	suri	0
 竘	surj	180000
 𠹪	surj	0
 𥩮	surj	0
 𩐝	surj	0
 详解	surl	14100000
 𧶜	surl	0
+𫁣	surl	0
 𤙺	surm	0
 𥪴	surm	0
 𩐨	surm	0
+𫁫	surm	0
 𣢦	suro	0
 𥪔	suro	0
+𫁬	suro	0
 䇋	surr	3710
 𥪫	surr	0
 𪅑	surr	0
@@ -78504,6 +81583,7 @@ encoder:
 鴗	surz	43000
 𥩞	surz	0
 𥪥	surz	0
+𫁡	surz	0
 旁证	susa	601000
 辨证	susa	5340000
 𢤴	susb	0
@@ -78534,10 +81614,12 @@ encoder:
 𧟛	susr	0
 𪆿	susr	0
 商议	suss	5970000
+𫁪	suss	0
 商谈	susu	4390000
 竝	susu	203000
 详谈	susu	1630000
 𥫑	susw	0
+𫐼	susw	0
 㿶	susx	5230
 䪩	susx	3690
 立方	susy	9360000
@@ -78547,6 +81629,7 @@ encoder:
 𣂅	sute	0
 𣂆	sute	0
 𣂉	sute	0
+𫖗	sute	0
 𩑈	sutg	0
 商店	suti	96800000
 𥪑	sutm	0
@@ -78593,9 +81676,11 @@ encoder:
 谦逊	suwy	1690000
 𥩾	suwy	0
 𧪶	suwy	0
+𫁭	suwy	0
 立案	suwz	11000000
 谈心	suwz	5070000
 𥿿	suwz	0
+𪬴	suwz	0
 䇈	suxb	4210
 𥩧	suxi	0
 𩐧	suxj	0
@@ -78625,34 +81710,47 @@ encoder:
 韶	suyj	3850000
 谈及	suym	4230000
 𩐚	suyn	0
+𫅬	suyo	0
 㼿	suys	6860
 瓿	suys	547000
 甋	suys	26700
 𩐛	suys	0
 𩐶	suys	0
+𫁤	suys	0
+𫑕	suyw	0
 䇃	suyy	3930
 翊	suyy	3200000
 譾	suyy	28800
 𦒍	suyy	0
+𫁩	suyy	0
+𫅬	suyy	0
+𫍿	suyy	0
 𥪲	suyz	0
 㡣	suzc	36300
+𫖘	suze	0
 𩐱	suzf	0
+𫏽	suzf	0
 𥪦	suzg	0
+𪥛	suzg	0
 𦁋	suzh	0
 𥩭	suzj	0
+𪡳	suzj	0
 详细	suzk	407000000
 𥪋	suzk	0
+𪽞	suzk	0
 𥉩	suzl	0
 𥪄	suzl	0
 𥫎	suzl	0
 妾	suzm	6730000
 竢	suzm	156000
 𣯡	suzm	0
+𫍴	suzm	0
 𥩲	suzo	0
 𥪧	suzo	0
 𩐰	suzo	0
 𧪜	suzq	0
 立约	suzr	192000
+𫁟	suzs	0
 𢠀	suzw	0
 韷	suzz	22600
 𥩚	suzz	0
@@ -78674,6 +81772,7 @@ encoder:
 率领	svow	9680000
 说服	svqy	16300000
 誂	svrd	159000
+𫍥	svrd	0
 说谎	svse	2920000
 说话	svsm	77300000
 说法	svvb	56600000
@@ -78709,6 +81808,7 @@ encoder:
 谉	swki	25200
 𧭟	swkm	0
 𧭈	swla	0
+𫍾	swla	0
 誼	swlc	3400000
 谊	swlc	5730000
 𧨏	swlc	0
@@ -78732,6 +81832,7 @@ encoder:
 𧬵	swoe	0
 𧨾	swof	0
 𧮈	swoj	0
+𫍇	swoj	0
 𧮎	swos	0
 𧩮	swox	0
 𧬯	swoy	0
@@ -78740,7 +81841,10 @@ encoder:
 𧭂	swrb	0
 訦	swrd	38800
 𧨾	swrf	0
+𫍦	swrh	0
+𫍈	swrn	0
 詑	swrr	502000
+𫍡	swrr	0
 𧭠	swru	0
 䛷	swry	3290
 谜语	swsb	7030000
@@ -78756,12 +81860,15 @@ encoder:
 這	swvv	166000000
 𧬪	swwf	0
 𧮘	swwf	0
+𫍌	swxl	0
 𧨠	swxs	0
 𧭋	swxs	0
 𧧕	swya	0
 诧异	swye	7050000
 謆	swyy	38700
+𫍸	swyy	0
 䛪	swyz	3410
+𫍒	swzl	0
 𧧼	swzm	0
 变形	sxae	16500000
 𦫍	sxae	0
@@ -78796,6 +81903,7 @@ encoder:
 𧫞	sxfv	0
 訣	sxgd	1760000
 诀	sxgd	5240000
+𫑯	sxge	0
 良辰	sxgh	2800000
 变态	sxgs	24100000
 译码	sxgx	518000
@@ -78803,6 +81911,7 @@ encoder:
 詖	sxia	49200
 诐	sxia	49000
 变频	sxik	17700000
+𫍏	sxil	0
 㐧	sxim	4640
 諝	sxiq	38700
 谞	sxiq	55500
@@ -78822,7 +81931,9 @@ encoder:
 誦	sxld	1270000
 诵	sxld	5190000
 𧧱	sxll	0
+𫍃	sxly	0
 朗县	sxlz	126000
+𫍅	sxmf	0
 变种	sxmj	8060000
 良种	sxmj	6580000
 譎	sxml	251000
@@ -78840,6 +81951,7 @@ encoder:
 㮾	sxqf	3920
 𧫫	sxqq	0
 𧩴	sxrf	0
+𫍘	sxri	0
 译名	sxrj	8510000
 讇	sxrn	20200
 欴	sxro	125000
@@ -78848,6 +81960,7 @@ encoder:
 变色	sxry	7560000
 𪁜	sxrz	0
 良言	sxsa	1710000
+𫌹	sxsa	0
 朗读	sxse	10500000
 謘	sxse	56300
 诵读	sxse	1740000
@@ -78864,6 +81977,7 @@ encoder:
 变为	sxuv	14100000
 变法	sxvb	1800000
 郎溪	sxvp	503000
+𪜊	sxvv	0
 诀窍	sxwb	5590000
 变速	sxwf	9310000
 变迁	sxwm	7200000
@@ -78895,7 +82009,9 @@ encoder:
 良缘	sxzz	5010000
 誳	sxzz	38900
 𧬲	sxzz	0
+𫍮	sxzz	0
 方形	syae	5340000
+𪯶	syag	0
 㫌	syai	4470
 方正	syai	16200000
 𣄍	syai	0
@@ -78925,7 +82041,9 @@ encoder:
 𪗅	sybx	0
 旔	syby	22200
 䶒	sybz	3770
+𪯹	sych	0
 𪗈	sycr	0
+𪯛	sycz	0
 记事	sydj	21900000
 方才	sydm	7420000
 𣄃	syec	0
@@ -78934,8 +82052,10 @@ encoder:
 记载	syeh	18300000
 譔	syeo	70000
 𣄗	syeo	0
+𫍖	syeo	0
 𣄄	syep	0
 𣄨	syep	0
+𪰃	syeu	0
 旚	syfb	24400
 𣄔	syfb	0
 𣄎	syfd	0
@@ -78962,6 +82082,7 @@ encoder:
 𧖊	syii	0
 𪚎	syii	0
 𣄅	syij	0
+𪯴	syij	0
 词频	syik	247000
 𢄲	syil	0
 㫍	syim	3980
@@ -78972,11 +82093,13 @@ encoder:
 𧘨	syir	0
 𥪱	syis	0
 记号	syja	3570000
+𪰄	syjb	0
 䫯	syjg	3540
 𩕲	syjg	0
 方圆	syjj	7350000
 𣃫	syjl	0
 𧬂	syjl	0
+𪯾	syjl	0
 𣃴	syjo	0
 𣃷	syjo	0
 弯路	syjr	3230000
@@ -78991,7 +82114,9 @@ encoder:
 𩐓	syka	0
 𣄛	sykb	0
 𣄢	sykb	0
+𪰅	sykc	0
 𠛍	sykd	0
+𪰀	syke	0
 𣄙	sykg	0
 旘	sykh	24600
 𣄞	sykh	0
@@ -79013,12 +82138,15 @@ encoder:
 𣃰	sylo	0
 𪗑	sylr	0
 𪗒	sylr	0
+𫑉	sylw	0
+𪯽	sylx	0
 誔	symb	288000
 𡌼	symb	0
 孪生	symc	2190000
 诞生	symc	55800000
 旗	syme	66600000
 𣃬	syme	0
+𫍕	syme	0
 𣄉	symf	0
 𧧇	symf	0
 𠅑	symg	0
@@ -79028,11 +82156,13 @@ encoder:
 诞	symi	4750000
 𧌱	symi	0
 𧐈	symi	0
+𪯕	symi	0
 方程	symj	4030000
 𣃥	symk	0
 𣃧	symk	0
 𣃵	symk	0
 𣃻	symk	0
+𪟒	symk	0
 斾	syml	137000
 𢄧	syml	0
 𣄘	syml	0
@@ -79043,6 +82173,8 @@ encoder:
 𣄓	symm	0
 𩀥	symn	0
 𩙴	symn	0
+𪯸	symn	0
+𫍄	symn	0
 放	symo	653000000
 𩜢	symo	0
 旂	symp	1390000
@@ -79055,6 +82187,7 @@ encoder:
 𩺯	symr	0
 訯	syms	19600
 旇	symx	477000
+𪯳	symx	0
 施	symy	126000000
 斿	symy	1320000
 𡥮	symy	0
@@ -79071,6 +82204,7 @@ encoder:
 齋	synk	4690000
 齍	synl	30700
 齎	synl	193000
+𪰂	synl	0
 𪗉	synm	0
 记仇	synq	735000
 𦠃	synq	0
@@ -79086,6 +82220,8 @@ encoder:
 䶒	synz	3770
 𣄀	syoc	0
 㫃	syod	8890
+𪯞	syoe	0
+𪰁	syoe	0
 𣃘	syoi	0
 𣃺	syoj	0
 㫆	syok	3550
@@ -79100,6 +82236,7 @@ encoder:
 𣄝	syoo	0
 𦠕	syoo	0
 𪗌	syoo	0
+𪯿	syoo	0
 謬	syop	751000
 谬	syop	2260000
 𧬶	syop	0
@@ -79109,6 +82246,8 @@ encoder:
 𣄪	syou	0
 旍	syow	146000
 𣃠	syow	0
+𪟑	syoy	0
+𪯲	sypd	0
 方针	sype	23600000
 𩕇	sypg	0
 旙	sypk	29000
@@ -79128,8 +82267,10 @@ encoder:
 𦦏	syrn	0
 𣃦	syro	0
 𩝦	syro	0
+𪴩	syro	0
 膂	syrq	155000
 𣃽	syrr	0
+𪬆	syrw	0
 鴋	syrz	36000
 𣃿	syrz	0
 方言	sysa	10500000
@@ -79142,6 +82283,7 @@ encoder:
 䜧	sysi	3590
 譅	sysi	68500
 𣄕	sysk	0
+𪯼	sysn	0
 谬论	syso	1400000
 𣁅	syso	0
 𣃚	sysq	0
@@ -79158,6 +82300,7 @@ encoder:
 乻	syty	43700
 𣃶	syty	0
 方差	syub	1020000
+𪯷	syuc	0
 旞	syug	26100
 词类	syug	308000
 𣄚	syug	0
@@ -79171,6 +82314,8 @@ encoder:
 旐	syvr	69500
 𧥟	syvv	0
 𧦫	syvv	0
+𫑟	syvv	0
+𪯻	sywd	0
 㫎	sywf	3740
 记述	sywf	2610000
 𣄈	sywf	0
@@ -79178,6 +82323,7 @@ encoder:
 𣄁	sywx	0
 方案	sywz	199000000
 誋	sywz	103000
+𫍪	sywz	0
 旔	syxb	22200
 旋	syxi	23800000
 𣃣	syxi	0
@@ -79185,6 +82331,7 @@ encoder:
 记录	syxk	300000000
 旎	syxr	5590000
 讔	syxw	34000
+𪯺	syxw	0
 𠆜	syxz	0
 𪗍	syxz	0
 𣃗	syyd	0
@@ -79224,6 +82371,7 @@ encoder:
 𩓗	szeg	0
 育苗	szek	2680000
 𠔚	szeo	0
+𫇄	szer	0
 刻薄	szev	2650000
 𢻉	szex	0
 罋	szez	23900
@@ -79255,6 +82403,7 @@ encoder:
 袬	szjr	31500
 䜈	szkf	4050
 𤰸	szki	0
+𫋉	szki	0
 𡄚	szkl	0
 𡅟	szkl	0
 玅	szkm	110000
@@ -79329,8 +82478,10 @@ encoder:
 充	szrd	82000000
 𠅵	szrd	0
 𩒘	szrg	0
+𫆡	szri	0
 𩩇	szrl	0
 𪁇	szrr	0
+𫆽	szrr	0
 育雏	szrx	328000
 𠡌	szry	0
 𠡜	szry	0
@@ -79348,6 +82499,7 @@ encoder:
 率	szve	325000000
 𧧈	szvv	0
 牽	szwm	9280000
+𪺮	szwm	0
 充裕	szwo	4210000
 夣	szwr	93700
 充实	szwt	17200000
@@ -79369,6 +82521,7 @@ encoder:
 詘	szzi	40900
 诎	szzi	268000
 𨏯	szzj	0
+𪞅	szzj	0
 畜	szzk	17200000
 𠛑	szzk	0
 𠾃	szzl	0
@@ -79405,6 +82558,7 @@ encoder:
 病号	taja	454000
 𤺡	tajb	0
 病因	tajd	5930000
+𪽶	tajl	0
 𣪪	tajq	0
 痘	taju	15900000
 㾘	tako	4810
@@ -79430,6 +82584,7 @@ encoder:
 病危	targ	1950000
 㾐	tark	5890
 𤷋	tarm	0
+𪽨	tars	0
 病变	tasx	5780000
 病畜	tasz	120000
 病症	tata	5830000
@@ -79469,10 +82624,12 @@ encoder:
 壮大	tbgd	19800000
 装有	tbgq	5500000
 装车	tbhe	2080000
+𪽸	tbhz	0
 庄园	tbjb	6360000
 㿒	tbjd	5080
 凌晨	tbkg	29200000
 装甲	tbki	6360000
+𪽬	tbko	0
 装置	tble	50500000
 装卸	tbma	3840000
 装箱	tbmf	1900000
@@ -79499,6 +82656,7 @@ encoder:
 瘗	tbub	246000
 𤺬	tbup	0
 装料	tbut	248000
+𪽷	tbuw	0
 壮举	tbva	1710000
 装潢	tbve	20900000
 凌源	tbvg	393000
@@ -79561,9 +82719,14 @@ encoder:
 𠘓	tdam	0
 𠗍	tdan	0
 𠖸	tdar	0
+𪞧	tdar	0
 㓕	tdau	4080
+𪞘	tdax	0
+𪞮	tdax	0
+𪞢	tdbb	0
 𠗭	tdbd	0
 𤸟	tdbd	0
+𪞭	tdbg	0
 冮	tdbi	1020000
 凋	tdbj	3080000
 𠸆	tdbj	0
@@ -79583,6 +82746,7 @@ encoder:
 𠙖	tdcq	0
 𪅯	tdcr	0
 馮	tdcu	4480000
+𪞪	tdcu	0
 憑	tdcw	8570000
 𨝭	tdcy	0
 㓖	tdeb	4250
@@ -79598,6 +82762,7 @@ encoder:
 𠗘	tdeo	0
 凘	tdep	48800
 𣁰	tdep	0
+𪯫	tdep	0
 𠙥	tdeq	0
 𣃜	tdes	0
 慿	tdew	76200
@@ -79618,15 +82783,20 @@ encoder:
 𤈀	tdfu	0
 头	tdgd	340000000
 𣂇	tdgk	0
+𪟅	tdgk	0
 𠗇	tdgu	0
 𠗊	tdhb	0
 㭍	tdhf	4250
 冴	tdhi	901000
 冻	tdhk	36900000
+𪞩	tdhn	0
+𪞞	tdhy	0
+𪞣	tdih	0
 𠘦	tdil	0
 𠖱	tdis	0
 凛	tdjb	10500000
 𠗃	tdjd	0
+𪧸	tdjd	0
 楶	tdjf	41300
 𣓫	tdjf	0
 𣙤	tdjf	0
@@ -79638,6 +82808,7 @@ encoder:
 凜	tdjm	1250000
 𠘡	tdjm	0
 𣯃	tdjm	0
+𪞫	tdjm	0
 𠗓	tdjq	0
 㖍	tdjr	4050
 况	tdjr	12500000
@@ -79653,10 +82824,13 @@ encoder:
 𠘁	tdjy	0
 𠘐	tdka	0
 𠗔	tdkb	0
+𪞬	tdke	0
 𠘊	tdkg	0
 𠖹	tdki	0
+𪞛	tdki	0
 𠘌	tdkk	0
 𠘔	tdkm	0
+𪞦	tdkq	0
 𠘠	tdkr	0
 𠗹	tdku	0
 冰	tdkv	132000000
@@ -79673,7 +82847,9 @@ encoder:
 𠘎	tdlk	0
 凟	tdll	28400
 凗	tdln	30200
+𪞗	tdlo	0
 闭眼	tdlx	2290000
+𫑫	tdly	0
 𠘅	tdlz	0
 𠗝	tdmb	0
 𡍼	tdmb	0
@@ -79690,14 +82866,17 @@ encoder:
 㓔	tdnd	4150
 凖	tdne	365000
 𠦥	tdne	0
+𪳙	tdnf	0
 准	tdni	141000000
 𠗯	tdnk	0
+𪞜	tdnk	0
 𠘇	tdnp	0
 𤌞	tdnu	0
 㕠	tdnx	4030
 闭合	tdoa	2130000
 㓐	tdob	4810
 闭会	tdob	536000
+𪞡	tdob	0
 㓌	tdoc	4100
 𠗎	tdoc	0
 𠗚	tdoe	0
@@ -79717,6 +82896,7 @@ encoder:
 𠗕	tdor	0
 㓒	tdou	4300
 冷	tdow	150000000
+𪞮	tdow	0
 飡	tdox	53100
 𠖲	tdoy	0
 凇	tdoz	759000
@@ -79725,11 +82905,13 @@ encoder:
 𠘖	tdpl	0
 凈	tdpx	2110000
 𠖵	tdqb	0
+𪞖	tdqd	0
 𩇟	tdql	0
 𠘒	tdqp	0
 垐	tdrb	61600
 𣁻	tdrd	0
 栥	tdrf	80200
+𪲁	tdrf	0
 𣂌	tdri	0
 𧊒	tdri	0
 咨	tdrj	17900000
@@ -79766,13 +82948,17 @@ encoder:
 𡣂	tdrz	0
 𥿩	tdrz	0
 𠗤	tdsc	0
+𪲜	tdsf	0
 𠗥	tdsk	0
 𠘤	tdsk	0
 闭市	tdsl	181000
 凕	tdso	28200
+𪞙	tdso	0
 𠗩	tdss	0
 𤷟	tdsu	0
 𠗋	tdsw	0
+𪞘	tdsx	0
+𪞚	tdsx	0
 𣁾	tdte	0
 𠘛	tdtg	0
 冸	tdub	39400
@@ -79781,15 +82967,23 @@ encoder:
 𣁿	tdvr	0
 𠗈	tdvs	0
 𤶩	tdvs	0
+𪞨	tdwa	0
+𪞥	tdwb	0
 𠗞	tdwd	0
 闭塞	tdwe	2020000
+𪲜	tdwf	0
+𪞯	tdwg	0
 𠗬	tdwl	0
 𠗵	tdws	0
 㓎	tdwx	4070
+𪞠	tdwy	0
 𠖶	tdwz	0
 冿	tdxb	199000
 𠗻	tdxb	0
+𪞝	tdxb	0
+𪞰	tdxc	0
 𠘣	tdxd	0
+𪲜	tdxf	0
 决	tdxg	61300000
 凝	tdxi	29700000
 凔	tdxj	67400
@@ -79799,6 +82993,8 @@ encoder:
 𣳆	tdxk	0
 𠘄	tdxm	0
 冹	tdxs	55700
+𪞚	tdxs	0
+𪞤	tdxw	0
 𠗱	tdxx	0
 𠗷	tdxy	0
 凄	tdxz	22000000
@@ -79875,6 +83071,7 @@ encoder:
 𤼚	tezi	0
 𤺔	tezl	0
 𤻜	tezl	0
+𪽴	tezl	0
 𤹖	tfae	0
 麾下	tfai	1970000
 磨灭	tfau	4240000
@@ -79957,6 +83154,7 @@ encoder:
 磨练	tfzh	4280000
 麻绳	tfzj	690000
 麻纱	tfzk	330000
+𪽳	tfzm	0
 麻纺	tfzs	361000
 㡰	tgad	5930
 𢊢	tgad	0
@@ -79967,9 +83165,11 @@ encoder:
 头顶	tgag	11700000
 庑	tgag	554000
 𢉶	tgag	0
+𪪙	tgag	0
 庁	tgai	7380000
 𢇗	tgai	0
 𢉴	tgai	0
+𪪎	tgai	0
 㢊	tgaj	3460
 㢌	tgaj	3890
 㾨	tgaj	5030
@@ -79977,6 +83177,7 @@ encoder:
 𢉔	tgak	0
 𢊮	tgal	0
 𪎯	tgal	0
+𪪌	tgal	0
 𢈷	tgan	0
 𢋛	tgan	0
 𢈮	tgao	0
@@ -79986,6 +83187,7 @@ encoder:
 𢌖	tgaw	0
 𢇱	tgaz	0
 庤	tgbd	823000
+𫜖	tgbj	0
 𤷈	tgbk	0
 𢉜	tgbm	0
 𢈩	tgbo	0
@@ -80014,8 +83216,11 @@ encoder:
 㢅	tgce	3860
 𢌊	tgce	0
 广丰	tgci	1020000
+𪪪	tgci	0
+𪪚	tgcj	0
 廭	tgcl	22800
 𢊷	tgcl	0
+𪪣	tgcl	0
 𢉋	tgcq	0
 𢉑	tgcq	0
 𢉿	tgcu	0
@@ -80061,6 +83266,7 @@ encoder:
 𢈧	tgex	0
 𢉎	tgex	0
 𢻘	tgex	0
+𪪖	tgex	0
 𢇸	tgez	0
 𢈊	tgez	0
 𢉮	tgez	0
@@ -80142,11 +83348,13 @@ encoder:
 𢈫	tggh	0
 𢉇	tggi	0
 𢉳	tggj	0
+𪪓	tggj	0
 𢇴	tggl	0
 𢊡	tggl	0
 𢊹	tggl	0
 庞	tggm	20200000
 庬	tggm	44400
+𪪑	tggn	0
 𢈓	tggq	0
 𢇟	tggr	0
 状态	tggs	303000000
@@ -80157,6 +83365,7 @@ encoder:
 𢉏	tggx	0
 𢈌	tggy	0
 𨟖	tggy	0
+𪪔	tggy	0
 庢	tghb	1470000
 库	tghe	622000000
 𢈽	tghh	0
@@ -80167,10 +83376,12 @@ encoder:
 㡲	tghm	4530
 廐	tghr	58700
 𢇙	tghs	0
+𪪐	tghs	0
 庉	tghz	63900
 𧍽	tgib	0
 𧑢	tgib	0
 𢈶	tgih	0
+𪪛	tgih	0
 蠯	tgii	23700
 𢊚	tgii	0
 𢌆	tgii	0
@@ -80180,7 +83391,9 @@ encoder:
 𢉠	tgil	0
 𢊐	tgio	0
 庛	tgir	461000
+𪪦	tgir	0
 𢉍	tgiu	0
+𪪟	tgiw	0
 头颅	tgix	4670000
 𢇮	tgix	0
 𢈂	tgix	0
@@ -80189,6 +83402,7 @@ encoder:
 𣀫	tgix	0
 𣀯	tgix	0
 𪎘	tgix	0
+𪪏	tgix	0
 𢋄	tgiy	0
 𤶐	tgiy	0
 𢉓	tgiz	0
@@ -80213,6 +83427,7 @@ encoder:
 𢋔	tgjj	0
 𢋢	tgjj	0
 𢋾	tgjj	0
+𪪞	tgjj	0
 𢈴	tgjk	0
 𢉨	tgjk	0
 㢗	tgjl	4130
@@ -80231,17 +83446,22 @@ encoder:
 𢋖	tgjs	0
 㢄	tgju	4210
 𤉽	tgju	0
+𪪨	tgju	0
+𫎃	tgju	0
 𢇵	tgjx	0
 𢈞	tgjx	0
 廍	tgjy	57400
 鄌	tgjy	42600
 𢌓	tgjy	0
+𪪘	tgjy	0
+𪪝	tgjy	0
 𢉈	tgjz	0
 㡺	tgka	3910
 𢋃	tgka	0
 𢌁	tgka	0
 𢌐	tgka	0
 𩐕	tgka	0
+𪪤	tgka	0
 㢆	tgkb	4090
 𢋂	tgkb	0
 䨾	tgkc	3900
@@ -80325,6 +83545,7 @@ encoder:
 𢈃	tglr	0
 𢈥	tglr	0
 𢊿	tglr	0
+𪪜	tglr	0
 廲	tglt	51500
 头骨	tglw	2470000
 廰	tglw	183000
@@ -80479,6 +83700,7 @@ encoder:
 㢖	tgpk	3640
 廞	tgpr	40300
 𢈕	tgpr	0
+𫜆	tgpr	0
 𢈅	tgps	0
 𢇥	tgqe	0
 㢏	tgqk	3770
@@ -80499,6 +83721,7 @@ encoder:
 𠝇	tgrk	0
 𠝡	tgrk	0
 𢋡	tgrk	0
+𫜗	tgrk	0
 广角	tgrl	9800000
 𪎬	tgrl	0
 㢝	tgrm	3630
@@ -80521,6 +83744,7 @@ encoder:
 𣩇	tgrr	0
 𪈾	tgrr	0
 𪎠	tgrr	0
+𪥀	tgrr	0
 㡱	tgrs	6700
 底	tgrs	123000000
 𢉕	tgrs	0
@@ -80543,11 +83767,14 @@ encoder:
 𠜢	tgsk	0
 𢉩	tgsk	0
 𤸙	tgsl	0
+𪽅	tgsm	0
 广义	tgso	4090000
+𪪍	tgso	0
 庡	tgsr	1650000
 𢊭	tgsr	0
 𢌀	tgsr	0
 𪂑	tgsr	0
+𪪠	tgsr	0
 㡴	tgsu	4280
 𢉛	tgsw	0
 𢊕	tgsw	0
@@ -80579,6 +83806,8 @@ encoder:
 䗪	tgui	3630
 𤺗	tguk	0
 𧷫	tgul	0
+𪪡	tgul	0
+𪪥	tgul	0
 㫂	tgup	5570
 鷓	tgur	161000
 鹧	tgur	894000
@@ -80635,13 +83864,16 @@ encoder:
 𢇳	tgxi	0
 𢈻	tgxi	0
 𥀱	tgxi	0
+𪪧	tgxi	0
 唐	tgxj	113000000
 𢈪	tgxj	0
 𨇭	tgxj	0
+𪪒	tgxj	0
 剫	tgxk	63500
 劆	tgxk	60400
 康	tgxk	155000000
 𢊺	tgxk	0
+𪪢	tgxk	0
 庸	tgxl	18700000
 𢊟	tgxl	0
 𢾅	tgxm	0
@@ -80653,6 +83885,7 @@ encoder:
 𢉄	tgxr	0
 𣤤	tgxr	0
 𪃒	tgxr	0
+𫛻	tgxr	0
 废	tgxs	31900000
 庹	tgxs	2160000
 𢊤	tgxs	0
@@ -80662,6 +83895,7 @@ encoder:
 𥹺	tgxu	0
 𢈸	tgxw	0
 廊	tgxy	31900000
+𪪗	tgxy	0
 𢊨	tgxz	0
 痞子	tgya	7660000
 邝	tgya	1240000
@@ -80708,6 +83942,7 @@ encoder:
 𢋘	tgzn	0
 𢌈	tgzn	0
 𪎣	tgzn	0
+𪪕	tgzo	0
 𢈋	tgzq	0
 𢇰	tgzr	0
 𤺤	tgzr	0
@@ -80828,6 +84063,7 @@ encoder:
 軰	tirf	177000
 酱	tirf	12000000
 奖	tirg	151000000
+𪟪	tirg	0
 𧉥	tiri	0
 浆	tirk	16600000
 𠛙	tirk	0
@@ -80848,6 +84084,7 @@ encoder:
 䉾	tiru	3840
 𢘠	tirw	0
 邶	tiry	281000
+𪜜	tiry	0
 装	tisr	459000000
 闽北	titr	584000
 𤮪	tiue	0
@@ -80860,6 +84097,7 @@ encoder:
 𤼁	tiwl	0
 𥦚	tiwq	0
 㾎	tixa	4550
+𪽮	tixm	0
 𠬧	tixs	0
 𠭼	tixx	0
 㼱	tiys	5410
@@ -80954,6 +84192,7 @@ encoder:
 冰箱	tkmf	25200000
 𤹊	tkmi	0
 㾪	tkml	4910
+𪽺	tkmo	0
 𤹾	tkmz	0
 冰川	tknd	4200000
 𤻵	tknh	0
@@ -80989,6 +84228,7 @@ encoder:
 间断	tkzu	7990000
 𤻗	tkzu	0
 闬	tlae	47900
+𫔭	tlae	0
 阕	tlag	3020000
 𨸉	tlaj	0
 阓	tlal	39000
@@ -80998,6 +84238,7 @@ encoder:
 阇	tlbm	262000
 𤻂	tlbu	0
 闱	tlby	775000
+𫔲	tlby	0
 闫	tlcd	9250000
 闻	tlce	82000000
 㿂	tlcm	7320
@@ -81019,6 +84260,7 @@ encoder:
 闼	tlgw	870000
 闳	tlgz	445000
 𨸅	tlhb	0
+𫔵	tlhm	0
 门口	tlja	47000000
 阈	tlja	1230000
 阃	tljf	656000
@@ -81034,6 +84276,7 @@ encoder:
 阐	tlke	971000
 闸	tlki	14400000
 阊	tlkk	854000
+𫔹	tlkl	0
 𡭜	tlko	0
 𨸇	tlko	0
 瘝	tlkv	210000
@@ -81052,8 +84295,11 @@ encoder:
 癭	tllz	62500
 门生	tlmc	1070000
 𨸃	tlmh	0
+𫔶	tlnf	0
 阀	tlnh	23100000
+𫔴	tlni	0
 𤼒	tlnl	0
+𫔱	tlno	0
 阋	tlnr	483000
 𨸋	tlnu	0
 䦷	tlob	16200
@@ -81067,6 +84313,7 @@ encoder:
 𤶨	tlrr	0
 䦶	tlrx	14900
 	tlrx	0
+𫔳	tlsb	0
 𨸁	tlsh	0
 门市	tlsl	8380000
 闹	tlsl	43300000
@@ -81076,6 +84323,7 @@ encoder:
 闶	tlsq	364000
 阆	tlsx	611000
 𨸂	tlsy	0
+𫔯	tlte	0
 门将	tltr	4010000
 门廊	tlts	414000
 门灯	tlua	155000
@@ -81097,7 +84345,9 @@ encoder:
 𨸄	tlxo	0
 𨸀	tlya	0
 门巴	tlyi	246000
+𫔷	tlyw	0
 阘	tlyy	33400
+𫔰	tlze	0
 阖	tlzl	2000000
 𨷿	tlzm	0
 㿚	tlzn	5740
@@ -81217,6 +84467,7 @@ encoder:
 𤹆	tnxs	0
 𤹑	tnxw	0
 𤵩	tnyi	0
+𪽩	tnym	0
 瘦弱	tnyt	3420000
 癙	tnzd	71900
 𤼞	tnzo	0
@@ -81718,6 +84969,7 @@ encoder:
 𤺫	twww	0
 㾼	twxo	5730
 𤶒	twym	0
+𪽱	twym	0
 疲于	txad	818000
 𪊑	txae	0
 𪋋	txae	0
@@ -81725,6 +84977,7 @@ encoder:
 麙	txaj	22800
 𪊪	txaj	0
 𪋳	txak	0
+𫜎	txak	0
 决裂	txar	1970000
 序列	txar	20000000
 𪋴	txar	0
@@ -81767,6 +85020,7 @@ encoder:
 康柏	txfn	3320000
 瘺	txfv	123000
 𪋉	txfv	0
+𫑃	txfw	0
 疦	txgd	25800
 𪋐	txgg	0
 𪋣	txgg	0
@@ -81899,6 +85153,7 @@ encoder:
 𤻿	txrf	0
 𪊘	txrh	0
 𪊲	txrj	0
+𫜍	txrj	0
 康乐	txrk	6320000
 疲惫	txrk	16800000
 𪊨	txrk	0
@@ -81908,6 +85163,7 @@ encoder:
 㿕	txrn	5240
 麡	txrn	36900
 𪊖	txro	0
+𫜌	txro	0
 痆	txrr	29000
 麀	txrr	47300
 𪊕	txrr	0
@@ -81919,6 +85175,7 @@ encoder:
 麅	txry	32600
 𪊡	txry	0
 𪋅	txry	0
+𫑭	txry	0
 𪋞	txrz	0
 序言	txsa	6350000
 麈	txsc	245000
@@ -81945,6 +85202,7 @@ encoder:
 麋	txuf	403000
 闯关	txug	3910000
 𧲊	txug	0
+𫋡	txui	0
 𣋴	txuk	0
 序性	txum	474000
 麃	txuo	44900
@@ -81988,6 +85246,7 @@ encoder:
 䴥	txyj	7940
 𢉻	txyj	0
 𤶹	txyj	0
+𫜋	txym	0
 癈	txyq	837000
 㼾	txys	5250
 𪊍	txyy	0
@@ -82013,9 +85272,11 @@ encoder:
 𤵤	tyhd	0
 𤸅	tyhk	0
 疤	tyia	5660000
+𪽯	tyik	0
 庭园	tyjb	1430000
 𤻾	tyke	0
 𤷪	tylk	0
+𪽹	tylz	0
 疗程	tymj	3630000
 㽺	tyms	5110
 疿	tynd	25600
@@ -82026,6 +85287,7 @@ encoder:
 瘸	tyoo	2740000
 瘳	tyop	307000
 𤺟	tyou	0
+𪽵	typs	0
 𤺼	typy	0
 𤺹	tyro	0
 疗效	tyso	15200000
@@ -82106,6 +85368,7 @@ encoder:
 𠁝	uaaj	0
 𠔺	uaaj	0
 𢥳	uaaj	0
+𪞍	uaaj	0
 𠁔	uaaz	0
 兰	uabd	153000000
 灯塔	uabe	2240000
@@ -82115,13 +85378,18 @@ encoder:
 忓	uaed	1790000
 頩	uaeg	149000
 𠛼	uaek	0
+𫗸	uaek	0
 𢼶	uaem	0
+𫗻	uaeq	0
 鵧	uaer	26100
+𫛨	uaer	0
 𣁊	uaes	0
 㤣	uaew	5290
 迸	uaew	3260000
 㔙	uaey	4040
 郱	uaey	41900
+𪲿	uafj	0
+𫉓	uafk	0
 𩠳	uafn	0
 关	uagd	93600000
 𦍍	uagd	0
@@ -82134,21 +85402,25 @@ encoder:
 送	uagw	456000000
 遂	uagw	20600000
 𢡊	uagw	0
+𪠫	uagx	0
 郑	uagy	72000000
 𨚜	uagy	0
 𢗄	uaid	0
+𫇥	uaid	0
 𢠟	uaig	0
 怔	uaii	8350000
 𣀚	uaim	0
 𩠰	uaim	0
 𧈁	uaio	0
 𢝒	uaiq	0
+𪬄	uaiw	0
 㪠	uaix	4120
 𢼩	uaix	0
 𩠮	uaix	0
 𢗙	uaiz	0
 馘	uaja	262000
 𩠲	uaja	0
+𫗷	uajf	0
 愊	uajk	43000
 𩉕	uajk	0
 𩫐	uajl	0
@@ -82160,8 +85432,10 @@ encoder:
 𡐂	uakb	0
 𥚘	uakb	0
 㮍	uakf	3970
+𪲫	uakf	0
 灯光	uakg	21600000
 𢞹	uakg	0
+𪥗	uakg	0
 𨂝	uakj	0
 普	uakk	177000000
 𣹅	uakk	0
@@ -82169,6 +85443,7 @@ encoder:
 𢡍	uakl	0
 𢡤	uakl	0
 𧡟	uakl	0
+𪭃	uakl	0
 㝺	uakm	4010
 𣮧	uakm	0
 𣯽	uakm	0
@@ -82190,6 +85465,7 @@ encoder:
 䚊	uall	3620
 怲	ualo	40800
 灯具	ualo	25400000
+𪪃	ualo	0
 鷁	ualr	82400
 鹢	ualr	54200
 𣣼	ualr	0
@@ -82200,6 +85476,8 @@ encoder:
 𩢁	uamc	0
 灯笼	uamg	8790000
 𩑿	uamg	0
+𪬔	uamk	0
+𫗶	uamu	0
 𠬵	uamx	0
 𩠓	uamy	0
 𩠱	uamy	0
@@ -82209,10 +85487,12 @@ encoder:
 𩖐	uang	0
 𢟟	uanh	0
 𩠛	uanh	0
+𪫮	uank	0
 首	uanl	2560000000
 𩠔	uanm	0
 𢆣	uanr	0
 道	uanw	619000000
+𪬐	uanw	0
 𠡼	uany	0
 𪕼	uanz	0
 𠧆	uaoe	0
@@ -82262,6 +85542,7 @@ encoder:
 𦥈	uawh	0
 噵	uawj	332000
 𩠱	uawn	0
+𫗹	uawq	0
 懮	uawr	825000
 𠭳	uaxb	0
 𢆗	uaxe	0
@@ -82280,6 +85561,7 @@ encoder:
 𢜂	uaxw	0
 悽	uaxz	1500000
 𩠧	uayj	0
+𫗺	uaym	0
 剙	uayo	572000
 剏	uays	60400
 瓶	uays	61400000
@@ -82292,6 +85574,7 @@ encoder:
 𦑦	uayy	0
 𦒂	uayy	0
 𦒟	uayy	0
+𫅦	uayy	0
 𡙛	uazg	0
 𩒋	uazg	0
 𩒕	uazg	0
@@ -82300,6 +85583,7 @@ encoder:
 屰	uazi	44900
 𠧦	uazi	0
 𤲸	uazk	0
+𪟄	uazk	0
 𦥭	uazn	0
 𦥾	uazn	0
 𨿄	uazn	0
@@ -82323,6 +85607,7 @@ encoder:
 半天	ubag	28000000
 𢞄	ubaj	0
 半百	uban	685000
+𪫭	ubaz	0
 兰考	ubba	459000
 憢	ubbg	41400
 䄅	ubbk	5830
@@ -82365,6 +85650,7 @@ encoder:
 恒量	ubka	114000
 判	ubkd	41200000
 𤱵	ubki	0
+𪟶	ubkl	0
 恒星	ubkm	3700000
 半晌	ubkn	10300000
 𩴏	ubkn	0
@@ -82442,11 +85728,13 @@ encoder:
 恒温	ubvk	4990000
 兰州	ubvn	27000000
 兰溪	ubvp	1910000
+𪫞	ubvv	0
 半空	ubwb	6490000
 恒定	ubwd	1890000
 懛	ubwh	53900
 差遣	ubwj	935000
 差额	ubwr	4110000
+𪟸	ubws	0
 半边	ubwy	2560000
 𠢁	ubwy	0
 𢘤	ubwz	0
@@ -82471,6 +85759,7 @@ encoder:
 巻	ubyy	47300000
 𠡶	ubyy	0
 弮	ubyz	571000
+𪬕	ubzk	0
 㥺	ubzl	4360
 𡛤	ubzm	0
 𢗝	ubzm	0
@@ -82481,6 +85770,7 @@ encoder:
 㤼	ubzy	4710
 勬	ubzy	1810000
 恸	ubzy	845000
+𪫸	ubzy	0
 	ucaa	0
 	ucaa	0
 𦍌	ucaa	0
@@ -82488,6 +85778,7 @@ encoder:
 精干	ucae	2320000
 𨷑	ucae	0
 䍪	ucaf	3640
+𫅏	ucai	0
 羬	ucaj	81800
 𠻁	ucaj	0
 𦎛	ucaj	0
@@ -82532,18 +85823,21 @@ encoder:
 羮	ucco	119000
 𢟩	uccx	0
 情操	ucdj	4080000
+𫅖	ucdj	0
 㤽	ucds	4890
 精挑	ucdv	2470000
 情报	ucdy	42400000
 𠵊	ucej	0
 𦍩	ucej	0
 𦎠	ucej	0
+𫅡	ucej	0
 𦏒	ucek	0
 𩼫	ucek	0
 𩽫	ucek	0
 精英	ucel	71800000
 羵	ucel	23800
 𦎽	ucel	0
+𫅗	ucel	0
 䍻	uceo	3440
 𪅠	ucer	0
 𢻐	ucex	0
@@ -82596,7 +85890,9 @@ encoder:
 䍺	uciw	3790
 㪨	ucix	4200
 𢼝	ucix	0
+𫅟	ucix	0
 𦎘	ucja	0
+𪬮	ucjc	0
 䍰	ucjd	4000
 𦏟	ucjd	0
 𦏛	ucjf	0
@@ -82622,6 +85918,8 @@ encoder:
 鄯	ucjy	913000
 羶	ucka	435000
 𦏄	ucka	0
+𫅑	ucka	0
+𫅝	ucka	0
 𦎐	uckb	0
 𦏆	uckb	0
 𦏏	uckk	0
@@ -82639,8 +85937,11 @@ encoder:
 𦎹	uckz	0
 𦍻	ucld	0
 精典	ucle	7140000
+𪥞	uclg	0
+𫅐	uclg	0
 盖	uclk	83600000
 𥃙	uclk	0
+𫅙	uclk	0
 𦏢	ucll	0
 㥽	uclo	3810
 羊肉	uclo	7640000
@@ -82665,6 +85966,7 @@ encoder:
 𦎶	ucmr	0
 精简	ucmt	9410000
 𤈩	ucmu	0
+𫅚	ucmx	0
 𦍥	ucmy	0
 䍴	ucmz	4210
 𢠅	ucnb	0
@@ -82703,6 +86005,7 @@ encoder:
 𦏂	ucqj	0
 羭	ucqk	159000
 𦎿	ucqq	0
+𫅛	ucqq	0
 羖	ucqx	93000
 羌	ucrd	3140000
 𦎆	ucrd	0
@@ -82711,6 +86014,7 @@ encoder:
 䍼	ucrk	3630
 𠒤	ucrk	0
 𦍴	ucrk	0
+𫕿	ucrk	0
 𦎈	ucrl	0
 𦎥	ucrn	0
 𦎪	ucro	0
@@ -82720,10 +86024,12 @@ encoder:
 𡗍	ucrr	0
 𦎄	ucrr	0
 𦎵	ucrr	0
+𪴴	ucrr	0
 羑	ucrs	114000
 羝	ucrs	197000
 𦍑	ucrs	0
 𦏇	ucrs	0
+𫅕	ucrs	0
 䍵	ucrx	3680
 𦍨	ucry	0
 𦫧	ucry	0
@@ -82744,6 +86050,7 @@ encoder:
 精良	ucsx	12100000
 羪	ucsx	29800
 養	ucsx	23300000
+𫑩	ucsy	0
 㕗	ucsz	4220
 精装	uctb	26100000
 𣁵	ucte	0
@@ -82751,6 +86058,7 @@ encoder:
 羡	uctr	8930000
 精度	uctv	19000000
 𩱋	ucua	0
+𫅓	ucuc	0
 䫞	ucug	3490
 情怀	ucug	16800000
 精美	ucug	64300000
@@ -82800,6 +86108,7 @@ encoder:
 羊群	ucxj	1880000
 𦎌	ucxj	0
 𩁥	ucxn	0
+𫅔	ucxo	0
 𢛏	ucxs	0
 𦍱	ucxs	0
 精灵	ucxu	68300000
@@ -82811,8 +86120,10 @@ encoder:
 𦍛	ucxz	0
 精子	ucya	6520000
 𢝛	ucyg	0
+𫅒	ucyh	0
 羓	ucyi	30700
 𦍔	ucyi	0
+𫅘	ucyj	0
 劷	ucym	120000
 慠	ucym	55500
 精力	ucym	37800000
@@ -82825,9 +86136,11 @@ encoder:
 𦎞	ucyz	0
 情绪	uczb	21800000
 𦎉	uczb	0
+𫅠	uczf	0
 精练	uczh	1020000
 羊绒	uczh	6550000
 羲	uczh	3340000
+𫅎	uczi	0
 精细	uczk	14900000
 姜	uczm	39300000
 𦎓	uczn	0
@@ -82848,10 +86161,12 @@ encoder:
 兽	udaj	86800000
 䶏	udan	3710
 𪗲	udax	0
+𪱗	udax	0
 𣍎	udbr	0
 𦍎	udck	0
 𠟃	uddk	0
 鷷	uddr	27800
+𫜄	uddr	0
 遵	uddw	32200000
 冁	udeh	35000
 𢧐	udeh	0
@@ -82860,6 +86175,7 @@ encoder:
 𡲞	udej	0
 兾	udeo	41500
 𫜺	uder	0
+𫛴	uder	0
 郸	udey	667000
 尊	udfd	30600000
 酋	udfd	1640000
@@ -82894,6 +86210,8 @@ encoder:
 𧔭	udii	0
 䤋	udja	3810
 𣚱	udjf	0
+𪞌	udjj	0
+𪫃	udjl	0
 兌	udjr	2700000
 兑	udjr	10500000
 𡈤	udjr	0
@@ -82914,6 +86232,7 @@ encoder:
 𤎯	udku	0
 𤎰	udku	0
 鄫	udky	53700
+𫜟	udkz	0
 𡘔	udlg	0
 曾	udlk	230000000
 𪔀	udmw	0
@@ -82933,6 +86252,7 @@ encoder:
 𤿫	udrx	0
 䒏	udry	3960
 𢛺	udry	0
+𪱗	udsx	0
 㤹	udvs	12600
 𧷭	udwa	0
 帰	udwl	6970000
@@ -82991,6 +86311,7 @@ encoder:
 糟蹋	uejk	8430000
 𢢩	uejm	0
 懽	uejn	83600
+𪬠	uejn	0
 𢚛	uejr	0
 𢡇	uejs	0
 懴	ueka	31500
@@ -83108,6 +86429,7 @@ encoder:
 𥸯	ufay	0
 𥹬	ufaz	0
 𥺒	ufaz	0
+𫃈	ufaz	0
 𥹩	ufbd	0
 𥻣	ufbd	0
 𥻵	ufbd	0
@@ -83126,6 +86448,7 @@ encoder:
 𥼹	ufbq	0
 粩	ufbr	196000
 𥹳	ufbr	0
+𫃊	ufbr	0
 𥺁	ufbs	0
 𥼯	ufbu	0
 𥼶	ufbu	0
@@ -83133,17 +86456,20 @@ encoder:
 𥺃	ufbw	0
 𥼳	ufbw	0
 𥺄	ufby	0
+𫃖	ufby	0
 𥹓	ufbz	0
 𥺭	ufbz	0
 𥺼	ufbz	0
 𥺅	ufcd	0
 𥹢	ufce	0
 粻	ufch	890000
+𫂶	ufci	0
 𥹯	ufck	0
 精	ufcl	0
 𥼃	ufcl	0
 𥼲	ufcm	0
 精	ufcq	220000000
+𫃂	ufcx	0
 𥺈	ufdp	0
 愽	ufds	122000
 慱	ufds	47800
@@ -83155,6 +86481,7 @@ encoder:
 籵	ufed	608000
 𥻔	ufee	0
 𥽒	ufef	0
+𫃌	ufeh	0
 䊀	ufej	5420
 𥺨	ufej	0
 米黄	ufek	1270000
@@ -83172,6 +86499,7 @@ encoder:
 𥸳	ufex	0
 糂	ufez	124000
 𥹑	ufez	0
+𫃒	ufez	0
 𥻸	uffa	0
 㦗	uffb	3780
 䊇	uffb	4010
@@ -83180,6 +86508,7 @@ encoder:
 䊜	uffd	3840
 糐	uffd	26600
 糰	uffd	2240000
+𫃎	ufff	0
 糯	uffg	3730000
 𥽢	uffg	0
 𥽨	uffg	0
@@ -83220,6 +86549,8 @@ encoder:
 𥽙	ufgs	0
 𥽉	ufgu	0
 𥹨	ufhb	0
+𫂽	ufhg	0
+𫂸	ufhl	0
 𥼘	ufho	0
 𥽘	ufhs	0
 𥺫	ufhu	0
@@ -83230,6 +86561,7 @@ encoder:
 𥻀	ufij	0
 糌	ufik	340000
 𥹴	ufik	0
+𫂻	ufik	0
 糈	ufiq	69500
 𥺾	ufiq	0
 𣀰	ufix	0
@@ -83238,15 +86570,19 @@ encoder:
 𥼐	ufjb	0
 𥺆	ufjc	0
 𥻯	ufjc	0
+𫃇	ufjc	0
 䊭	ufjd	3840
+𫂾	ufjd	0
 𥼾	ufjf	0
 尊贵	ufji	9940000
 糨	ufji	84100
+𫃅	ufjj	0
 糆	ufjk	23600
 𥻃	ufjk	0
 𥻅	ufjk	0
 𥼽	ufjk	0
 𥽯	ufjk	0
+𫃏	ufjk	0
 𥻥	ufjl	0
 𥻱	ufjl	0
 𥼱	ufjl	0
@@ -83279,6 +86615,7 @@ encoder:
 糎	ufkb	79600
 糧	ufkb	7500000
 𥻝	ufkb	0
+𫒄	ufkb	0
 𥺘	ufkc	0
 䊤	ufke	4060
 憛	ufke	70400
@@ -83290,6 +86627,7 @@ encoder:
 糢	ufkg	292000
 畨	ufki	311000
 粙	ufki	784000
+𫂺	ufki	0
 粬	ufkk	387000
 糟	ufkk	14200000
 𢥱	ufkk	0
@@ -83311,6 +86649,7 @@ encoder:
 𥼜	ufku	0
 𥼞	ufku	0
 𥽑	ufku	0
+𪹦	ufku	0
 𥻏	ufkw	0
 𥽜	ufkw	0
 𥹥	ufkx	0
@@ -83333,6 +86672,7 @@ encoder:
 籼	ufll	565000
 𢢻	ufll	0
 𥼇	ufll	0
+𪾚	ufll	0
 𥼂	ufln	0
 𥹘	uflo	0
 𥺎	uflo	0
@@ -83341,6 +86681,7 @@ encoder:
 粯	uflr	957000
 𥺺	ufls	0
 尊崇	uflw	1980000
+𫃓	uflw	0
 䊡	uflx	4090
 𩱸	ufly	0
 䊪	uflz	3990
@@ -83349,6 +86690,7 @@ encoder:
 𥻿	uflz	0
 𥼝	uflz	0
 𥺆	ufmb	0
+𫂶	ufmb	0
 𥽪	ufmc	0
 粁	ufme	497000
 𥺛	ufme	0
@@ -83380,6 +86722,7 @@ encoder:
 𥸼	ufms	0
 𥻾	ufms	0
 𥼕	ufms	0
+𫜏	ufmt	0
 䉿	ufmu	3890
 𥼄	ufmu	0
 𥼨	ufmu	0
@@ -83416,11 +86759,13 @@ encoder:
 𩏶	ufnu	0
 𩏷	ufnu	0
 𩏸	ufnu	0
+𫃗	ufnu	0
 𥸺	ufnx	0
 𥻬	ufnx	0
 𥻎	ufob	0
 𥸪	ufod	0
 粹	ufoe	8720000
+𫂷	ufoe	0
 𥻹	ufof	0
 𥼪	ufok	0
 𥺌	ufom	0
@@ -83438,20 +86783,24 @@ encoder:
 糭	ufor	33500
 𥺙	ufor	0
 𥽁	ufor	0
+𫃘	ufou	0
 𥹕	ufow	0
 𥼸	ufow	0
 粉	ufoy	142000000
 𥺯	ufoy	0
 𢛒	ufoz	0
+𪬷	ufpb	0
 䉼	ufpd	4030
 慚	ufpd	336000
 𥹽	ufpd	0
+𫃋	ufpe	0
 䊩	ufpk	3800
 䊝	ufpw	3670
 𢣥	ufpw	0
 粄	ufpx	350000
 𥺲	ufpx	0
 粰	ufpy	172000
+𫃃	ufpy	0
 粣	ufqa	570000
 𥸻	ufqa	0
 籶	ufqd	21600
@@ -83471,6 +86820,7 @@ encoder:
 𥽴	ufrj	0
 糣	ufrk	18700
 𥺢	ufrk	0
+𫂼	ufrk	0
 懒	ufrl	63800000
 懶	ufrl	9730000
 𥼓	ufrl	0
@@ -83529,6 +86879,7 @@ encoder:
 𥹎	ufub	0
 𥹿	ufub	0
 𥽞	ufub	0
+𫂷	ufue	0
 憟	ufuf	238000
 𥹫	ufuf	0
 懒惰	ufug	1560000
@@ -83546,8 +86897,11 @@ encoder:
 𥽎	ufux	0
 䊎	ufuy	3800
 𥺀	ufuy	0
+𫃔	ufuy	0
 𥺇	ufuz	0
 米酒	ufvf	4100000
+𫃁	ufvs	0
+𪫟	ufvv	0
 懒汉	ufvx	764000
 米汤	ufvy	517000
 𥹍	ufwa	0
@@ -83557,6 +86911,7 @@ encoder:
 糘	ufwg	56200
 糄	ufwl	20300
 𥺥	ufwl	0
+𫃓	ufwl	0
 粐	ufwm	191000
 𥹅	ufwm	0
 𥹈	ufwr	0
@@ -83566,11 +86921,13 @@ encoder:
 𥻮	ufws	0
 𥺑	ufwx	0
 𥹸	ufwy	0
+𫃑	ufwy	0
 憓	ufwz	105000
 𢘻	ufwz	0
 𢝴	ufwz	0
 𥹀	ufwz	0
 𥻨	ufwz	0
+𫃀	ufwz	0
 䊕	ufxb	3650
 𥹧	ufxb	0
 粈	ufxe	1120000
@@ -83585,6 +86942,7 @@ encoder:
 糠	ufxk	3540000
 𥼴	ufxk	0
 𥻡	ufxl	0
+𫃍	ufxl	0
 䊊	ufxm	4950
 糇	ufxm	181000
 𥺶	ufxm	0
@@ -83599,17 +86957,21 @@ encoder:
 𥽆	ufxu	0
 𥽣	ufxu	0
 𥺴	ufxw	0
+𫃐	ufxw	0
 𥽊	ufxy	0
+𫃖	ufxy	0
 籽	ufya	12100000
 𩱸	ufya	0
 㐘	ufyd	4510
 籸	ufye	35800
 𦧾	ufye	0
+𪪷	ufye	0
 𡙢	ufyg	0
 𩔫	ufyg	0
 粌	ufyi	565000
 粑	ufyi	1370000
 𧏟	ufyi	0
+𫂴	ufyi	0
 𥹙	ufyj	0
 𥺸	ufyk	0
 𥺬	ufyl	0
@@ -83636,6 +86998,7 @@ encoder:
 𥼁	ufze	0
 𥻈	ufzf	0
 𥽗	ufzf	0
+𫏻	ufzf	0
 纇	ufzg	256000
 颣	ufzg	34000
 𥻺	ufzg	0
@@ -83660,6 +87023,9 @@ encoder:
 𥼗	ufzt	0
 𥺇	ufzu	0
 𥼮	ufzu	0
+𫃄	ufzw	0
+𫃕	ufzw	0
+𫐷	ufzw	0
 𥸴	ufzy	0
 𥹱	ufzy	0
 糍	ufzz	620000
@@ -83672,6 +87038,7 @@ encoder:
 㥓	ugaj	4060
 美丽	ugal	146000000
 𢛄	ugbb	0
+𪫦	ugbi	0
 怀来	ugbk	799000
 㦋	ugbm	4030
 惰	ugbq	2200000
@@ -83783,6 +87150,7 @@ encoder:
 美观	ugxl	17000000
 怀柔	ugxx	5700000
 怀孕	ugym	56200000
+𪫡	ugym	0
 𦑑	ugyy	0
 恞	ugyz	37700
 关台	ugzj	33000
@@ -83826,11 +87194,13 @@ encoder:
 炼钢	uhpl	1900000
 炼铁	uhpm	1080000
 憯	uhrk	77200
+𪫨	uhrs	0
 惬意	uhsk	6440000
 烧烤	uhub	9460000
 烧瓶	uhue	270000
 惭愧	uhun	8220000
 烧火	uhuo	704000
+𪫯	uhuo	0
 炼油	uhvk	7550000
 慳	uhxb	1140000
 𢤞	uhxl	0
@@ -83844,6 +87214,7 @@ encoder:
 懅	uigq	315000
 𢟧	uijo	0
 𢛈	uijw	0
+𪬍	uijw	0
 𢤯	uika	0
 悼	uike	3020000
 烛光	uikg	4100000
@@ -83860,6 +87231,7 @@ encoder:
 𢟶	uios	0
 粘膜	uiqe	4740000
 𢟡	uirl	0
+𪬰	uirl	0
 粘剂	uisn	305000
 悼词	uisy	551000
 丫头	uitg	17700000
@@ -83867,6 +87239,8 @@ encoder:
 𢘷	uivv	0
 𢥞	uivv	0
 粘连	uiwh	1730000
+𪬍	uizt	0
+𪬍	uizv	0
 悮	ujag	85000
 总政	ujai	677000
 愦	ujal	316000
@@ -83904,6 +87278,7 @@ encoder:
 烟叶	ujje	1960000
 懆	ujjf	429000
 𢠮	ujjk	0
+𪬱	ujjl	0
 总师	ujka	163000
 总量	ujka	20400000
 烟尘	ujkb	2710000
@@ -84005,6 +87380,7 @@ encoder:
 𢤗	ukjl	0
 𢢪	ukju	0
 𢢳	ukkb	0
+𪬨	ukkb	0
 愰	ukkg	1190000
 憹	ukkg	52800
 单显	ukkk	67900
@@ -84016,6 +87392,7 @@ encoder:
 𢠵	uklm	0
 𢢔	ukls	0
 慢	uklx	90600000
+𪬢	ukly	0
 㥥	uklz	4870
 单县	uklz	536000
 惺	ukmc	1430000
@@ -84024,6 +87401,7 @@ encoder:
 单程	ukmj	2070000
 单利	ukmk	154000
 𢜫	ukml	0
+𪬌	ukml	0
 𢚕	ukms	0
 单传	uknb	348000
 单身	uknc	41200000
@@ -84086,6 +87464,7 @@ encoder:
 普安	ukwz	392000
 悭	ukxb	528000
 单骑	ukxg	2960000
+𪬡	ukxl	0
 炒买	ukxt	157000
 单子	ukya	3380000
 普及	ukym	46800000
@@ -84129,6 +87508,7 @@ encoder:
 𢚭	ulkv	0
 𢢥	ulkw	0
 懼	ulln	2100000
+𪭈	ulln	0
 𢠼	ullo	0
 着眼	ullx	13500000
 盖县	ullz	67400
@@ -84184,6 +87564,7 @@ encoder:
 曾经	ulzx	124000000
 𢤝	umaj	0
 炸死	umar	2190000
+𪬀	umaz	0
 𢡩	umbd	0
 炸坝	umbl	21700
 𢣤	umbu	0
@@ -84209,6 +87590,7 @@ encoder:
 憍	umjl	201000
 慥	umjw	148000
 性别	umjy	145000000
+𪬏	umka	0
 𢝆	umkb	0
 悧	umkd	675000
 愎	umkr	441000
@@ -84223,6 +87605,7 @@ encoder:
 炸伤	umnm	542000
 性命	umoa	10900000
 怢	umod	572000
+𪬻	umoh	0
 性质	umpe	72500000
 性爱	umpw	76300000
 拳脚	umqb	4440000
@@ -84231,14 +87614,17 @@ encoder:
 性腺	umqn	939000
 炸鱼	umra	306000
 𢝤	umra	0
+𪬗	umrb	0
 𢙝	umrd	0
 㦧	umrk	3900
 㦫	umrl	3710
 慯	umro	262000
 性急	umrx	1720000
+𪬣	umsj	0
 性状	umtg	2940000
 拳头	umtg	11800000
 𢟊	umtr	0
+𪬁	umtr	0
 性情	umuc	11200000
 忏悔	umum	4800000
 愀	umuo	806000
@@ -84260,6 +87646,7 @@ encoder:
 养殖	unar	41800000
 熄灭	unau	5240000
 惟一	unav	14300000
+𪬀	unaz	0
 𢝘	unbi	0
 惟恐	unbq	2010000
 惶恐	unbq	4040000
@@ -84375,6 +87762,7 @@ encoder:
 煶	uoai	341000
 𤌗	uoai	0
 𤐔	uoai	0
+𪹈	uoai	0
 恰	uoaj	17000000
 炣	uoaj	33200
 烚	uoaj	143000
@@ -84383,10 +87771,13 @@ encoder:
 𤏃	uoaj	0
 𤏉	uoaj	0
 𤏧	uoaj	0
+𪸴	uoaj	0
+𪹽	uoaj	0
 𤉴	uoak	0
 㷍	uoal	4150
 惀	uoal	489000
 𤏳	uoal	0
+𪺊	uoal	0
 𤊪	uoao	0
 𤇊	uoau	0
 𤏘	uoaw	0
@@ -84411,10 +87802,12 @@ encoder:
 灴	uobi	398000
 𢘐	uobi	0
 𤈄	uobj	0
+𪸼	uobj	0
 㶹	uobk	4650
 烜	uobk	304000
 煊	uobk	902000
 𤇋	uobk	0
+𪸙	uobk	0
 熕	uobl	37900
 𤉑	uobl	0
 𤒠	uobl	0
@@ -84428,8 +87821,12 @@ encoder:
 𤊳	uobq	0
 𤌃	uobq	0
 𤐢	uobq	0
+𪹆	uobq	0
+𪹴	uobq	0
 烷	uobr	8150000
+𪸑	uobr	0
 𤆧	uobs	0
+𪸱	uobs	0
 㷵	uobu	4500
 燡	uobu	28600
 燵	uobu	46100
@@ -84438,8 +87835,11 @@ encoder:
 𤒋	uobu	0
 𤓂	uobu	0
 𤓦	uobu	0
+𪹝	uobu	0
 𤈷	uobv	0
+𪫺	uobv	0
 𤌷	uobw	0
+𪹪	uobw	0
 𤊫	uobx	0
 㷲	uoby	3830
 炜	uoby	5590000
@@ -84452,10 +87852,13 @@ encoder:
 𤉁	uobz	0
 𤑼	uobz	0
 𤒫	uobz	0
+𪸒	uobz	0
+𪸘	uobz	0
 㷯	uocb	4380
 𤊡	uocb	0
 㸎	uocc	5010
 𤆜	uocd	0
+𪸥	uoce	0
 𤊴	uocg	0
 㷃	uoch	3820
 𤊞	uoch	0
@@ -84463,6 +87866,7 @@ encoder:
 𤈞	uock	0
 𤑈	uocm	0
 煅	uocq	1240000
+𪸛	uocs	0
 𤌬	uocu	0
 𤌰	uocu	0
 熢	uocw	35500
@@ -84503,6 +87907,7 @@ encoder:
 焟	uoek	34100
 𤋙	uoek	0
 𤍬	uoek	0
+𪹒	uoek	0
 煵	uoel	35300
 燌	uoel	23100
 𤊧	uoel	0
@@ -84515,16 +87920,19 @@ encoder:
 𤈝	uoeo	0
 𤌱	uoeo	0
 𤒩	uoeo	0
+𪸸	uoeo	0
 燍	uoep	27000
 火警	uoer	1510000
 爙	uoer	23000
 𤓢	uoer	0
+𪹷	uoer	0
 𤊊	uoes	0
 㷻	uoeu	4190
 熫	uoeu	37500
 𤌰	uoeu	0
 𤎫	uoeu	0
 𢻑	uoex	0
+𪯅	uoex	0
 火药	uoez	2140000
 煁	uoez	333000
 熎	uoez	24300
@@ -84562,6 +87970,7 @@ encoder:
 㸌	uofn	5250
 火枪	uofo	696000
 𤍖	uofp	0
+𪹡	uofp	0
 𢟌	uofq	0
 𤐊	uofr	0
 炢	uofs	34300
@@ -84571,6 +87980,7 @@ encoder:
 𡗩	uogd	0
 𤍇	uogd	0
 𤒛	uogd	0
+𪹅	uogd	0
 𤉻	uoge	0
 𤊠	uoge	0
 𤎋	uoge	0
@@ -84584,6 +87994,7 @@ encoder:
 𤌕	uogj	0
 𤎐	uogj	0
 𨆜	uogj	0
+𪸚	uogj	0
 𤒳	uogk	0
 悕	uogl	693000
 烯	uogl	18900000
@@ -84601,11 +88012,13 @@ encoder:
 粉碎	uogs	12000000
 𤋀	uogs	0
 𤓊	uogs	0
+𪺉	uogs	0
 烣	uogu	49700
 𤌢	uogu	0
 𤏵	uogu	0
 𤒁	uogu	0
 𤒺	uogu	0
+𪹇	uogu	0
 燧	uogw	811000
 煖	uogx	636000
 𤇉	uogy	0
@@ -84621,12 +88034,16 @@ encoder:
 𤈪	uohe	0
 烧	uohg	64500000
 𤇽	uohg	0
+𪸶	uohh	0
 𤆹	uohi	0
+𪸵	uohi	0
+𪸬	uohj	0
 𤐒	uohl	0
 𤇦	uohm	0
 𤋖	uohm	0
 炬	uohx	3970000
 𤆻	uohy	0
+𪸤	uohy	0
 炖	uohz	6370000
 爞	uoia	150000
 益虫	uoia	380000
@@ -84635,11 +88052,15 @@ encoder:
 𤋛	uoig	0
 爞	uoii	150000
 𤎠	uoii	0
+𪸔	uoii	0
 炶	uoij	422000
 煔	uoij	32000
 㷔	uoik	3980
 焔	uoik	1050000
+𪹣	uoik	0
 𤋺	uoil	0
+𪹋	uoil	0
+𪹳	uoil	0
 𤑉	uoio	0
 火柴	uoir	8480000
 𤍲	uoiw	0
@@ -84652,6 +88073,7 @@ encoder:
 𤎍	uoja	0
 燷	uojb	21800
 𤎌	uojb	0
+𪺃	uojb	0
 𤒌	uojc	0
 烟	uojd	96800000
 燖	uojd	39100
@@ -84695,6 +88117,7 @@ encoder:
 𤓀	uojl	0
 𤓝	uojl	0
 𪛑	uojl	0
+𪸧	uojl	0
 煒	uojm	1710000
 燣	uojm	25200
 𤒢	uojm	0
@@ -84702,6 +88125,7 @@ encoder:
 炽	uojo	4450000
 𤈆	uojo	0
 𤌜	uojo	0
+𪸜	uojo	0
 焆	uojq	41400
 煳	uojq	113000
 𤍦	uojq	0
@@ -84718,6 +88142,7 @@ encoder:
 𤏈	uoju	0
 𤐆	uoju	0
 𧺄	uoju	0
+𪹐	uoju	0
 煾	uojw	37300
 𤐉	uojw	0
 𤇆	uojx	0
@@ -84729,6 +88154,7 @@ encoder:
 𨚊	uojy	0
 𨞴	uojy	0
 𨟏	uojy	0
+𪸝	uojy	0
 𤉈	uojz	0
 㷥	uoka	4470
 懺	uoka	1420000
@@ -84765,6 +88191,7 @@ encoder:
 𤏏	uokg	0
 𤒚	uokg	0
 𩖋	uokg	0
+𪸮	uokg	0
 煨	uokh	1770000
 熾	uokh	1750000
 炠	uoki	29000
@@ -84778,6 +88205,7 @@ encoder:
 𤐀	uokk	0
 𤒬	uokk	0
 𤓗	uokk	0
+𪹓	uokk	0
 煴	uokl	56900
 爐	uokl	6660000
 𤉆	uokl	0
@@ -84789,6 +88217,7 @@ encoder:
 𤎤	uokm	0
 熦	uokn	25800
 熿	uoko	29500
+𪸫	uoko	0
 焇	uokq	25800
 焨	uokq	20100
 煟	uokq	701000
@@ -84800,6 +88229,7 @@ encoder:
 𤋟	uokr	0
 𤐚	uokr	0
 煜	uoks	5230000
+𪸻	uoks	0
 㸁	uoku	6680
 𤍅	uoku	0
 𤐄	uoku	0
@@ -84836,6 +88266,7 @@ encoder:
 焹	uold	50100
 𤆳	uold	0
 燺	uolf	24800
+𪴍	uolf	0
 炴	uolg	2070000
 焕	uolg	5320000
 煐	uolg	445000
@@ -84852,6 +88283,7 @@ encoder:
 灿	uoll	6520000
 爦	uoll	24800
 𤋫	uoll	0
+𪺁	uoll	0
 𤏮	uolm	0
 𤏰	uolm	0
 熣	uoln	37300
@@ -84865,13 +88297,17 @@ encoder:
 𤌭	uolo	0
 𤑍	uolo	0
 𤑣	uolo	0
+𪸭	uolo	0
+𪸹	uolp	0
 䙺	uolr	3670
 𤋬	uolr	0
 𤓇	uolr	0
+𪹢	uolr	0
 𤍉	uols	0
 𤓧	uolt	0
 熥	uolw	41400
 𤐾	uolw	0
+𪺅	uolw	0
 熳	uolx	198000
 𤈬	uolx	0
 㷒	uolz	3800
@@ -84891,6 +88327,7 @@ encoder:
 秌	uomf	32200
 𤌴	uomf	0
 𤏆	uomf	0
+𪸨	uomf	0
 𤌡	uomg	0
 𤒟	uomg	0
 𩕶	uomg	0
@@ -84919,6 +88356,7 @@ encoder:
 𤊿	uomn	0
 炇	uomo	20200
 𣃌	uomp	0
+𪸎	uomq	0
 烍	uomr	27600
 熪	uomr	28300
 𤆣	uoms	0
@@ -84939,6 +88377,8 @@ encoder:
 𤑓	uomy	0
 𤑲	uomy	0
 𨞧	uomy	0
+𪸏	uomy	0
+𪸕	uomy	0
 烸	uomz	74500
 𤉦	uomz	0
 𤍃	uomz	0
@@ -84954,11 +88394,15 @@ encoder:
 𤆑	uond	0
 焷	uone	35300
 烌	uonf	25300
+𪹯	uonf	0
+𪸽	uonh	0
 火候	uoni	2740000
 焳	uoni	21000
 𤈍	uonj	0
 𤌋	uonj	0
 𤍀	uonj	0
+𪸰	uonj	0
+𪹔	uonj	0
 㷧	uonk	4390
 𤇢	uonk	0
 𤏚	uonn	0
@@ -84978,6 +88422,7 @@ encoder:
 燋	uonu	78600
 爑	uonu	23100
 熄	uonw	7790000
+𫑔	uonw	0
 𤐰	uonx	0
 恰似	uonz	2270000
 粉盒	uooa	709000
@@ -84989,6 +88434,7 @@ encoder:
 𤑥	uooc	0
 焠	uooe	111000
 𢙋	uooe	0
+𪺀	uooe	0
 𤉾	uoof	0
 㷜	uoog	3800
 𤋋	uoog	0
@@ -84998,6 +88444,7 @@ encoder:
 𢠰	uooi	0
 焀	uooj	32300
 熔	uooj	7380000
+𪫹	uooj	0
 爆	uook	108000000
 𢡽	uook	0
 𤎳	uook	0
@@ -85011,6 +88458,7 @@ encoder:
 𧶦	uool	0
 𤐲	uoom	0
 𤒦	uoom	0
+𪹘	uoom	0
 炌	uoon	26800
 𤊍	uoon	0
 𤋽	uoon	0
@@ -85033,15 +88481,18 @@ encoder:
 𤆢	uoor	0
 𤊥	uoor	0
 𤎑	uoor	0
+𪺈	uoor	0
 㤊	uoos	5390
 𤐐	uoos	0
 𤉪	uoot	0
 𤏟	uoou	0
 𤒾	uoou	0
+𪹼	uoou	0
 炩	uoow	577000
 燯	uoow	27000
 𢝦	uoow	0
 𤋶	uoow	0
+𪹄	uoow	0
 炝	uooy	594000
 𤆶	uooy	0
 𤊈	uooy	0
@@ -85056,6 +88507,7 @@ encoder:
 熖	uopn	34000
 𤓁	uopn	0
 𤉒	uopq	0
+𪹙	uopq	0
 焮	uopr	79000
 𤋻	uopr	0
 炿	uops	28100
@@ -85065,17 +88517,22 @@ encoder:
 𢥒	uopw	0
 𤎕	uopw	0
 炍	uopx	51300
+𪸾	uopx	0
 烐	uopy	26600
 烰	uopy	26100
+𪸯	uopz	0
 𤇒	uoqa	0
 𤇛	uoqa	0
 𤊚	uoqb	0
 𤎞	uoqb	0
 𤆘	uoqd	0
+𪹻	uoqf	0
 煈	uoqi	177000
 㷙	uoqk	3630
 愉	uoqk	5710000
+𪹊	uoqk	0
 𤐟	uoql	0
+𪹲	uoqm	0
 𤑍	uoqo	0
 焩	uoqq	17600
 𤎒	uoqs	0
@@ -85084,6 +88541,9 @@ encoder:
 𤆥	uorb	0
 𤎆	uorb	0
 𤏯	uorb	0
+𪸷	uorb	0
+𪹥	uorb	0
+𪹾	uorb	0
 㷨	uorc	6460
 烽	uorc	5800000
 熢	uorc	35500
@@ -85096,6 +88556,7 @@ encoder:
 燭	uori	3690000
 爥	uori	28500
 益处	uori	4520000
+𪸟	uori	0
 烙	uorj	5020000
 㶷	uork	4190
 烁	uork	3440000
@@ -85104,6 +88565,7 @@ encoder:
 𤈎	uork	0
 𤈘	uork	0
 𤑟	uork	0
+𪸞	uork	0
 㸊	uorl	5330
 𤓎	uorl	0
 𧣌	uorl	0
@@ -85124,6 +88586,7 @@ encoder:
 煬	uoro	175000
 𤆞	uoro	0
 爩	uorp	29200
+𪹎	uorp	0
 𤊷	uorq	0
 㶴	uorr	5190
 焜	uorr	1250000
@@ -85154,6 +88617,7 @@ encoder:
 焥	uory	23200
 𤊵	uory	0
 𦫟	uory	0
+𪸺	uory	0
 䲴	uorz	6360
 煼	uorz	94000
 熓	uorz	21800
@@ -85168,17 +88632,20 @@ encoder:
 焙	uosj	3680000
 䪯	uosk	3290
 𤋾	uosk	0
+𪸠	uosk	0
 𤐎	uosl	0
 𤐛	uosl	0
 燩	uosm	26000
 𢰣	uosm	0
 𤊦	uosm	0
+𪹰	uosn	0
 炆	uoso	887000
 熐	uoso	32100
 𤊋	uoso	0
 烿	uosp	26900
 炕	uosq	3300000
 𤒀	uosq	0
+𪹤	uosq	0
 褮	uosr	23100
 𧚵	uosr	0
 烬	uost	810000
@@ -85196,6 +88663,7 @@ encoder:
 炓	uote	36600
 𣂈	uote	0
 𤉜	uotf	0
+𪹜	uotf	0
 爌	uotg	102000
 粉状	uotg	1790000
 𤆓	uotg	0
@@ -85213,6 +88681,7 @@ encoder:
 𤑆	uoub	0
 𤒲	uoub	0
 𥚡	uoub	0
+𪺌	uoub	0
 烊	uouc	325000
 羚羊	uouc	3930000
 怜惜	uoue	3070000
@@ -85233,6 +88702,9 @@ encoder:
 𤏢	uoug	0
 𤓔	uoug	0
 𩖖	uoug	0
+𪥢	uoug	0
+𪹏	uoug	0
+𪹺	uoug	0
 㸍	uouh	6340
 火炬	uouh	7010000
 火烧	uouh	8250000
@@ -85246,6 +88718,7 @@ encoder:
 覢	uoul	25300
 𤏲	uoul	0
 𤑦	uoul	0
+𪹧	uoul	0
 㲜	uoum	4090
 㲭	uoum	3760
 㷣	uoum	4160
@@ -85256,6 +88729,7 @@ encoder:
 炎	uouo	78100000
 炏	uouo	60800
 𨧿	uoup	0
+𪹫	uoup	0
 飊	uouq	62400
 𤈺	uouq	0
 𤎒	uouq	0
@@ -85323,6 +88797,7 @@ encoder:
 𤌫	uowg	0
 𤐶	uowg	0
 𤐽	uowh	0
+𪸩	uowh	0
 螢	uowi	26300000
 㽦	uowk	8190
 滎	uowk	439000
@@ -85344,6 +88819,7 @@ encoder:
 𤯵	uowm	0
 𤌍	uown	0
 𤏥	uown	0
+𪸖	uowo	0
 鎣	uowp	78100
 𤬐	uowp	0
 焭	uowq	26100
@@ -85361,6 +88837,8 @@ encoder:
 𤋩	uows	0
 𤍩	uows	0
 𤓋	uows	0
+𪹚	uows	0
+𪹞	uows	0
 火灾	uowu	8830000
 熒	uowu	936000
 𤐥	uowu	0
@@ -85404,6 +88882,8 @@ encoder:
 㶦	uoxi	4230
 𢜢	uoxi	0
 𤊂	uoxi	0
+𪸢	uoxi	0
+𪹵	uoxi	0
 㤷	uoxj	7710
 愴	uoxj	203000
 焐	uoxj	908000
@@ -85419,9 +88899,12 @@ encoder:
 煝	uoxl	63700
 熥	uoxl	41400
 粉刷	uoxl	1960000
+𪹨	uoxl	0
 𤈦	uoxm	0
+𪹍	uoxm	0
 熽	uoxn	28600
 𤑳	uoxn	0
+𪹠	uoxn	0
 焿	uoxo	109000
 熌	uoxo	57000
 爘	uoxo	23400
@@ -85447,6 +88930,8 @@ encoder:
 㸅	uoxy	5450
 𤍎	uoxy	0
 𨛂	uoxy	0
+𪺄	uoxy	0
+𪺆	uoxy	0
 㤋	uoyd	4000
 灱	uoyd	545000
 㷀	uoye	4690
@@ -85460,17 +88945,21 @@ encoder:
 炤	uoyj	338000
 焗	uoyj	1880000
 𤐵	uoyj	0
+𪸲	uoyj	0
+𪸳	uoyj	0
 熘	uoyk	448000
 益阳	uoyk	5060000
 燲	uoyl	22100
 𢞂	uoyl	0
 𢠈	uoyl	0
+𪹁	uoyl	0
 㷪	uoym	4540
 燉	uoym	1730000
 𠠽	uoym	0
 𤆈	uoym	0
 𤍗	uoym	0
 𤐃	uoym	0
+𪹖	uoym	0
 炥	uoyn	24400
 熠	uoyn	945000
 燿	uoyn	913000
@@ -85487,6 +88976,7 @@ encoder:
 𤬬	uoys	0
 𤭰	uoys	0
 𤮶	uoys	0
+𪸐	uoys	0
 爋	uoyu	24500
 𤎶	uoyu	0
 𤏂	uoyu	0
@@ -85509,8 +88999,11 @@ encoder:
 𤍪	uoyy	0
 𤒻	uoyy	0
 𦒪	uoyy	0
+𪸪	uoyy	0
+𪹹	uoyy	0
 𤆺	uoyz	0
 𤏦	uoyz	0
+𪸡	uoyz	0
 粉红	uozb	24500000
 𡓧	uozb	0
 煠	uozf	102000
@@ -85538,6 +89031,8 @@ encoder:
 𤇱	uozl	0
 𤎽	uozl	0
 𤐩	uozl	0
+𪹟	uozl	0
+𪺇	uozl	0
 㶼	uozm	7200
 𤓩	uozm	0
 𤐣	uozn	0
@@ -85545,8 +89040,10 @@ encoder:
 𤓓	uozn	0
 烗	uozo	24100
 焴	uozq	31700
+𪹛	uozq	0
 恱	uozr	36600
 𢚔	uozr	0
+𪸗	uozr	0
 忪	uozs	469000
 𤎄	uozu	0
 𤐴	uozu	0
@@ -85741,6 +89238,7 @@ encoder:
 焕发	urzv	5550000
 忙于	usad	9760000
 𢤈	usae	0
+𪬸	usax	0
 惊喜	usbj	35100000
 𢦅	usbl	0
 𢥃	usbm	0
@@ -85758,6 +89256,7 @@ encoder:
 粮棉	usfn	434000
 惊奇	usga	11800000
 𢟰	usgq	0
+𪬜	usgs	0
 惊厥	usgu	1520000
 忙碌	usgx	20600000
 𢡠	ushk	0
@@ -85766,6 +89265,7 @@ encoder:
 惊吓	usja	7860000
 懔	usjb	605000
 𢥢	usjc	0
+𪬹	usji	0
 㥫	usjk	4080
 惊	usjk	131000000
 𢞟	usjl	0
@@ -85922,12 +89422,16 @@ encoder:
 㦈	uulk	3930
 憎	uulk	4130000
 𢣂	uumh	0
+𪬾	uumy	0
 善待	uuob	6130000
+𪬘	uuol	0
+𪭆	uuor	0
 善后	uupa	4560000
 憐	uurm	1720000
 𢣶	uurm	0
 善意	uusk	11200000
 𢟣	uusk	0
+𪭇	uuss	0
 善良	uusx	28800000
 懩	uusx	41800
 炎症	uuta	7880000
@@ -85944,6 +89448,7 @@ encoder:
 𢣙	uuwc	0
 𢤨	uuwi	0
 憦	uuwy	26700
+𪬝	uuwz	0
 慊	uuxk	327000
 𢛗	uuym	0
 𢤻	uuym	0
@@ -85956,6 +89461,7 @@ encoder:
 为辅	uvhf	2830000
 为止	uvii	80900000
 为此	uvir	43700000
+𪬙	uvjq	0
 为题	uvka	2400000
 𢟗	uvkb	0
 为时	uvkd	3970000
@@ -85989,6 +89495,7 @@ encoder:
 悾	uwbi	643000
 悰	uwbk	513000
 愃	uwbk	86600
+𪫻	uwbr	0
 𢥼	uwbw	0
 煽动	uwbz	18500000
 𢞐	uwcj	0
@@ -86002,11 +89509,14 @@ encoder:
 恽	uwhe	701000
 熔点	uwij	1320000
 𢠠	uwix	0
+𪭄	uwjg	0
 𢠲	uwjk	0
 𢞏	uwjn	0
 𢣐	uwkl	0
+𪬦	uwko	0
 𢠭	uwkx	0
 懧	uwla	45600
+𪬃	uwlc	0
 惼	uwld	27000
 𢣄	uwlj	0
 㦥	uwlw	26200
@@ -86023,6 +89533,8 @@ encoder:
 㤾	uwof	4530
 愹	uwoj	19200
 𢢈	uwot	0
+𪬺	uwpk	0
+𪬚	uwpo	0
 炉膛	uwqk	609000
 𢣼	uwrb	0
 㦀	uwrc	5110
@@ -86060,7 +89572,9 @@ encoder:
 𢟔	uwxo	0
 炉子	uwya	1790000
 𢛙	uwyz	0
+𪫲	uwzm	0
 熔断	uwzu	1100000
+𪬑	uxae	0
 𢜽	uxag	0
 𢘶	uxbd	0
 𢠢	uxbd	0
@@ -86111,7 +89625,9 @@ encoder:
 快件	uxnm	2650000
 㦦	uxnr	4450
 𢘧	uxod	0
+𪬖	uxod	0
 𢚌	uxoo	0
+𪬭	uxpx	0
 快艇	uxpy	2180000
 㥡	uxrf	4250
 快乐	uxrk	224000000
@@ -86193,6 +89709,7 @@ encoder:
 弟子	uyya	18800000
 𢖭	uyyb	0
 剃刀	uyyd	1250000
+𪬞	uyyi	0
 慴	uyyn	103000
 𢣷	uyyn	0
 愶	uyyq	679000
@@ -86242,6 +89759,7 @@ encoder:
 惨重	uzmk	4580000
 慈利	uzmk	340000
 数年	uzmm	20400000
+𪬶	uzmz	0
 惯例	uzna	9960000
 数值	uzne	12900000
 惨白	uznk	608000
@@ -86262,6 +89780,7 @@ encoder:
 塑胶	uzqs	16400000
 数月	uzqv	4870000
 惯犯	uzqy	507000
+𪫤	uzrd	0
 𢟒	uzrr	0
 数论	uzso	455000
 惨状	uztg	3750000
@@ -86318,18 +89837,22 @@ encoder:
 𤃈	vaer	0
 举世	vaev	5470000
 河槽	vafe	113000
+𪷩	vaff	0
 举杯	vafg	2920000
 河西	vafj	13700000
 河套	vagc	774000
 𣵞	vagj	0
 兴奋	vagk	48500000
 𣸸	vagk	0
+𪶍	vagm	0
 㴿	vago	5710
 𣲘	vagr	0
 添	vagu	42700000
 𣵍	vagx	0
+𪷎	vahl	0
 兴致	vahm	15500000
 兴盛	vahy	3080000
+𪵩	vaid	0
 举止	vaii	7030000
 泟	vaii	103000
 河口	vaja	5810000
@@ -86345,8 +89868,10 @@ encoder:
 𣽐	vakl	0
 浭	vako	63200
 河畔	vaku	11000000
+𪶭	vaku	0
 汗水	vakv	10900000
 河水	vakv	7240000
+𪶮	vakw	0
 举贤	vakx	278000
 𣶣	vakz	0
 𣶩	vakz	0
@@ -86432,6 +89957,7 @@ encoder:
 澆	vbbg	1970000
 𣼤	vbbg	0
 江城	vbbh	3790000
+𪳼	vbbk	0
 𤃋	vbbl	0
 法规	vbbo	449000000
 𣽟	vbbr	0
@@ -86477,6 +90003,7 @@ encoder:
 涞	vbkv	1130000
 涞水	vbkv	278000
 潜水	vbkv	22200000
+𪶚	vbkw	0
 𣷻	vbla	0
 㴂	vblb	5660
 𣷻	vblb	0
@@ -86522,9 +90049,11 @@ encoder:
 𤄁	vbqi	0
 㳩	vbqs	4290
 𣼳	vbqs	0
+𪷴	vbqu	0
 𤃲	vbqz	0
 沅	vbrd	3600000
 法条	vbrf	721000
+𪶏	vbri	0
 𣹡	vbrk	0
 𣳩	vbro	0
 㳣	vbrr	4720
@@ -86587,6 +90116,7 @@ encoder:
 法案	vbwz	8230000
 潜心	vbwz	3480000
 𣽏	vbwz	0
+𪫚	vbxb	0
 浯	vbxj	774000
 𤃀	vbxk	0
 𣳏	vbxs	0
@@ -86594,7 +90124,9 @@ encoder:
 涍	vbya	41400
 江陵	vbyb	2090000
 沅陵	vbyb	523000
+𪵸	vbyi	0
 𤀺	vbyj	0
+𪷪	vbyl	0
 江孜	vbym	400000
 漖	vbym	195000
 潜力	vbym	37100000
@@ -86676,6 +90208,8 @@ encoder:
 清盘	vcpl	409000
 淸	vcqa	1360000
 㵾	vcql	4070
+𪷍	vcql	0
+𪸃	vcqm	0
 清脆	vcqr	7050000
 𣷴	vcrh	0
 𣿛	vcrj	0
@@ -86719,6 +90253,7 @@ encoder:
 滶	vcym	38700
 清除	vcyo	296000000
 潔	vcyz	14400000
+𪶝	vczj	0
 清剿	vczk	721000
 灩	vczl	609000
 𡝝	vczm	0
@@ -86749,6 +90284,7 @@ encoder:
 㳺	vdmy	5020
 州	vdnd	99300000
 举	vdob	75100000
+𪿝	vdog	0
 挙	vdom	726000
 誉	vdos	25400000
 浙	vdpd	90800000
@@ -86756,6 +90292,8 @@ encoder:
 鼡	vdqb	139000
 𩖟	vdqi	0
 𧇳	vdri	0
+𪷀	vdsp	0
+𪶜	vdue	0
 浙江	vdvb	226000000
 浗	vdvs	873000
 栄	vdwf	7970000
@@ -86770,8 +90308,10 @@ encoder:
 労	vdwy	5720000
 学	vdwy	406000000
 𣻧	vdxw	0
+𪶎	vdyj	0
 敩	vdym	128000
 澣	veae	90100
+𪶗	veae	0
 满天	veag	8450000
 濛	veag	1480000
 𣿮	veag	0
@@ -86790,6 +90330,7 @@ encoder:
 𤅼	vebr	0
 𤅽	vebr	0
 𣶽	vebz	0
+𪷵	vebz	0
 渎职	vecj	1960000
 𣽇	vecx	0
 灌救	vedv	55700
@@ -86806,17 +90347,20 @@ encoder:
 瀻	veeo	338000
 潮	veeq	47500000
 𣿯	veex	0
+𪷒	veez	0
 灌木	vefa	4780000
 𣽡	vefd	0
 泄露	vefj	13400000
 𣺋	vefj	0
 灡	vefl	374000
 𣸃	vefs	0
+𪷺	vefw	0
 𤅠	vegc	0
 𣸽	vege	0
 渃	vegj	63200
 满面	vegj	10800000
 濗	vegl	18900
+𪷠	vegx	0
 𤂘	vehh	0
 𣸻	vehm	0
 洪雅	vehn	450000
@@ -86831,6 +90375,7 @@ encoder:
 漌	vejc	19400
 𣾑	vejc	0
 𤃂	vejd	0
+𪶲	vejd	0
 𣼑	vejf	0
 𣾓	vejh	0
 满足	veji	118000000
@@ -87022,6 +90567,7 @@ encoder:
 𤄓	vexg	0
 濸	vexj	73800
 𤃦	vexk	0
+𪷞	vexl	0
 瀟	vexn	503000
 汥	vexs	49100
 潮阳	veyk	1800000
@@ -87034,6 +90580,7 @@ encoder:
 渫	vezf	264000
 𤄶	vezf	0
 㶓	vezh	4680
+𪭕	vezh	0
 港台	vezj	41100000
 𣹓	vezj	0
 𣺾	vezj	0
@@ -87048,6 +90595,8 @@ encoder:
 𣺕	vfae	0
 𣸑	vfaf	0
 𣾐	vfaj	0
+𪷳	vfal	0
+𪶯	vfan	0
 𣻔	vfau	0
 溎	vfbb	52300
 㵱	vfbd	5820
@@ -87117,11 +90666,13 @@ encoder:
 𣿙	vfll	0
 𣿊	vflm	0
 𣿦	vflo	0
+𪷋	vfme	0
 𤃏	vfmg	0
 𧗉	vfml	0
 漂移	vfmr	3210000
 𣿋	vfmu	0
 𣸯	vfmy	0
+𪜚	vfmy	0
 沐川	vfnd	289000
 淅川	vfnd	376000
 瀖	vfni	26900
@@ -87135,12 +90686,14 @@ encoder:
 𤂭	vfoe	0
 漆	vfok	27500000
 𣿀	vfok	0
+𪷫	vfok	0
 淶	vfoo	705000
 𤂉	vfoo	0
 𤅷	vfoo	0
 𤀍	vfop	0
 𪅍	vfor	0
 𤅒	vfou	0
+𪬬	vfou	0
 澪	vfow	1530000
 𤅫	vfow	0
 淞	vfoz	4510000
@@ -87200,6 +90753,7 @@ encoder:
 潓	vfwz	65100
 濋	vfxi	1580000
 𤅉	vfxq	0
+𪸀	vfxx	0
 𣵎	vfya	0
 淋巴	vfyi	9220000
 沭阳	vfyk	4320000
@@ -87208,6 +90762,7 @@ encoder:
 𤄐	vfyk	0
 𪆟	vfyr	0
 𪆵	vfyr	0
+𪶪	vfyy	0
 𤄿	vfzf	0
 㜑	vfzm	4360
 㴗	vfzm	3880
@@ -87219,7 +90774,10 @@ encoder:
 𣳙	vgae	0
 渏	vgaj	63900
 𤂾	vgak	0
+𪵱	vgay	0
+𪵭	vgaz	0
 涯	vgbb	9770000
+𪶙	vgbb	0
 𣳇	vgbi	0
 㴎	vgbk	4580
 㵔	vgbm	6040
@@ -87249,6 +90807,7 @@ encoder:
 湹	vgkb	126000
 潦	vgkk	1340000
 𣿳	vgku	0
+𪷌	vgku	0
 沥水	vgkv	263000
 𣵟	vgkv	0
 𣸼	vgkv	0
@@ -87266,6 +90825,7 @@ encoder:
 𤃉	vgmw	0
 𣶐	vgmy	0
 𣽂	vgnd	0
+𪶫	vgni	0
 源	vgnk	268000000
 源泉	vgnk	10900000
 源自	vgnl	9420000
@@ -87285,8 +90845,10 @@ encoder:
 𧚚	vgsr	0
 源头	vgtg	10500000
 涿鹿	vgtx	453000
+𪷝	vgtx	0
 𣷟	vgub	0
 𤄊	vgub	0
+𪷏	vgud	0
 𣸷	vguk	0
 𣽄	vguk	0
 洃	vguo	126000
@@ -87314,6 +90876,7 @@ encoder:
 𣸵	vhaz	0
 汇款	vhbb	65700000
 𣿷	vhbb	0
+𪵷	vhbd	0
 涇	vhbi	293000
 𣸂	vhbo	0
 汇聚	vhcx	10400000
@@ -87340,6 +90903,8 @@ encoder:
 灊	vhjl	425000
 澸	vhjw	25000
 𣽦	vhjz	0
+𪶬	vhkc	0
+𪶌	vhkd	0
 浅显	vhkk	1830000
 浇水	vhkv	2980000
 𣹐	vhkz	0
@@ -87356,6 +90921,7 @@ encoder:
 柒佰	vhna	62800
 汇集	vhnf	12800000
 滙	vhni	580000
+𪷐	vhni	0
 柒仟	vhnm	51100
 𣾀	vhnn	0
 汇价	vhno	1770000
@@ -87367,8 +90933,11 @@ encoder:
 沤	vhos	943000
 𣶠	vhou	0
 浇铸	vhpc	702000
+𫆏	vhpc	0
 渐	vhpd	26800000
+𫗚	vhpo	0
 𣲪	vhrd	0
+𪸄	vhri	0
 潛	vhrk	4730000
 𤁭	vhrl	0
 𤂯	vhrl	0
@@ -87394,9 +90963,11 @@ encoder:
 渠	vhxf	9080000
 𤂐	vhxl	0
 𣶔	vhxn	0
+𪷬	vhxz	0
 沏	vhyd	2030000
 𤀠	vhyu	0
 𤏁	vhyu	0
+𪷨	vhyw	0
 𣶕	vhzc	0
 㵴	vhzh	12800
 沌	vhzi	1540000
@@ -87469,6 +91040,7 @@ encoder:
 𤃒	viol	0
 𤃯	viop	0
 𤁊	vios	0
+𪵺	vios	0
 滮	vipd	54100
 𣾅	vipk	0
 𣾥	vipy	0
@@ -87477,6 +91049,7 @@ encoder:
 𣻶	virb	0
 濒危	virg	4030000
 涉外	viri	8300000
+𪷡	viro	0
 泚	virr	285000
 𤃫	virr	0
 𣿤	virs	0
@@ -87490,6 +91063,7 @@ encoder:
 㵃	viwr	4640
 涉案	viwz	4890000
 滤	viwz	17700000
+𪵲	vixa	0
 𣵕	vixi	0
 泸	vixm	2490000
 𣲏	vixs	0
@@ -87502,6 +91076,7 @@ encoder:
 𤅦	vizi	0
 滤纸	vizr	874000
 涉嫌	vizu	18200000
+𪷓	vizy	0
 𣷶	vizz	0
 洖	vjag	969000
 𤀅	vjaj	0
@@ -87570,13 +91145,16 @@ encoder:
 溃烂	vjuu	2060000
 涡流	vjvs	1090000
 泅渡	vjvt	260000
+𪶑	vjwm	0
 溃退	vjwx	311000
 𣲷	vjxs	0
 𣳚	vjxs	0
 𣳲	vjya	0
 𣴵	vjya	0
 浥	vjyi	261000
+𪶃	vjyk	0
 𣳧	vjzd	0
+𪷢	vjzi	0
 𣹺	vjzk	0
 𣷢	vjzq	0
 淂	vkad	665000
@@ -87599,6 +91177,7 @@ encoder:
 溡	vkbd	725000
 𣻞	vkbd	0
 𣵀	vkbi	0
+𪶼	vkbj	0
 濐	vkbm	211000
 油井	vkbn	901000
 灙	vkbu	136000
@@ -87615,6 +91194,7 @@ encoder:
 滥捕	vkdf	105000
 混排	vkdk	546000
 𣼬	vkdp	0
+𪶄	vkds	0
 渴求	vkdv	1780000
 滭	vkeb	29100
 𤀾	vkee	0
@@ -87655,6 +91235,7 @@ encoder:
 𣽠	vkix	0
 沙哑	vkja	1300000
 漟	vkjb	92400
+𪸈	vkjd	0
 漫骂	vkjj	8940000
 澋	vkjk	34200
 澢	vkjk	32600
@@ -87668,6 +91249,7 @@ encoder:
 䣉	vkjy	3270
 消暑	vkkb	2870000
 灅	vkkb	52100
+𪷑	vkkb	0
 浀	vkkd	132000
 滉	vkkg	424000
 濃	vkkg	18400000
@@ -87728,6 +91310,7 @@ encoder:
 乷	vkmy	83800
 油气	vkmy	4320000
 湿气	vkmy	1040000
+𪟜	vkmy	0
 娑	vkmz	3830000
 混乱	vkmz	33300000
 𦀟	vkmz	0
@@ -87748,6 +91331,7 @@ encoder:
 璗	vkoc	42600
 混入	vkod	4290000
 滥杀	vkof	803000
+𪳷	vkof	0
 𧑘	vkoi	0
 𣽞	vkoj	0
 瀑	vkok	5340000
@@ -87790,6 +91374,7 @@ encoder:
 消音	vksk	2160000
 沙市	vksl	744000
 渂	vkso	27600
+𪷕	vkso	0
 渴望	vksq	34200000
 裟	vksr	916000
 漫谈	vksu	5930000
@@ -87845,12 +91430,14 @@ encoder:
 油层	vkxb	216000
 𣼦	vkxb	0
 𣼫	vkxi	0
+𪷃	vkxl	0
 𣴉	vkxs	0
 温柔	vkxx	49100000
 沙子	vkya	4780000
 消弭	vkyc	713000
 𤃑	vkyg	0
 𣸬	vkyj	0
+𪶀	vkym	0
 消费	vkyn	151000000
 消除	vkyo	39800000
 消防	vkys	38000000
@@ -87869,6 +91456,7 @@ encoder:
 𣺝	vkzz	0
 𤂽	vkzz	0
 𣵼	vlae	0
+𪶐	vlae	0
 𣿄	vlak	0
 𣼍	vlal	0
 漄	vlbb	94400
@@ -87876,6 +91464,7 @@ encoder:
 𣳷	vlbd	0
 淍	vlbj	47500
 濖	vlbm	21900
+𪷁	vlbm	0
 𤅵	vlbq	0
 𣵘	vlbr	0
 潶	vlbu	522000
@@ -87944,6 +91533,7 @@ encoder:
 滑县	vllz	489000
 瀴	vllz	58200
 滑稽	vlmg	16300000
+𪶞	vlmi	0
 𣽋	vlmj	0
 测算	vlml	8340000
 𣺐	vlmo	0
@@ -87979,11 +91569,13 @@ encoder:
 潉	vlrr	52100
 𤁣	vlrr	0
 𤄧	vlrs	0
+𪶒	vlrs	0
 湍急	vlrx	1140000
 𪂔	vlrz	0
 𪆸	vlrz	0
 测评	vlsa	21300000
 𣷪	vlsc	0
+𪶱	vlse	0
 测试	vlsh	321000000
 𤀆	vlss	0
 涔	vlsx	2070000
@@ -88062,6 +91654,8 @@ encoder:
 海西	vmfj	1340000
 𣽤	vmfl	0
 海霞	vmfx	415000
+𪣡	vmgb	0
+𪶇	vmgb	0
 𤅲	vmgc	0
 沃	vmgd	59500000
 浩大	vmgd	3950000
@@ -88115,8 +91709,10 @@ encoder:
 湩	vmkb	84500
 浰	vmkd	44700
 㶘	vmke	4000
+𪶣	vmke	0
 𣼖	vmkf	0
 浩淼	vmkk	702000
+𪷘	vmkm	0
 洙	vmko	2140000
 潲	vmkq	121000
 𣸪	vmkr	0
@@ -88130,6 +91726,7 @@ encoder:
 海岸	vmlg	24700000
 潈	vmlg	144000
 潨	vmlg	92600
+𪵴	vmli	0
 洫	vmlk	206000
 淛	vmlk	46000
 汽缸	vmme	1760000
@@ -88138,6 +91735,7 @@ encoder:
 潨	vmmk	92600
 活血	vmml	3350000
 𣾽	vmmm	0
+𪶵	vmmo	0
 𤅏	vmms	0
 𤅃	vmmx	0
 瀿	vmmz	46500
@@ -88151,12 +91749,14 @@ encoder:
 泆	vmod	491000
 潻	vmok	472000
 𤂱	vmok	0
+𪷮	vmom	0
 澨	vmoo	44600
 洗钱	vmph	1890000
 洗盘	vmpl	1210000
 汽船	vmpq	727000
 海豹	vmpr	2380000
 𣵸	vmqd	0
+𪵬	vmqd	0
 海豚	vmqg	10700000
 瀩	vmqg	31000
 洗脸	vmqo	6680000
@@ -88170,6 +91770,7 @@ encoder:
 活象	vmrj	419000
 濳	vmrk	55300
 灒	vmrl	494000
+𪷽	vmrl	0
 㵲	vmrm	8680
 漡	vmro	32400
 鍌	vmrp	1670000
@@ -88256,6 +91857,7 @@ encoder:
 激烈	vnar	47000000
 澚	vnaz	26300
 𤀀	vnaz	0
+𪶔	vnbb	0
 𣲚	vnbd	0
 𣽎	vnbe	0
 湼	vnbi	86000
@@ -88273,6 +91875,7 @@ encoder:
 準	vned	49300000
 𠦭	vned	0
 𣴢	vned	0
+𪶣	vnee	0
 淮南	vnel	7670000
 激荡	vnev	4310000
 鼝	vnex	26400
@@ -88303,6 +91906,7 @@ encoder:
 激光	vnkg	34800000
 𤃗	vnkl	0
 𣸇	vnko	0
+𪴞	vnkq	0
 激昂	vnkr	2780000
 濮	vnku	4580000
 𤂛	vnku	0
@@ -88325,10 +91929,13 @@ encoder:
 㵿	vnnn	4340
 激化	vnnr	3780000
 㳛	vnod	3800
+𪵻	vnod	0
 𤀈	vnog	0
 𤅛	vnog	0
+𪶓	vnog	0
 灚	vnol	538000
 𤃘	vnol	0
+𪶢	vnom	0
 𣾄	vnoo	0
 𣼺	vnor	0
 𣳦	vnos	0
@@ -88340,12 +91947,14 @@ encoder:
 𣴟	vnrd	0
 滌	vnrf	962000
 𣺢	vnrf	0
+𪽠	vnrk	0
 𣺅	vnro	0
 𣺫	vnrp	0
 滫	vnrq	40700
 沎	vnrr	31600
 𣴡	vnrr	0
 𣹮	vnrr	0
+𪶠	vnrr	0
 潟	vnru	2030000
 漗	vnrw	22000
 𣿒	vnse	0
@@ -88357,6 +91966,7 @@ encoder:
 淮北	vntr	5190000
 𣵲	vnub	0
 激情	vnuc	40300000
+𪶤	vnuc	0
 𤃙	vnue	0
 渊	vnuf	17400000
 澳	vnug	63800000
@@ -88390,6 +92000,7 @@ encoder:
 洽	voaj	21400000
 淪	voal	1580000
 𣹘	vobd	0
+𪶅	vobk	0
 𣺺	vobo	0
 𣹶	vobr	0
 浍	vobz	722000
@@ -88512,11 +92123,14 @@ encoder:
 沧	voyy	19300000
 滃	voyy	1400000
 潝	voyy	37400
+𪶡	voyy	0
 汹	vozi	321000
 𣳸	vozr	0
 㳂	vozs	5950
 洉	vpaj	113000
+𪷼	vpaj	0
 𣺧	vpal	0
+𪸊	vpbg	0
 渓	vpbo	1590000
 浮动	vpbz	8460000
 浮现	vpcv	8750000
@@ -88534,6 +92148,7 @@ encoder:
 鸂	vpgr	57900
 湲	vpgx	857000
 淫威	vpha	887000
+𪷻	vphh	0
 㴲	vpih	6080
 浮点	vpij	2610000
 㴞	vpik	4360
@@ -88556,8 +92171,11 @@ encoder:
 淫秽	vpml	44800000
 派系	vpmz	5940000
 滔	vpnb	2490000
+𪶴	vpnk	0
 𤂚	vpnr	0
+𪸆	vpoj	0
 派往	vpos	1610000
+𪷶	vpow	0
 𣹊	vppd	0
 𤁩	vppl	0
 派兵	vppo	2150000
@@ -88569,6 +92187,7 @@ encoder:
 瀊	vpql	37100
 𤅪	vprd	0
 派	vprh	409000000
+𪡤	vprj	0
 𣾠	vpro	0
 𤅥	vprx	0
 浮记	vpsy	3590
@@ -88627,10 +92246,13 @@ encoder:
 𣻽	vqhb	0
 染成	vqhv	1930000
 𣶴	vqji	0
+𪷄	vqjr	0
 𤂲	vqko	0
 沿岸	vqlg	5640000
 盕	vqlk	17400
 沿用	vqlv	4680000
+𪶟	vqmo	0
+𪷗	vqne	0
 㵻	vqnx	4000
 沿街	vqob	2230000
 㶀	vqop	4930
@@ -88638,6 +92260,7 @@ encoder:
 沿儿	vqrd	85700
 㴯	vqrk	4460
 𣶘	vqrr	0
+𪷔	vqrr	0
 染色	vqry	6210000
 𣑱	vqsf	0
 浵	vqsp	66500
@@ -88646,6 +92269,7 @@ encoder:
 𥹦	vquf	0
 㴨	vqug	5020
 沿着	vqul	15300000
+𪶆	vquo	0
 染料	vqut	9540000
 𤂵	vquz	0
 沿江	vqvb	3880000
@@ -88657,11 +92281,13 @@ encoder:
 汍	vqya	82000
 淝	vqyi	1050000
 𤅂	vqyl	0
+𪟛	vqym	0
 𣳜	vqyy	0
 沿线	vqzh	9260000
 𥁼	vral	0
 湰	vram	408000
 𣹯	vraz	0
+𪷿	vrbg	0
 𣽃	vrbj	0
 漈	vrbk	238000
 兆赫	vrbn	357000
@@ -88686,6 +92312,7 @@ encoder:
 涤棉	vrfn	710000
 頫	vrgo	164000
 𣻳	vrgo	0
+𫖯	vrgo	0
 𤀴	vrgq	0
 𤃽	vrgq	0
 洈	vrgy	103000
@@ -88694,6 +92321,7 @@ encoder:
 𣳢	vrid	0
 𣵥	vrik	0
 潒	vrjg	137000
+𪸉	vrjk	0
 𩁧	vrjn	0
 浼	vrjr	3060000
 𤀧	vrjr	0
@@ -88718,9 +92346,11 @@ encoder:
 渔利	vrmk	648000
 𣶌	vrmo	0
 𣼋	vrmr	0
+𪶿	vrmr	0
 泖	vrmy	243000
 淘气	vrmy	10900000
 𤄏	vrmz	0
+𪸅	vrmz	0
 淊	vrnb	41200
 洛川	vrnd	370000
 𨾾	vrni	0
@@ -88733,6 +92363,7 @@ encoder:
 𣹒	vrok	0
 澹	vros	2310000
 𣲢	vros	0
+𪶳	vrot	0
 𣶾	vrou	0
 淴	vrow	53900
 洶	vroz	258000
@@ -88750,9 +92381,11 @@ encoder:
 鴵	vrrz	21000
 𣺥	vrrz	0
 𥁼	vrsl	0
+𪷖	vrsu	0
 𠡑	vrsy	0
 汮	vrtd	25700
 泈	vrtd	22800
+𪾒	vrtl	0
 㶍	vruc	4040
 淗	vruf	29000
 洛美	vrug	301000
@@ -88767,6 +92400,7 @@ encoder:
 洛宁	vrwa	245000
 𣸢	vrwm	0
 沟通	vrwx	61800000
+𪷾	vrwx	0
 浄	vrxb	1330000
 𤁒	vrxi	0
 𤂰	vrxk	0
@@ -88809,6 +92443,7 @@ encoder:
 乼	vscy	28300
 流毒	vscz	370000
 滚热	vsdq	489000
+𪶊	vsds	0
 济南	vsel	140000000
 滦南	vsel	482000
 潼南	vsel	748000
@@ -88843,6 +92478,7 @@ encoder:
 汶上	vsiv	321000
 𤅝	vsiy	0
 游园	vsjb	1690000
+𪷤	vsjb	0
 𤄲	vsjc	0
 𣹾	vsje	0
 𤁘	vsji	0
@@ -88853,6 +92489,7 @@ encoder:
 㗟	vsjr	3560
 渷	vsjr	122000
 滾	vsjr	12400000
+𪶦	vsjr	0
 涥	vsjy	27900
 淳	vsjy	12700000
 𤅻	vsjy	0
@@ -88938,10 +92575,14 @@ encoder:
 游行	vsoi	12800000
 滧	vsom	27800
 洨	vsoo	1260000
+𪷙	vsop	0
 𣺓	vsor	0
 𤅭	vsor	0
+𪷥	vsor	0
+𪶺	vsos	0
 淤	vsot	3300000
 𣻒	vsow	0
+𪶧	vsoy	0
 𤄰	vspg	0
 注销	vspk	19200000
 滚翻	vspk	98200
@@ -89030,6 +92671,7 @@ encoder:
 滂	vsws	660000
 流通	vswx	60600000
 淳安	vswz	1080000
+𪤊	vsxb	0
 游戏	vsxh	598000000
 漩	vsxi	1140000
 浪	vsxo	53400000
@@ -89041,6 +92683,7 @@ encoder:
 𤅀	vsyg	0
 𤅗	vsyg	0
 游民	vsyh	22800000
+𪷰	vsyj	0
 济阳	vsyk	754000
 浏阳	vsyk	2620000
 潡	vsym	698000
@@ -89073,7 +92716,9 @@ encoder:
 泫	vszz	862000
 流出	vszz	20000000
 𣴔	vtae	0
+𪸁	vtbx	0
 灋	vtbz	84700
+𪷲	vteb	0
 㳆	vted	3900
 𣳝	vted	0
 㵂	vteu	5600
@@ -89092,16 +92737,20 @@ encoder:
 𤃢	vtjm	0
 𣼟	vtkv	0
 𣴿	vtmb	0
+𪶹	vtmb	0
 𣳥	vtmh	0
 㶐	vtnw	4060
 瀍	vtob	175000
+𪶶	vtob	0
 𤄟	vtoj	0
 渡船	vtpq	1390000
 澬	vtrl	77800
 𣳩	vtro	0
 𣼀	vtrp	0
+𪶻	vtrq	0
 𣷳	vtrs	0
 润色	vtry	841000
+𪸇	vtub	0
 𤃱	vtuf	0
 瀌	vtuo	32600
 濂	vtux	3180000
@@ -89110,6 +92759,7 @@ encoder:
 润滑	vtvl	8960000
 澜沧	vtvo	419000
 渡过	vtwd	5180000
+𪷸	vtwr	0
 溏	vtxj	3760000
 漮	vtxk	37100
 滽	vtxl	27700
@@ -89118,6 +92768,7 @@ encoder:
 𣿕	vtzu	0
 㳕	vubd	3940
 溠	vubi	115000
+𪶥	vubk	0
 滋长	vuch	1310000
 𤀡	vucx	0
 滋扰	vudg	378000
@@ -89153,6 +92804,7 @@ encoder:
 淡水	vukv	21900000
 漛	vukv	18600
 𣻌	vukv	0
+𪷇	vuky	0
 潧	vulk	1080000
 洋县	vulz	354000
 𣹌	vumf	0
@@ -89192,6 +92844,7 @@ encoder:
 𣷇	vuuo	0
 𣺸	vuuo	0
 𤄂	vuuu	0
+𪸂	vuux	0
 㴴	vuuz	9130
 淡漠	vuve	2920000
 洋浦	vuvf	491000
@@ -89204,8 +92857,10 @@ encoder:
 渊深	vuvw	143000
 渊远	vuwb	179000
 𣿩	vuwb	0
+𪷯	vuwb	0
 瀅	vuwc	967000
 濚	vuwf	130000
+𪷟	vuwg	0
 㶈	vuwi	4000
 滋补	vuwi	3980000
 濴	vuwk	26500
@@ -89225,6 +92880,7 @@ encoder:
 涕	vuyz	3690000
 淡红	vuzb	2240000
 𤀟	vuzb	0
+𪶕	vuzi	0
 㴊	vuzk	4550
 溇	vuzm	150000
 溯	vuzq	3950000
@@ -89304,6 +92960,7 @@ encoder:
 沉醉	vwfs	6520000
 𣾡	vwfv	0
 𢣣	vwfw	0
+𪷦	vwfw	0
 㳠	vwgd	18500
 涙	vwgd	41600000
 	vwgd	0
@@ -89331,9 +92988,11 @@ encoder:
 深切	vwhy	6060000
 滱	vwix	35100
 𣵈	vwiz	0
+𪷚	vwji	0
 㴦	vwjj	5180
 浑圆	vwjj	1480000
 演唱	vwjk	105000000
+𪷛	vwjk	0
 学员	vwjl	20200000
 演员	vwjl	85200000
 沉吟	vwjo	5340000
@@ -89345,6 +93004,7 @@ encoder:
 𤁖	vwkf	0
 渖	vwki	264000
 𤃜	vwkk	0
+𪷷	vwkk	0
 濱	vwkl	4250000
 演	vwko	49400000
 𣿌	vwkr	0
@@ -89408,6 +93068,7 @@ encoder:
 学会	vwob	82800000
 学徒	vwob	17300000
 𤀕	vwob	0
+𪸋	vwoc	0
 深入	vwod	88300000
 𣿈	vwoe	0
 深	vwof	301000000
@@ -89417,6 +93078,7 @@ encoder:
 觉得	vwok	397000000
 𣺑	vwol	0
 𣼂	vwol	0
+𪷱	vwol	0
 𤀿	vwoo	0
 㵳	vwop	7520
 𣽬	vwot	0
@@ -89453,6 +93115,7 @@ encoder:
 𤉠	vwru	0
 涴	vwry	598000
 深色	vwry	3660000
+𪶉	vwry	0
 𣸦	vwrz	0
 演讲	vwsb	28800000
 滓	vwse	1460000
@@ -89462,6 +93125,7 @@ encoder:
 深交	vwso	4330000
 溟	vwso	1540000
 𣼗	vwso	0
+𪷆	vwso	0
 深望	vwsq	28200
 学说	vwsv	10700000
 演说	vwsv	5470000
@@ -89488,6 +93152,7 @@ encoder:
 𤁷	vwul	0
 𣿪	vwun	0
 淀粉	vwuo	14600000
+𪷅	vwuu	0
 深为	vwuv	1360000
 𣸈	vwux	0
 沁源	vwvg	357000
@@ -89514,6 +93179,7 @@ encoder:
 沉溺	vwvy	3870000
 深远	vwwb	9190000
 学过	vwwd	5670000
+𪷦	vwwf	0
 学家	vwwg	23900000
 沉寂	vwwi	5980000
 澝	vwwl	48900
@@ -89558,6 +93224,7 @@ encoder:
 𤀓	vwzk	0
 𤁂	vwzl	0
 洝	vwzm	369000
+𪶷	vwzn	0
 浓缩	vwzw	10300000
 演绎	vwzx	27800000
 学好	vwzy	6330000
@@ -89570,6 +93237,7 @@ encoder:
 湀	vxag	534000
 泥土	vxba	3490000
 堻	vxbb	46900
+𪷭	vxbb	0
 津	vxbd	39100000
 𣻷	vxbd	0
 汉城	vxbh	4550000
@@ -89628,8 +93296,10 @@ encoder:
 湋	vxjm	58400
 𤁵	vxjn	0
 澼	vxjs	55300
+𪸌	vxjs	0
 澄	vxju	12900000
 𣹢	vxju	0
+𪷧	vxju	0
 汉中	vxjv	6280000
 波恩	vxjw	915000
 㴫	vxjy	5710
@@ -89738,6 +93408,7 @@ encoder:
 泽普	vxuk	196000
 涵盖	vxul	11300000
 濜	vxul	25400
+𪾛	vxul	0
 涵养	vxun	2100000
 漏粉	vxuo	85300
 泥塑	vxuz	1290000
@@ -89770,12 +93441,14 @@ encoder:
 浸	vxwx	17900000
 汉字	vxwy	60800000
 㵍	vxwz	4090
+𪶽	vxxf	0
 汿	vxxi	19200
 𤁍	vxxi	0
 𣲺	vxxs	0
 涰	vxxx	28200
 溊	vxxx	23400
 𣴫	vxxx	0
+𪵽	vxxx	0
 汉子	vxya	5680000
 汉阳	vxyk	2350000
 波阳	vxyk	159000
@@ -89839,12 +93512,14 @@ encoder:
 涨跌	vyjm	16300000
 𣽻	vykh	0
 𣶻	vyki	0
+𪶖	vyki	0
 𣹝	vykq	0
 沸水	vykv	2420000
 溺水	vykv	2110000
 涨幅	vyla	14300000
 䀀	vylk	17800
 梁山	vyll	3810000
+𪶾	vylo	0
 汲县	vylz	51100
 滁县	vylz	55500
 𣿃	vylz	0
@@ -89876,6 +93551,7 @@ encoder:
 𣽓	vyou	0
 𥹦	vyou	0
 𣼢	vyow	0
+𪶾	vyoz	0
 䀊	vypl	6320
 沸腾	vyqu	8910000
 瀡	vyqw	210000
@@ -89918,10 +93594,12 @@ encoder:
 㵫	vyyk	5730
 𣻭	vyyl	0
 泐	vyym	250000
+𪵶	vyym	0
 漝	vyyn	33100
 濯	vyyn	2800000
 汤阴	vyyq	515000
 𣹩	vyyq	0
+𪷊	vyys	0
 溺	vyyt	6930000
 𣴆	vyyt	0
 𣷺	vyyx	0
@@ -89957,13 +93635,16 @@ encoder:
 𣹤	vzjm	0
 𣷢	vzjq	0
 㖳	vzjr	3710
+𪶩	vzjw	0
 㴩	vzjy	5090
 㵖	vzjz	3960
 漅	vzkf	28700
 淄	vzki	1770000
+𪷉	vzki	0
 𣺤	vzkk	0
 𣿍	vzkl	0
 𥂖	vzkl	0
+𪶋	vzkm	0
 治水	vzkv	1930000
 淥	vzkv	110000
 渗水	vzkv	1010000
@@ -89972,6 +93653,7 @@ encoder:
 𣶄	vzlk	0
 𣳺	vzll	0
 𣻀	vzlo	0
+𪷈	vzlo	0
 𣾧	vzly	0
 浚县	vzlz	486000
 涘	vzma	2210000
@@ -90002,6 +93684,7 @@ encoder:
 𤄋	vzsw	0
 治病	vzta	6640000
 治疗	vzty	74700000
+𪶈	vzuf	0
 汝州	vzvn	624000
 𣴍	vzvv	0
 渗漏	vzvx	2320000
@@ -90012,6 +93695,7 @@ encoder:
 𣸏	vzxm	0
 泼	vzxs	8980000
 𣷕	vzxs	0
+𪶨	vzxw	0
 汝阳	vzyk	342000
 灉	vzyn	516000
 灣	vzyz	15800000
@@ -90049,6 +93733,7 @@ encoder:
 迀	waed	30800
 宁南	wael	529000
 逼真	wael	9910000
+𫑖	waeo	0
 宁蒗	waev	306000
 富蕴	waez	207000
 迗	wagd	88300
@@ -90083,6 +93768,7 @@ encoder:
 𨒘	walm	0
 之内	walo	35500000
 宁冈	walo	73300
+𫐣	walo	0
 邐	walt	78500
 宁县	walz	5050000
 富县	walz	393000
@@ -90268,6 +93954,7 @@ encoder:
 社保	wbnj	10500000
 空白	wbnk	50300000
 运作	wbnm	27600000
+𫐨	wbno	0
 宣化	wbnr	1140000
 进化	wbnr	10700000
 进货	wbnr	9500000
@@ -90296,6 +93983,8 @@ encoder:
 𨘝	wbrn	0
 𨒮	wbro	0
 完毕	wbrr	31900000
+𫐥	wbrr	0
+𫐫	wbrr	0
 宣言	wbsa	37900000
 宣讲	wbsb	2520000
 宣读	wbse	5630000
@@ -90436,6 +94125,7 @@ encoder:
 𡩞	wdai	0
 𡬈	wdai	0
 𣦍	wdai	0
+𪧍	wdai	0
 㝓	wdaj	4050
 寄	wdaj	223000000
 𡧻	wdaj	0
@@ -90448,6 +94138,8 @@ encoder:
 㿾	wdal	6130
 𡪲	wdal	0
 𧵒	wdal	0
+𪧅	wdal	0
+𫁛	wdal	0
 㝫	wdam	3930
 㲰	wdam	4430
 宺	wdan	22000
@@ -90463,6 +94155,7 @@ encoder:
 𡧒	wdar	0
 𡩲	wdar	0
 𡪊	wdar	0
+𫛢	wdar	0
 𡧊	wday	0
 𡩸	wdaz	0
 𡪑	wdaz	0
@@ -90479,6 +94172,7 @@ encoder:
 𡧱	wdbj	0
 𡫸	wdbj	0
 𡬋	wdbj	0
+𪧱	wdbj	0
 宗	wdbk	47800000
 宣	wdbk	41200000
 寐	wdbk	4290000
@@ -90489,9 +94183,12 @@ encoder:
 𡩮	wdbl	0
 𡪓	wdbl	0
 𧹆	wdbl	0
+𪧪	wdbl	0
 宑	wdbn	36100
 㝬	wdbo	3750
 𡧢	wdbo	0
+𫐧	wdbo	0
+𪧢	wdbq	0
 完	wdbr	246000000
 鶎	wdbr	959
 𡩃	wdbr	0
@@ -90504,6 +94201,7 @@ encoder:
 䵫	wdbu	4080
 𤎟	wdbu	0
 𢤑	wdbw	0
+𫐱	wdbw	0
 㝮	wdbx	4380
 𡫉	wdbx	0
 宯	wdby	27000
@@ -90514,6 +94212,7 @@ encoder:
 𡧈	wdbz	0
 𡩭	wdbz	0
 𡩱	wdbz	0
+𪧼	wdcd	0
 𡫶	wdce	0
 𡨒	wdcg	0
 寷	wdci	45800
@@ -90527,6 +94226,8 @@ encoder:
 𡨲	wdcr	0
 宝	wdcs	469000000
 㝡	wdcx	5300
+𪧨	wdcx	0
+𪧊	wddj	0
 𧵿	wddl	0
 衬托	wddm	5340000
 守势	wddq	404000
@@ -90547,6 +94248,7 @@ encoder:
 寛	wdel	5480000
 𡩖	wdel	0
 𡨄	wdeo	0
+𪧴	wdeo	0
 定期	wdeq	106000000
 过期	wdeq	23300000
 𡨜	wdet	0
@@ -90559,6 +94261,9 @@ encoder:
 𡧰	wdez	0
 𡩧	wdez	0
 𡩴	wdez	0
+𪧕	wdez	0
+𪧥	wdez	0
+𪧬	wdez	0
 𡨾	wdfb	0
 𨕝	wdfb	0
 㝝	wdff	4070
@@ -90568,13 +94273,16 @@ encoder:
 𡧳	wdfj	0
 寴	wdfl	39600
 𡫎	wdfm	0
+𪧭	wdfp	0
 𡪎	wdfr	0
 𡫊	wdfs	0
 寭	wdfw	28000
 𢚠	wdfw	0
+𪧵	wdfz	0
 过硬	wdga	10600000
 𡩳	wdgb	0
 𡫼	wdgb	0
+𪧫	wdgc	0
 䢇	wdgd	3410
 定夺	wdgd	1070000
 𡫦	wdgd	0
@@ -90588,12 +94296,14 @@ encoder:
 𡧣	wdgj	0
 𡧶	wdgj	0
 𧠽	wdgl	0
+𪩶	wdgl	0
 宠	wdgm	22200000
 顁	wdgo	224000
 𡧞	wdgo	0
 宥	wdgq	5030000
 家	wdgq	1100000000
 𡧘	wdgq	0
+𪧰	wdgq	0
 𡧉	wdgr	0
 𡫰	wdgr	0
 𪀱	wdgr	0
@@ -90603,11 +94313,15 @@ encoder:
 𤠊	wdgs	0
 𢥜	wdgu	0
 𢥛	wdgw	0
+𪬅	wdgw	0
 𡧭	wdgy	0
 𡫌	wdgy	0
 宏	wdgz	71800000
+𪧩	wdgz	0
 室	wdhb	549000000
+𪧧	wdhh	0
 𪀥	wdhr	0
+𪧝	wdhu	0
 宬	wdhy	462000
 过盛	wdhy	311000
 𡩍	wdhy	0
@@ -90624,6 +94338,7 @@ encoder:
 寊	wdil	55500
 𡪝	wdil	0
 𧡧	wdil	0
+𫁝	wdil	0
 𩝩	wdio	0
 𪅢	wdir	0
 𨐝	wdis	0
@@ -90648,6 +94363,7 @@ encoder:
 额	wdjg	90500000
 𡧲	wdji	0
 𡨌	wdji	0
+𪧎	wdji	0
 宫	wdjj	99700000
 𡩾	wdjj	0
 𡫆	wdjj	0
@@ -90676,13 +94392,16 @@ encoder:
 𣣶	wdjr	0
 𪃜	wdjr	0
 𪃭	wdjr	0
+𫛕	wdjr	0
 𡪺	wdju	0
 𡫋	wdju	0
 𡬗	wdju	0
 𧯜	wdju	0
 𧯳	wdju	0
+𪧏	wdju	0
 愙	wdjw	66500
 𢞩	wdjw	0
+𫁑	wdjw	0
 𠢆	wdjy	0
 𡩫	wdjy	0
 𨜱	wdjy	0
@@ -90696,6 +94415,7 @@ encoder:
 𡫝	wdka	0
 𡪂	wdkb	0
 𡪸	wdkb	0
+𪧳	wdkb	0
 𡨰	wdkc	0
 𩤡	wdkc	0
 定时	wdkd	15900000
@@ -90706,11 +94426,13 @@ encoder:
 𡪪	wdkg	0
 宙	wdki	8240000
 审	wdki	51700000
+𪧈	wdki	0
 寮	wdkk	13800000
 𠝳	wdkk	0
 𠠙	wdkk	0
 𡩦	wdkk	0
 𡪏	wdkk	0
+𪧛	wdkk	0
 寳	wdkl	4660000
 覾	wdkl	22400
 賓	wdkl	7290000
@@ -90751,7 +94473,9 @@ encoder:
 㝤	wdlb	4370
 寗	wdlb	68400
 𡩋	wdlb	0
+𫁌	wdlb	0
 宜	wdlc	64100000
+𪧯	wdle	0
 𡩈	wdlf	0
 𡩼	wdlf	0
 寏	wdlg	28000
@@ -90774,6 +94498,8 @@ encoder:
 定岗	wdll	434000
 𡫨	wdll	0
 𧢘	wdll	0
+𪾺	wdll	0
+𫁝	wdll	0
 𡫄	wdlm	0
 𡫵	wdlm	0
 𣰨	wdlm	0
@@ -90786,6 +94512,7 @@ encoder:
 𡩂	wdlo	0
 𡬔	wdlp	0
 𨭧	wdlp	0
+𫆴	wdlq	0
 䴐	wdlr	4540
 定购	wdlr	10800000
 𡕹	wdlr	0
@@ -90798,6 +94525,7 @@ encoder:
 寬	wdls	23400000
 𡪍	wdlu	0
 𡫅	wdlu	0
+𪹿	wdlu	0
 憲	wdlw	5680000
 𡫇	wdlw	0
 𢜇	wdlw	0
@@ -90822,6 +94550,7 @@ encoder:
 𡧪	wdmh	0
 𡧿	wdmh	0
 𡨉	wdmh	0
+𪧮	wdmh	0
 㝚	wdmi	3800
 宱	wdmi	24100
 蜜	wdmi	42600000
@@ -90841,6 +94570,8 @@ encoder:
 𡪳	wdml	0
 𡪽	wdml	0
 𧶡	wdml	0
+𪧟	wdml	0
+𪧠	wdml	0
 守敌	wdmm	166000
 过年	wdmm	15900000
 𡪣	wdmm	0
@@ -90861,6 +94592,7 @@ encoder:
 𡪉	wdmy	0
 过敏	wdmz	11600000
 𡨑	wdmz	0
+𪧞	wdmz	0
 𡧛	wdnd	0
 定做	wdne	11600000
 𡨯	wdne	0
@@ -90873,6 +94605,8 @@ encoder:
 定向	wdnj	10800000
 𢳔	wdnm	0
 𤛝	wdnm	0
+𪧤	wdnm	0
+𪧐	wdnn	0
 定价	wdno	27200000
 𡨁	wdno	0
 𡩟	wdno	0
@@ -90883,6 +94617,7 @@ encoder:
 𡨇	wdnr	0
 𡪆	wdnr	0
 定位	wdns	59500000
+𪧖	wdnu	0
 定息	wdnw	213000
 𡧺	wdnx	0
 𨜳	wdny	0
@@ -90906,6 +94641,7 @@ encoder:
 蹇	wdoj	4090000
 𠹟	wdoj	0
 过得	wdok	17200000
+𪧦	wdok	0
 賽	wdol	27500000
 赛	wdol	141000000
 𡫛	wdol	0
@@ -90925,6 +94661,7 @@ encoder:
 𦢽	wdoo	0
 寥	wdop	1370000
 𡫱	wdop	0
+𪧉	wdop	0
 𦞫	wdoq	0
 鶱	wdor	60900
 謇	wdos	780000
@@ -90932,6 +94669,7 @@ encoder:
 𡧴	wdos	0
 寒	wdot	82200000
 𡬜	wdot	0
+𪧑	wdot	0
 𡨿	wdou	0
 𡪹	wdou	0
 𢞝	wdou	0
@@ -90944,11 +94682,13 @@ encoder:
 弿	wdoy	105000
 过分	wdoy	21200000
 𡧋	wdoy	0
+𪧔	wdoy	0
 㝐	wdoz	4410
 𡨭	wdoz	0
 𡩊	wdoz	0
 𡪋	wdoz	0
 𡫾	wdoz	0
+𫁙	wdoz	0
 定金	wdpa	4390000
 过后	wdpa	29700000
 逝	wdpd	22900000
@@ -90992,17 +94732,22 @@ encoder:
 𡫥	wdrj	0
 𡫲	wdrj	0
 𡬚	wdrj	0
+𪧒	wdrj	0
 守备	wdrk	876000
 𡨩	wdrk	0
+𪧣	wdrk	0
 䙾	wdrl	3350
 𡧸	wdrl	0
 𡩅	wdrl	0
 𡫛	wdrl	0
 𥁗	wdrl	0
 𧶉	wdrl	0
+𫁋	wdrl	0
 𡨥	wdrm	0
 𢼊	wdrm	0
 𢽉	wdrm	0
+𫁒	wdrn	0
+𫁖	wdrn	0
 𡧤	wdro	0
 𡨳	wdro	0
 𡨷	wdro	0
@@ -91023,8 +94768,10 @@ encoder:
 宛	wdry	14000000
 𡩄	wdry	0
 𡪬	wdry	0
+𫁕	wdry	0
 宼	wdrz	28800
 𪁶	wdrz	0
+𪧋	wdrz	0
 㝘	wdsa	3930
 𡫑	wdsb	0
 𡫓	wdsb	0
@@ -91044,6 +94791,7 @@ encoder:
 定产	wdsm	257000
 𡫀	wdsm	0
 𡫣	wdsm	0
+𪧜	wdsm	0
 过夜	wdsn	4800000
 𡧽	wdsn	0
 㝠	wdso	4980
@@ -91062,6 +94810,7 @@ encoder:
 㝗	wdsx	3950
 㝑	wdsy	3850
 𨓓	wdsy	0
+𫁚	wdte	0
 实	wdtg	151000000
 过头	wdtg	19500000
 过问	wdtj	5530000
@@ -91098,6 +94847,7 @@ encoder:
 叜	wdux	42600
 过快	wdux	5800000
 𡬎	wduz	0
+𪧘	wduz	0
 定兴	wdva	439000
 守法	wdvb	39600000
 𡪦	wdvb	0
@@ -91106,6 +94856,7 @@ encoder:
 过活	wdvm	1230000
 定州	wdvn	1020000
 过激	wdvn	2550000
+𪧓	wdvn	0
 宨	wdvr	51800
 逑	wdvs	1550000
 𡨃	wdvs	0
@@ -91116,6 +94867,7 @@ encoder:
 𡬀	wdwc	0
 𡬏	wdwc	0
 𡨺	wdwd	0
+𪧚	wdwd	0
 𡬇	wdwg	0
 𡬄	wdwk	0
 㝲	wdwl	3950
@@ -91156,6 +94908,7 @@ encoder:
 𡫽	wdwz	0
 𡩌	wdxb	0
 𡩿	wdxb	0
+𪹀	wdxb	0
 定居	wdxe	6070000
 𡧖	wdxf	0
 𡪧	wdxf	0
@@ -91185,6 +94938,7 @@ encoder:
 𡧐	wdxo	0
 𡫕	wdxr	0
 㝊	wdxs	4280
+𪧆	wdxs	0
 𡪼	wdxu	0
 𡧕	wdxx	0
 𡨤	wdxx	0
@@ -91192,6 +94946,7 @@ encoder:
 𡪅	wdxy	0
 𨝢	wdxy	0
 𡪚	wdxz	0
+𪧙	wdxz	0
 字	wdya	693000000
 守卫	wdya	4700000
 定陵	wdyb	258000
@@ -91227,6 +94982,7 @@ encoder:
 翧	wdyy	68700
 𡦻	wdyy	0
 𨜌	wdyy	0
+𫅭	wdyy	0
 宆	wdyz	38000
 宖	wdyz	33200
 𡨻	wdyz	0
@@ -91235,13 +94991,17 @@ encoder:
 鞌	wdze	41900
 𡧵	wdze	0
 案	wdzf	103000000
+𪧌	wdzf	0
+𫐂	wdzf	0
 頞	wdzg	99000
 𡧑	wdzg	0
 𡩀	wdzg	0
 𡩽	wdzg	0
 𩓘	wdzg	0
 𧊹	wdzi	0
+𪧇	wdzi	0
 过细	wdzk	544000
+𪽣	wdzk	0
 䀂	wdzl	7790
 實	wdzl	29500000
 寶	wdzl	52600000
@@ -91260,11 +95020,15 @@ encoder:
 䴁	wdzr	5570
 定婚	wdzr	329000
 鴳	wdzr	36000
+𫛙	wdzr	0
+𫛩	wdzr	0
 寣	wdzs	73000
 㝥	wdzu	4380
 定编	wdzw	391000
 𡪾	wdzw	0
+𫑈	wdzw	0
 𡩝	wdzx	0
+𪧲	wdzx	0
 䢿	wdzy	3710
 定级	wdzy	1100000
 𠡓	wdzy	0
@@ -91272,6 +95036,7 @@ encoder:
 𡧍	wdzy	0
 𡧨	wdzz	0
 𦀀	wdzz	0
+𫁗	wdzz	0
 𨘞	weae	0
 𦽙	weao	0
 遭殃	wear	2500000
@@ -91304,6 +95069,7 @@ encoder:
 𨙕	wejn	0
 赛跑	wejr	3000000
 𨘏	wejr	0
+𫐦	wejr	0
 寒暑	wekb	1310000
 𨘦	wekb	0
 𨕡	weke	0
@@ -91319,6 +95085,7 @@ encoder:
 𦳖	weld	0
 𨗲	welj	0
 遭罪	welk	455000
+𫈡	welo	0
 邁	welz	6200000
 𨕇	wemi	0
 赛程	wemj	6210000
@@ -91329,6 +95096,7 @@ encoder:
 遳	weob	27100
 宽余	weom	170000
 寒舍	weom	800000
+𫑆	weox	0
 赛后	wepa	4690000
 遭受	wepw	22100000
 寒风	weqo	7050000
@@ -91387,10 +95155,12 @@ encoder:
 𨖇	wfds	0
 䢞	wffa	3430
 𨗆	wfgl	0
+𫑐	wfgs	0
 𨗇	wfgw	0
 遷	wfgy	3300000
 速成	wfhv	6340000
 遫	wfjm	27200
+𫐿	wfjm	0
 遬	wfjr	27000
 䢮	wfki	3710
 𨖚	wfkk	0
@@ -91413,8 +95183,10 @@ encoder:
 逨	wfoo	67300
 𨙛	wfoo	0
 𨗺	wfow	0
+𫑅	wfow	0
 𨘱	wfpx	0
 述评	wfsa	4740000
+𫑒	wfsj	0
 速调	wfsl	131000
 速效	wfso	2500000
 鶐	wfsr	19700
@@ -91423,6 +95195,7 @@ encoder:
 速记	wfsy	2810000
 速冻	wfth	2240000
 速度	wftv	184000000
+𫐠	wfvv	0
 速溶	wfvw	720000
 速写	wfwa	1950000
 𨙤	wfwr	0
@@ -91434,6 +95207,7 @@ encoder:
 𨔣	wfyj	0
 襟翼	wfyy	188000
 𨖝	wfzd	0
+𫑋	wfzm	0
 𨓾	wgaj	0
 还款	wgbb	5920000
 逐项	wgbg	1490000
@@ -91457,6 +95231,7 @@ encoder:
 还要	wgfv	123000000
 宏大	wggd	10400000
 寄存	wggi	3790000
+𫐾	wggi	0
 还原	wggn	30700000
 还有	wggq	317000000
 突袭	wggs	9330000
@@ -91699,6 +95474,7 @@ encoder:
 补益	wiuo	888000
 𧉌	wivv	0
 𨒷	wivv	0
+𫐞	wivv	0
 寂寞	wiwe	116000000
 补遗	wiwj	581000
 补选	wiwm	614000
@@ -91779,6 +95555,7 @@ encoder:
 逞强	wjyj	3170000
 𨔗	wjyj	0
 宫廷	wjym	5550000
+𫑍	wjym	0
 遗孀	wjzf	555000
 逞能	wjzq	470000
 启发	wjzv	12400000
@@ -91833,6 +95610,7 @@ encoder:
 神仙	wknl	14700000
 神像	wknr	2230000
 宴会	wkob	16500000
+𫑀	wkob	0
 𨕲	wkoi	0
 𨔫	wkor	0
 𨕟	wkor	0
@@ -91921,6 +95699,7 @@ encoder:
 宜山	wlll	305000
 𨓒	wlmb	0
 祖籍	wlmc	1720000
+𫑑	wlmm	0
 祖先	wlmr	8200000
 视乎	wlmu	615000
 𨘩	wlmz	0
@@ -91940,6 +95719,7 @@ encoder:
 𪆹	wlrz	0
 𨓹	wlsc	0
 宜章	wlsk	451000
+𫑌	wlsk	0
 宜良	wlsx	463000
 视为	wluv	26200000
 宜兴	wlva	6220000
@@ -92034,8 +95814,11 @@ encoder:
 𣙅	wmhf	0
 啔	wmhj	43000
 䁉	wmhl	6170
+𫎠	wmhl	0
 选区	wmho	2540000
 造成	wmhv	236000000
+𪭘	wmhx	0
+𪦽	wmhy	0
 䋯	wmhz	3500
 迮	wmid	160000
 𨑶	wmid	0
@@ -92071,6 +95854,7 @@ encoder:
 适时	wmkd	13400000
 𢿭	wmke	0
 𦠰	wmke	0
+𪭛	wmke	0
 𢩊	wmkg	0
 㧂	wmki	5190
 追星	wmkm	6220000
@@ -92085,6 +95869,7 @@ encoder:
 𢨷	wmlc	0
 扁	wmld	34900000
 扃	wmld	269000
+𪭙	wmld	0
 𥳪	wmle	0
 𨖼	wmlg	0
 帍	wmli	30200
@@ -92094,6 +95879,7 @@ encoder:
 𧢞	wmll	0
 㲢	wmlm	4620
 𢨿	wmlo	0
+𪭙	wmlo	0
 㼐	wmlp	4570
 选购	wmlr	40400000
 鶣	wmlr	25100
@@ -92106,6 +95892,7 @@ encoder:
 𨕀	wmma	0
 户籍	wmmc	10700000
 𨖬	wmmc	0
+𫆈	wmmc	0
 选手	wmmd	19200000
 𢨮	wmme	0
 𢨵	wmme	0
@@ -92113,6 +95900,7 @@ encoder:
 𣘼	wmmf	0
 牢笼	wmmg	1060000
 𢩏	wmmi	0
+𫑎	wmmi	0
 啓	wmmj	3270000
 牢靠	wmmj	1220000
 选种	wmmj	540000
@@ -92149,10 +95937,12 @@ encoder:
 造化	wmnr	3690000
 适合	wmoa	245000000
 𥲽	wmob	0
+𪭚	wmob	0
 迁入	wmod	1790000
 迭	wmod	5150000
 𢨨	wmod	0
 透彻	wmoh	5710000
+𪭙	wmoj	0
 邌	wmok	25800
 𨙢	wmol	0
 遾	wmoo	25600
@@ -92171,6 +95961,7 @@ encoder:
 透镜	wmps	1170000
 造反	wmpx	3560000
 顅	wmqg	29600
+𫖶	wmqg	0
 𠶳	wmqj	0
 𧡌	wmql	0
 必胜	wmqm	6030000
@@ -92188,6 +95979,7 @@ encoder:
 户外	wmri	51200000
 户名	wmrj	15100000
 𢩁	wmrj	0
+𫑓	wmrj	0
 必备	wmrk	26300000
 𨘯	wmrm	0
 𣢖	wmro	0
@@ -92215,6 +96007,7 @@ encoder:
 𢩞	wmsp	0
 扆	wmsr	237000
 造诣	wmsr	2980000
+𫆥	wmsr	0
 𢩀	wmss	0
 𢨶	wmsu	0
 房	wmsy	573000000
@@ -92233,6 +96026,7 @@ encoder:
 𦂟	wmtz	0
 追悼	wmui	4130000
 追悔	wmum	1500000
+𫐵	wmuo	0
 扊	wmuu	32200
 选举	wmva	15800000
 宪法	wmvb	28800000
@@ -92349,12 +96143,14 @@ encoder:
 𨘐	wnnn	0
 𨖽	wnob	0
 𨗭	wnob	0
+𫐯	wnod	0
 𨗮	wnoe	0
 𨘤	wnol	0
 宿舍	wnom	59800000
 𨗔	wnon	0
 𨕵	wnqx	0
 𨓅	wnrd	0
+𫐰	wnrd	0
 𨕉	wnrx	0
 宿主	wnsc	2530000
 邀请	wnsc	59000000
@@ -92393,14 +96189,17 @@ encoder:
 𥦽	woai	0
 䆟	woaj	3610
 䢔	woaj	3910
+𫐮	woal	0
 窿	woam	1400000
 𥦴	woao	0
 𥥍	woau	0
 𥥋	woax	0
+𫐡	woax	0
 窍	woaz	7130000
 窐	wobb	172000
 窪	wobb	2670000
 𥧀	wobb	0
+𪥔	wobg	0
 容城	wobh	254000
 逾越	wobh	3060000
 空	wobi	488000000
@@ -92495,6 +96294,7 @@ encoder:
 䆖	wogz	4030
 窒	wohb	3540000
 𥥻	wohb	0
+𫁔	wohc	0
 𥤥	wohd	0
 穿	wohi	154000000
 𥥰	wohs	0
@@ -92553,6 +96353,8 @@ encoder:
 𥦗	wojw	0
 𥧁	wojw	0
 𥩇	wojw	0
+𪬛	wojw	0
+𪠮	wojx	0
 𥨪	wojy	0
 䆗	wojz	3720
 容量	woka	99400000
@@ -92574,6 +96376,7 @@ encoder:
 𥥉	woki	0
 竂	wokk	39100
 𥨕	wokm	0
+𫁐	wokm	0
 𥦕	woko	0
 𨒛	woko	0
 䆞	wokr	3990
@@ -92644,6 +96447,7 @@ encoder:
 𥧦	womj	0
 𥦉	womk	0
 𥧎	womk	0
+𫁍	womk	0
 䆝	woml	3850
 䆷	woml	3710
 䆾	woml	3600
@@ -92661,6 +96465,7 @@ encoder:
 𥨚	womy	0
 䆧	womz	3850
 䆤	wonc	4120
+𫁓	wonc	0
 𥩄	wond	0
 𨑸	wond	0
 䆿	wonf	4500
@@ -92682,6 +96487,7 @@ encoder:
 𥦊	woob	0
 𥧚	woob	0
 𥨁	woob	0
+𫐩	woob	0
 𡨙	wood	0
 𨑹	wood	0
 窣	wooe	170000
@@ -92692,10 +96498,12 @@ encoder:
 𧯉	wooj	0
 𥨹	wook	0
 𨗀	wook	0
+𪧗	wook	0
 窥	wool	18500000
 窺	wool	3700000
 𥥸	woom	0
 𥨅	woom	0
+𫁏	woom	0
 窔	wooo	394000
 𥤹	wooo	0
 𥦑	wooo	0
@@ -92753,6 +96561,7 @@ encoder:
 𥥱	worr	0
 𨔩	worr	0
 𪄑	worr	0
+𫁜	worr	0
 穸	wors	257000
 𥤯	wors	0
 𥦱	wors	0
@@ -92785,6 +96594,7 @@ encoder:
 𥥴	wosr	0
 䆫	wosw	3800
 䆡	wosx	4310
+𫁊	wosy	0
 窲	wote	26000
 𥦖	wote	0
 𥧇	wote	0
@@ -92816,6 +96626,7 @@ encoder:
 䆮	wowx	3830
 𥧿	wowx	0
 𥨊	wowx	0
+𫁘	wowx	0
 𥥁	wowz	0
 𥦐	woxa	0
 𥧬	woxb	0
@@ -92872,6 +96683,7 @@ encoder:
 𥥅	woyz	0
 𥥈	woyz	0
 𥦷	woyz	0
+𫁎	woyz	0
 梥	wozf	26200
 𥨀	wozi	0
 𥧺	wozj	0
@@ -92904,6 +96716,7 @@ encoder:
 逓	wpbl	85200
 祈求	wpdv	5040000
 遥控	wpdw	15900000
+𫑇	wpec	0
 遁	wpel	6120000
 近期	wpeq	96700000
 遥	wpez	21100000
@@ -92953,14 +96766,17 @@ encoder:
 𨖠	wpwl	0
 宾客	wpwr	3870000
 𨘅	wpxb	0
+𫐭	wpxb	0
 𨗿	wpxo	0
 返	wpxs	70000000
 𨘓	wpxw	0
 𨔕	wpxx	0
 宾阳	wpyk	613000
+𫐺	wpyq	0
 𨖿	wpyu	0
 𨗽	wpzq	0
 返乡	wpzz	2070000
+𫑁	wqaj	0
 𨖢	wqcc	0
 冗长	wqch	1750000
 𨑙	wqda	0
@@ -93057,6 +96873,8 @@ encoder:
 逸	wrrs	33600000
 逸	wrrs	0
 𨗧	wrrs	0
+𫐶	wrrz	0
+𫐻	wrrz	0
 迎新	wrsf	7460000
 客商	wrsu	8010000
 𨒟	wrtd	0
@@ -93103,6 +96921,7 @@ encoder:
 𨖣	wrzs	0
 农奴	wrzx	531000
 𨘺	wrzz	0
+𫑂	wrzz	0
 礻	wsaa	274000
 𥛉	wsac	0
 𥘏	wsae	0
@@ -93125,6 +96944,7 @@ encoder:
 𥘞	wsax	0
 𥚜	wsay	0
 𥜊	wsaz	0
+𫀕	wsaz	0
 𥙞	wsbb	0
 𥛇	wsbb	0
 𥛈	wsbb	0
@@ -93143,6 +96963,7 @@ encoder:
 𥜃	wsbu	0
 䄊	wsbw	5390
 祎	wsby	492000
+𫑕	wsby	0
 祛	wsbz	12200000
 𥘟	wsbz	0
 𥘡	wsbz	0
@@ -93151,6 +96972,7 @@ encoder:
 祷	wscd	3060000
 𥙟	wsce	0
 𨔉	wsci	0
+𫀇	wsck	0
 䄝	wscn	4290
 禡	wscu	64500
 𥚅	wscz	0
@@ -93216,6 +97038,7 @@ encoder:
 祬	wshb	44400
 祴	wshe	597000
 𥜤	wshh	0
+𫀐	wshi	0
 房东	wshk	10400000
 䄀	wshm	19300
 禨	wsho	45800
@@ -93228,6 +97051,7 @@ encoder:
 𥚚	wsih	0
 祉	wsii	1590000
 𥛨	wsii	0
+𫀅	wsij	0
 𥙺	wsik	0
 𥛳	wsik	0
 䄔	wsil	5100
@@ -93255,6 +97079,7 @@ encoder:
 𥙙	wsjl	0
 𥛍	wsjl	0
 𥛒	wsjl	0
+𫀠	wsjl	0
 禕	wsjm	168000
 𨘿	wsjn	0
 𥚄	wsjo	0
@@ -93280,6 +97105,7 @@ encoder:
 禪	wske	3880000
 禫	wske	88200
 遧	wske	32400
+𫀑	wske	0
 祼	wskf	2150000
 禯	wskg	40100
 𥔻	wskg	0
@@ -93293,6 +97119,7 @@ encoder:
 𥚕	wskk	0
 𥛰	wskk	0
 𥛼	wskk	0
+𫀚	wskl	0
 𥘤	wskm	0
 𥘷	wskm	0
 𥛹	wskm	0
@@ -93310,10 +97137,12 @@ encoder:
 𥙧	wskz	0
 𥚥	wskz	0
 𥛧	wskz	0
+𫀓	wskz	0
 𥚳	wslb	0
 祖	wslc	41100000
 𥚼	wslc	0
 𥘝	wsld	0
+𫀈	wsld	0
 䄃	wslg	5860
 𥚻	wslg	0
 房贴	wsli	111000
@@ -93323,10 +97152,13 @@ encoder:
 𨙎	wslk	0
 䄣	wsll	5820
 房山	wsll	2660000
+𫀌	wsll	0
 𥛄	wslm	0
+𫀢	wsln	0
 祸	wslo	35300000
 禛	wslo	271000
 𥛺	wslo	0
+𫀃	wslo	0
 視	wslr	65400000
 视	wslr	322000000
 𥜰	wslt	0
@@ -93345,6 +97177,7 @@ encoder:
 𥘥	wsme	0
 𥘪	wsme	0
 𥛏	wsme	0
+𫀣	wsme	0
 䄏	wsmg	4950
 祅	wsmg	853000
 䄉	wsmh	5600
@@ -93357,6 +97190,8 @@ encoder:
 房租	wsml	6650000
 𥛯	wsml	0
 𥜓	wsml	0
+𫀉	wsml	0
+𫑉	wsml	0
 䢟	wsmo	3430
 祑	wsmo	84200
 遃	wsmp	19100
@@ -93364,6 +97199,7 @@ encoder:
 祣	wsmr	48000
 𪄬	wsmr	0
 𥘜	wsms	0
+𫀍	wsms	0
 遊	wsmy	50500000
 𥙁	wsmy	0
 𥙢	wsmy	0
@@ -93381,6 +97217,8 @@ encoder:
 房价	wsno	20400000
 迹	wsno	14400000
 𥛩	wsno	0
+𫀖	wsnr	0
+𫀗	wsnr	0
 𥛲	wsnu	0
 𥙢	wsnx	0
 𥛭	wsnx	0
@@ -93404,6 +97242,7 @@ encoder:
 𥚒	wsoo	0
 𥜋	wsoo	0
 𨘰	wsoo	0
+𫀋	wsoo	0
 𥘼	wsop	0
 祾	wsor	59200
 禝	wsor	38500
@@ -93440,6 +97279,7 @@ encoder:
 𡎺	wsrb	0
 𥚊	wsrb	0
 𥛝	wsrc	0
+𫀔	wsrf	0
 祇	wsrh	3830000
 迹象	wsrj	15300000
 𥘮	wsrj	0
@@ -93461,6 +97301,7 @@ encoder:
 𥘨	wsro	0
 𥚯	wsro	0
 𥛙	wsro	0
+𫀒	wsro	0
 禙	wsrq	114000
 䃾	wsrr	4540
 𥘇	wsrr	0
@@ -93479,6 +97320,7 @@ encoder:
 𥙅	wssl	0
 房产	wssm	188000000
 䄙	wsso	4420
+𫀊	wssr	0
 𥘸	wssu	0
 𥚆	wssw	0
 𥘞	wssx	0
@@ -93522,6 +97364,7 @@ encoder:
 𥙇	wswr	0
 𥜚	wswr	0
 䄘	wsws	4720
+𫐼	wsws	0
 祲	wswx	75500
 𥜐	wswx	0
 𥘚	wswz	0
@@ -93532,9 +97375,11 @@ encoder:
 禟	wsxj	104000
 𥜢	wsxj	0
 𥜮	wsxj	0
+𫀞	wsxj	0
 禄	wsxk	10600000
 𥛽	wsxk	0
 𥜑	wsxk	0
+𫀘	wsxk	0
 𥚵	wsxl	0
 𥚏	wsxo	0
 祓	wsxs	478000
@@ -93543,6 +97388,7 @@ encoder:
 䄌	wsxx	4960
 𨖅	wsxy	0
 𥛭	wsxz	0
+𫀛	wsxz	0
 房子	wsya	65700000
 𥘆	wsyd	0
 𥘉	wsyd	0
@@ -93559,6 +97405,7 @@ encoder:
 𥘬	wsyn	0
 𥜔	wsyn	0
 𥘳	wsys	0
+𪬂	wsyw	0
 𥙈	wsyx	0
 𥙥	wsyx	0
 祀	wsyy	2470000
@@ -93591,6 +97438,7 @@ encoder:
 𥚝	wszq	0
 𥘍	wszt	0
 𥙪	wszu	0
+𫀡	wszx	0
 𨕕	wszy	0
 禌	wszz	107000
 𥘢	wszz	0
@@ -93611,6 +97459,7 @@ encoder:
 褆	wtai	222000
 𧘔	wtai	0
 𧘿	wtai	0
+𫐤	wtai	0
 袔	wtaj	87900
 袷	wtaj	898000
 裿	wtaj	25700
@@ -93680,12 +97529,15 @@ encoder:
 𧘚	wtbz	0
 𧘢	wtbz	0
 𧘧	wtbz	0
+𫋻	wtbz	0
+𫋾	wtbz	0
 襵	wtcc	21200
 𧙫	wtce	0
 𧚂	wtce	0
 𧛇	wtch	0
 𧜅	wtcj	0
 襀	wtcl	26500
+𫌀	wtcl	0
 𧟓	wtcm	0
 𧜧	wtcn	0
 𧚫	wtcq	0
@@ -93696,6 +97548,7 @@ encoder:
 襊	wtcx	23900
 𧚥	wtcx	0
 𧜮	wtcx	0
+𫌘	wtcx	0
 𧚊	wtcz	0
 𧛔	wtcz	0
 遮掩	wtdg	8240000
@@ -93703,6 +97556,7 @@ encoder:
 遮挡	wtdk	3110000
 衬	wtds	10900000
 襅	wteb	30400
+𫌊	wteb	0
 褀	wtec	64800
 䢏	wted	3460
 𧜿	wtef	0
@@ -93743,6 +97597,7 @@ encoder:
 𧛮	wtfb	0
 䙏	wtfd	5670
 襦	wtfg	684000
+𫌕	wtfi	0
 𧚏	wtfj	0
 𧜦	wtfj	0
 襋	wtfl	22800
@@ -93751,6 +97606,7 @@ encoder:
 襴	wtfl	49900
 襽	wtfl	20600
 𧙞	wtfl	0
+𫋿	wtfm	0
 𧜁	wtfq	0
 䘤	wtfs	4320
 实惠	wtfw	18100000
@@ -93758,6 +97614,7 @@ encoder:
 实权	wtfx	1220000
 䙅	wtfz	5440
 袏	wtgb	443000
+𫌄	wtgc	0
 褥	wtgd	2260000
 𧘬	wtge	0
 𧜒	wtge	0
@@ -93771,6 +97628,7 @@ encoder:
 𧙛	wtgl	0
 襻	wtgm	217000
 䘠	wtgo	13400
+𫋸	wtgq	0
 𧛍	wtgr	0
 袱	wtgs	671000
 𧘹	wtgs	0
@@ -93788,6 +97646,7 @@ encoder:
 裓	wthe	52500
 䘬	wthg	3880
 𧜆	wthg	0
+𫋹	wthg	0
 䙁	wthh	5240
 𧘪	wthi	0
 𧙅	wthj	0
@@ -93795,12 +97654,14 @@ encoder:
 𧝊	wthk	0
 𧛢	wthm	0
 𧝞	wtho	0
+𫋲	wtho	0
 𧜳	wthr	0
 䘝	wths	3640
 襪	wths	8750000
 𧙠	wths	0
 裢	wthw	149000
 𧘸	wthz	0
+𫌐	wthz	0
 𧘕	wtia	0
 补	wtid	73400000
 𧝲	wtig	0
@@ -93857,6 +97718,9 @@ encoder:
 裋	wtju	43900
 𧜄	wtju	0
 𧞫	wtju	0
+𫌋	wtju	0
+𫌓	wtju	0
+𫌔	wtju	0
 𧜐	wtjw	0
 𧙊	wtjx	0
 𧜇	wtjy	0
@@ -93881,6 +97745,7 @@ encoder:
 𧝊	wtkh	0
 䘥	wtki	4080
 袖	wtki	32100000
+𫋵	wtki	0
 䙯	wtkj	4150
 裮	wtkk	31500
 褿	wtkk	23400
@@ -93890,6 +97755,7 @@ encoder:
 𧞭	wtkk	0
 𧟂	wtkk	0
 𧟔	wtkk	0
+𫌑	wtkk	0
 䘷	wtkl	3930
 褞	wtkl	204000
 𧛕	wtkl	0
@@ -93944,6 +97810,7 @@ encoder:
 䙬	wtlz	4220
 褵	wtlz	95000
 𧞵	wtlz	0
+𫌁	wtlz	0
 𨕾	wtma	0
 衽	wtmb	891000
 袵	wtmb	58300
@@ -93982,11 +97849,13 @@ encoder:
 𧜃	wtmy	0
 𧚀	wtmz	0
 𧚃	wtmz	0
+𫌂	wtmz	0
 实例	wtna	51800000
 裑	wtnc	299000
 袝	wtnd	133000
 裫	wtnd	19400
 𧛼	wtnd	0
+𫌗	wtnd	0
 裨	wtne	1260000
 实体	wtnf	18300000
 襍	wtnf	103000
@@ -94007,10 +97876,12 @@ encoder:
 𧝈	wtnu	0
 𧞤	wtnx	0
 𧟝	wtnx	0
+𫌆	wtnx	0
 𧘒	wtoa	0
 𧛛	wtoc	0
 𧟑	wtoc	0
 䘹	wtoe	4330
+𫌖	wtof	0
 𧟒	wtog	0
 䙕	wtoi	4000
 实行	wtoi	70600000
@@ -94074,6 +97945,7 @@ encoder:
 衹	wtrh	746000
 䙱	wtri	3780
 襡	wtri	53800
+𫋶	wtri	0
 实名	wtrj	95500000
 袧	wtrj	403000
 袼	wtrj	150000
@@ -94086,6 +97958,8 @@ encoder:
 襸	wtrl	19900
 𧚓	wtrl	0
 𧝝	wtrl	0
+𫋽	wtrl	0
+𫌈	wtrl	0
 袶	wtrm	29000
 𧜨	wtrm	0
 𧚧	wtrn	0
@@ -94093,6 +97967,7 @@ encoder:
 𧞓	wtrn	0
 裼	wtro	211000
 𨒮	wtro	0
+𫌅	wtro	0
 褙	wtrq	211000
 袳	wtrr	34000
 裩	wtrr	47100
@@ -94137,6 +98012,7 @@ encoder:
 𧜢	wtsw	0
 衿	wtsx	4190000
 𧚅	wtsx	0
+𫋳	wtsy	0
 𧚪	wtsz	0
 𧘞	wtte	0
 褲	wttf	11600000
@@ -94161,13 +98037,16 @@ encoder:
 𤇷	wtuo	0
 𨓩	wtuo	0
 裧	wtuu	21000
+𫌉	wtuu	0
 𧝮	wtuw	0
 𧞋	wtux	0
 裷	wtuy	29400
 实数	wtuz	710000
 褛	wtuz	1440000
+𫋺	wtvr	0
 䘢	wtwa	4410
 𧚬	wtwb	0
+𫌌	wtwb	0
 䘺	wtwd	3960
 褌	wtwf	1090000
 褳	wtwf	40700
@@ -94204,6 +98083,7 @@ encoder:
 𧙔	wtxb	0
 𧙻	wtxb	0
 𧜶	wtxb	0
+𫋷	wtxb	0
 𧘥	wtxe	0
 褬	wtxf	23500
 𧜾	wtxf	0
@@ -94216,6 +98096,7 @@ encoder:
 𧚼	wtxj	0
 䘵	wtxk	4640
 襇	wtxk	32300
+𫌙	wtxk	0
 𧚔	wtxl	0
 𧛰	wtxl	0
 𧝴	wtxl	0
@@ -94235,6 +98116,7 @@ encoder:
 𧛋	wtxw	0
 𧞎	wtxw	0
 裰	wtxx	249000
+𫌇	wtxx	0
 𧜛	wtxy	0
 褄	wtxz	98900
 𧜱	wtxz	0
@@ -94275,6 +98157,7 @@ encoder:
 䙎	wtzg	4370
 褖	wtzg	463000
 𧚴	wtzi	0
+𫌃	wtzi	0
 袽	wtzj	82100
 䙒	wtzk	5030
 𧛾	wtzl	0
@@ -94288,6 +98171,7 @@ encoder:
 䘪	wtzr	3860
 䙠	wtzr	4250
 𧘾	wtzr	0
+𫌒	wtzr	0
 𧞌	wtzu	0
 𧞦	wtzu	0
 𧟆	wtzu	0
@@ -94328,6 +98212,7 @@ encoder:
 送餐	wuir	946000
 道上	wuiv	5770000
 逆回	wujj	92700
+𫑔	wujn	0
 㘏	wujr	4580
 迷路	wujr	8330000
 道路	wujr	151000000
@@ -94335,6 +98220,7 @@ encoder:
 送别	wujy	2560000
 道光	wukg	2040000
 遂昌	wukk	782000
+𫐽	wukm	0
 遵照	wuky	9230000
 送电	wukz	915000
 𨒾	wuli	0
@@ -94407,6 +98293,7 @@ encoder:
 递加	wuyj	64500
 递	wuyz	27600000
 逆	wuzi	81200000
+𫐷	wuzm	0
 送给	wuzo	40400000
 𨕜	wuzo	0
 遡	wuzq	478000
@@ -94475,6 +98362,7 @@ encoder:
 𠖑	wwbk	0
 𠖚	wwbk	0
 𠖟	wwbk	0
+𫐱	wwbk	0
 𠖫	wwbl	0
 𠕻	wwbr	0
 𠖣	wwbu	0
@@ -94484,6 +98372,8 @@ encoder:
 密云	wwbz	5660000
 𠖖	wwcu	0
 冣	wwcx	178000
+𪞔	wwcx	0
+𪪹	wwde	0
 䢘	wwds	3730
 密探	wwdw	1760000
 𠖉	wweg	0
@@ -94515,6 +98405,7 @@ encoder:
 𦊅	wwgs	0
 𤏷	wwgu	0
 密码	wwgx	1360000000
+𪞕	wwgy	0
 军	wwhe	142000000
 皲	wwhx	640000
 密切	wwhy	49400000
@@ -94528,12 +98419,15 @@ encoder:
 𢻼	wwix	0
 𢼀	wwix	0
 𢼐	wwix	0
+𪞑	wwji	0
 冨	wwjk	1910000
 𠖐	wwjk	0
 密匙	wwka	281000
 𠔸	wwke	0
 𢍔	wwke	0
 𦋐	wwke	0
+𫅃	wwke	0
+𪳨	wwkf	0
 𠖇	wwkg	0
 𨕫	wwki	0
 𣍍	wwkk	0
@@ -94553,6 +98447,7 @@ encoder:
 𢚞	wwlw	0
 𠖗	wwlx	0
 密县	wwlz	242000
+𫑈	wwlz	0
 㓃	wwmh	4970
 𨕠	wwmi	0
 𨖄	wwmj	0
@@ -94566,6 +98461,7 @@ encoder:
 鹤	wwnr	46100000
 𠕿	wwnr	0
 𣤇	wwnr	0
+𫛏	wwnr	0
 密信	wwns	287000
 𠕳	wwod	0
 罙	wwof	89500
@@ -94583,8 +98479,10 @@ encoder:
 密令	wwow	845000
 鼆	wwow	26000
 𠖝	wwow	0
+𪞓	wwox	0
 鄍	wwoy	45000
 𨔎	wwoy	0
+𪞐	wwoy	0
 𠕺	wwoz	0
 密钥	wwpq	1300000
 𠖒	wwpr	0
@@ -94604,6 +98502,7 @@ encoder:
 𨑻	wwrd	0
 𦉲	wwre	0
 䪴	wwrg	3550
+𫖫	wwrg	0
 农	wwrh	191000000
 沊	wwrk	34600
 𠛌	wwrk	0
@@ -94620,6 +98519,7 @@ encoder:
 鸩	wwrr	479000
 𣢌	wwrr	0
 𩵫	wwrr	0
+𫚲	wwrr	0
 冤	wwrs	9370000
 𠕸	wwrs	0
 冩	wwru	1210000
@@ -94628,6 +98528,7 @@ encoder:
 褪色	wwry	4750000
 邥	wwry	31100
 𠠹	wwry	0
+𪞏	wwry	0
 㓂	wwrz	4540
 𠖜	wwsb	0
 密谋	wwse	2330000
@@ -94638,6 +98539,7 @@ encoder:
 密谈	wwsu	587000
 𠖃	wwsu	0
 密闭	wwtd	2520000
+𪞒	wwte	0
 密度	wwtv	21500000
 冞	wwuf	192000
 邃	wwug	880000
@@ -94870,6 +98772,7 @@ encoder:
 字距	wyjh	249000
 边距	wyjh	386000
 官员	wyjl	48100000
+𫑊	wyjl	0
 初中	wyjv	77500000
 辽中	wyjv	425000
 字量	wyka	37000
@@ -94898,6 +98801,7 @@ encoder:
 𨔌	wyps	0
 初犯	wyqy	499000
 迅猛	wyqy	11200000
+𫐪	wyrk	0
 官邸	wyrs	4160000
 边贸	wyrs	768000
 逊色	wyry	8540000
@@ -95166,6 +99070,7 @@ encoder:
 登场	xaby	34300000
 登报	xady	750000
 登基	xaeb	1800000
+𫘛	xaed	0
 登载	xaeh	4900000
 马克	xaej	11000000
 登机	xafq	2210000
@@ -95227,6 +99132,7 @@ encoder:
 垦荒	xbes	237000
 慰劳	xbew	829000
 𢻀	xbex	0
+𫄽	xbez	0
 𢑤	xbfj	0
 𢑧	xbfj	0
 颈椎	xbfn	4740000
@@ -95254,6 +99160,7 @@ encoder:
 𤲿	xbjk	0
 𢽤	xbjm	0
 𦘤	xbjo	0
+𪠬	xbjx	0
 晝	xbka	1850000
 畫	xbka	57400000
 𤲯	xbka	0
@@ -95290,12 +99197,15 @@ encoder:
 𩒔	xblg	0
 帇	xbli	250000
 𥁞	xblk	0
+𪟖	xblk	0
 㞪	xbll	3780
 𢽰	xblm	0
+𪧾	xbln	0
 𦐯	xblo	0
 𧶁	xblo	0
 𣃏	xblp	0
 𪂪	xblr	0
+𫛆	xblr	0
 𢃳	xbly	0
 𡞒	xblz	0
 𦘚	xblz	0
@@ -95317,6 +99227,7 @@ encoder:
 歗	xbnr	25900
 鷫	xbnr	36400
 粛	xbnu	454000
+𪬵	xbnw	0
 彟	xbnx	77700
 彠	xbnx	41600
 𢑫	xbob	0
@@ -95335,6 +99246,7 @@ encoder:
 𦄳	xboz	0
 𢑵	xbpk	0
 𡬶	xbqd	0
+𪧹	xbqd	0
 𢑿	xbqf	0
 𣕡	xbqf	0
 𠙛	xbqq	0
@@ -95377,8 +99289,10 @@ encoder:
 层层	xbxb	9600000
 𢑑	xbxb	0
 𦘞	xbxb	0
+𪹂	xbxb	0
 䫗	xbxg	3200
 𩒸	xbxg	0
+𪩺	xbxg	0
 𧎂	xbxi	0
 𠜘	xbxk	0
 𢑨	xbxk	0
@@ -95398,6 +99312,7 @@ encoder:
 叚	xbxx	201000
 𢑰	xbxx	0
 𣆸	xbxx	0
+𪠪	xbxx	0
 𦐱	xbxy	0
 𨛃	xbxy	0
 𦘣	xbyb	0
@@ -95506,6 +99421,8 @@ encoder:
 寻求	xddv	83200000
 𨳼	xdeb	0
 𨶱	xdeb	0
+𫔥	xdec	0
+𫔜	xdej	0
 𨵴	xdel	0
 閧	xdeo	180000
 𨶷	xdeo	0
@@ -95531,6 +99448,7 @@ encoder:
 𨶶	xdgb	0
 𨳓	xdgd	0
 𨷼	xdgg	0
+𫔫	xdgg	0
 𨳫	xdgi	0
 𨳾	xdgj	0
 𨵫	xdgj	0
@@ -95572,6 +99490,8 @@ encoder:
 𨶴	xdjb	0
 閫	xdjf	1100000
 𨵓	xdji	0
+𫔚	xdji	0
+𫔢	xdji	0
 閭	xdjj	1190000
 闆	xdjj	1150000
 𨷰	xdjj	0
@@ -95596,6 +99516,7 @@ encoder:
 闦	xdju	22000
 𨶮	xdju	0
 𨶿	xdju	0
+𫔡	xdju	0
 𨴽	xdjw	0
 䦔	xdka	3680
 𨵀	xdka	0
@@ -95611,9 +99532,11 @@ encoder:
 𨴝	xdke	0
 𨶤	xdke	0
 𨵚	xdkf	0
+𫔩	xdkg	0
 閘	xdki	1620000
 𨳸	xdki	0
 𨴁	xdki	0
+𫔞	xdki	0
 閶	xdkk	62800
 𨵝	xdkk	0
 𨶺	xdkk	0
@@ -95634,6 +99557,7 @@ encoder:
 閖	xdkv	106000
 寻常	xdkw	13800000
 寻思	xdkw	3410000
+𫔪	xdkw	0
 䦰	xdkz	3350
 閹	xdkz	3930000
 𨴄	xdkz	0
@@ -95678,6 +99602,7 @@ encoder:
 𨴬	xdmj	0
 䦭	xdmk	3120
 𡮤	xdmk	0
+𫔣	xdmk	0
 䦗	xdml	3290
 寻租	xdml	1010000
 寻衅	xdml	601000
@@ -95702,6 +99627,7 @@ encoder:
 𨵹	xdne	0
 闑	xdnf	29200
 閥	xdnh	2150000
+𫔟	xdnh	0
 閵	xdni	1990000
 𨳢	xdni	0
 闎	xdnk	22600
@@ -95710,6 +99636,7 @@ encoder:
 䦝	xdno	3450
 𨴧	xdnp	0
 䦧	xdnr	3710
+𫔛	xdnr	0
 𨶲	xdnu	0
 𨳭	xdnx	0
 𨷍	xdnz	0
@@ -95733,11 +99660,13 @@ encoder:
 䦵	xdoo	3510
 閦	xdoo	71800
 𨷬	xdoo	0
+𫔧	xdoo	0
 𨶪	xdop	0
 䦲	xdos	3750
 閼	xdot	1410000
 閝	xdow	35100
 𨶟	xdox	0
+𫔨	xdox	0
 闀	xdoy	1030000
 𨳚	xdoy	0
 𨴶	xdoy	0
@@ -95778,6 +99707,7 @@ encoder:
 𨵶	xdro	0
 𨴢	xdrr	0
 𨶙	xdrr	0
+𫔠	xdrt	0
 闧	xdrw	29200
 𨷟	xdrw	0
 𨷺	xdrw	0
@@ -95787,6 +99717,7 @@ encoder:
 𨶠	xdrz	0
 誾	xdsa	104000
 𨷙	xdsb	0
+𫔤	xdsb	0
 𨳳	xdsc	0
 𨴲	xdse	0
 𨳑	xdsh	0
@@ -95973,6 +99904,8 @@ encoder:
 𥁝	xglk	0
 颇具	xglo	6160000
 𨾕	xgni	0
+𫘪	xgnk	0
+𫘭	xgoo	0
 骑兵	xgpo	7290000
 鴂	xgrz	58300
 颇为	xguv	10400000
@@ -96030,6 +99963,7 @@ encoder:
 㿹	xibu	5860
 皮球	xicd	2640000
 𤿬	xice	0
+𪾉	xicy	0
 𤿋	xidm	0
 皮鞋	xieb	11600000
 𠦁	xied	0
@@ -96047,6 +99981,7 @@ encoder:
 𥀸	xifl	0
 皮棉	xifn	443000
 疏松	xifo	3470000
+𪾈	xifz	0
 㿵	xigg	5300
 𠠉	xigk	0
 臩	xign	79600
@@ -96078,11 +100013,13 @@ encoder:
 𥀤	xils	0
 㿸	xilx	6930
 皮毛	ximh	5380000
+𪾇	ximo	0
 蛋白	xink	18000000
 皮货	xinr	259000
 皮质	xipe	7190000
 皮肤	xiqb	60000000
 㿪	xiqs	8340
+𪾆	xiri	0
 疏解	xirl	419000
 疏忽	xiro	6740000
 𤿦	xirr	0
@@ -96127,6 +100064,7 @@ encoder:
 壁画	xjak	4790000
 𩏡	xjal	0
 𩏱	xjal	0
+𫖍	xjal	0
 𩎟	xjbk	0
 𩎨	xjbk	0
 𩏆	xjbk	0
@@ -96192,6 +100130,7 @@ encoder:
 𩏘	xjln	0
 䪏	xjlo	3370
 䯄	xjlo	3320
+𫖏	xjlx	0
 韋	xjmb	9220000
 韔	xjmc	56300
 韚	xjme	21000
@@ -96278,7 +100217,9 @@ encoder:
 𩎢	xjzx	0
 壁垒	xjzz	5360000
 驶出	xjzz	1090000
+𫘣	xkae	0
 𨋬	xkaf	0
+𫘨	xkai	0
 𠜉	xkak	0
 脀	xkaq	38700
 烝	xkau	239000
@@ -96304,10 +100245,12 @@ encoder:
 𩨎	xkeo	0
 剥落	xkev	1570000
 承蒙	xkew	1740000
+𫏵	xkfk	0
 丞相	xkfl	2420000
 录相	xkfl	595000
 尿检	xkfo	292000
 剥夺	xkgd	8040000
+𫘡	xkgr	0
 𩧨	xkia	0
 尿频	xkik	1130000
 𢾧	xkix	0
@@ -96332,6 +100275,7 @@ encoder:
 承受	xkpw	40100000
 录象	xkrj	7070000
 犀角	xkrl	302000
+𫘥	xkrr	0
 尿急	xkrx	943000
 承包	xkry	19300000
 𦫠	xkry	0
@@ -96350,6 +100294,7 @@ encoder:
 届满	xkve	2070000
 尿液	xkvs	2100000
 驲	xkvv	41000
+𫘫	xkwz	0
 隶属	xkxm	7600000
 骡子	xkya	1070000
 承办	xkyo	50700000
@@ -96377,6 +100322,7 @@ encoder:
 眉毛	xlmh	9140000
 观看	xlml	73100000
 勇气	xlmy	31800000
+𫘱	xlnl	0
 观众	xloo	36100000
 观念	xlos	43900000
 勇猛	xlqy	3950000
@@ -96404,6 +100350,7 @@ encoder:
 䪳	xmag	3580
 頵	xmag	53900
 𠹩	xmag	0
+𫖳	xmag	0
 𢧃	xmah	0
 𠧬	xmai	0
 𡰨	xmai	0
@@ -96416,9 +100363,11 @@ encoder:
 𢂫	xmal	0
 𢃆	xmal	0
 𢑺	xmal	0
+𪨉	xmal	0
 𢽏	xmam	0
 𣀆	xmam	0
 𦢱	xmaq	0
+𪱛	xmaq	0
 裠	xmar	36200
 鵘	xmar	21900
 𣩩	xmar	0
@@ -96454,6 +100403,7 @@ encoder:
 𡲌	xmbp	0
 㞡	xmbr	3680
 鷵	xmbr	24200
+𪴫	xmbr	0
 𨐧	xmbs	0
 𨐬	xmbs	0
 𪑐	xmbu	0
@@ -96487,6 +100437,7 @@ encoder:
 熨	xmdu	3480000
 慰	xmdw	9980000
 展	xmeh	307000000
+𪨛	xmeh	0
 居	xmej	155000000
 𡳰	xmej	0
 𠝭	xmek	0
@@ -96506,18 +100457,21 @@ encoder:
 㞖	xmfl	3980
 属相	xmfl	1850000
 尾椎	xmfn	164000
+𪨜	xmfs	0
 屚	xmfv	24800
 𡲱	xmge	0
 屒	xmgh	27900
 𡲃	xmgh	0
 𡲫	xmgl	0
 骄	xmgn	9950000
+𪨗	xmgn	0
 𡳔	xmgp	0
 𡱂	xmgq	0
 𡱰	xmgq	0
 𡰽	xmgr	0
 㞘	xmgs	4380
 𡳁	xmgs	0
+𪨐	xmgs	0
 𠭝	xmgx	0
 𥖑	xmgx	0
 𡱐	xmgy	0
@@ -96526,6 +100480,7 @@ encoder:
 𧎰	xmhi	0
 𨃨	xmhj	0
 剭	xmhk	376000
+𪨞	xmhl	0
 𣪵	xmhq	0
 𡲽	xmhr	0
 𡳅	xmhr	0
@@ -96543,6 +100498,7 @@ encoder:
 𡱇	xmij	0
 劚	xmik	271000
 𡳵	xmik	0
+𪨏	xmik	0
 属	xmil	200000000
 𡲇	xmil	0
 𡳆	xmil	0
@@ -96559,6 +100515,7 @@ encoder:
 𢾂	xmix	0
 𣀻	xmix	0
 𡳚	xmja	0
+𪨒	xmjb	0
 𧲜	xmjg	0
 𩒫	xmjg	0
 𩓛	xmjg	0
@@ -96570,6 +100527,7 @@ encoder:
 屫	xmjl	18900
 𡲻	xmjl	0
 𡳯	xmjl	0
+𪨓	xmjl	0
 𡱶	xmjn	0
 𡳎	xmjn	0
 咫	xmjo	992000
@@ -96593,6 +100551,7 @@ encoder:
 屪	xmkk	31700
 𡲘	xmkk	0
 𣍁	xmkk	0
+𪨟	xmkk	0
 𡳬	xmkl	0
 犀	xmkm	4770000
 𡱳	xmkm	0
@@ -96612,6 +100571,7 @@ encoder:
 𡳒	xmkz	0
 𡳟	xmkz	0
 𤳰	xmkz	0
+𪽗	xmkz	0
 𡰯	xmli	0
 㔉	xmlk	4470
 刷	xmlk	44400000
@@ -96627,11 +100587,13 @@ encoder:
 鹛	xmlr	181000
 𪅱	xmlr	0
 𦎨	xmlu	0
+𫐹	xmlw	0
 㕞	xmlx	4310
 郿	xmly	131000
 𡳱	xmlz	0
 𡳲	xmlz	0
 𡱁	xmma	0
+𪨋	xmmb	0
 屗	xmmd	42000
 𡱚	xmme	0
 𡱱	xmmg	0
@@ -96639,6 +100601,7 @@ encoder:
 𡱫	xmmh	0
 𠧮	xmmi	0
 𡳸	xmmi	0
+𪨘	xmmj	0
 㓾	xmmk	4170
 㞙	xmmk	3790
 𡰹	xmmk	0
@@ -96647,6 +100610,8 @@ encoder:
 𡲉	xmmk	0
 𡳕	xmmk	0
 𩡛	xmmk	0
+𪨖	xmmk	0
+𪨝	xmmk	0
 𡲤	xmml	0
 𡲔	xmmm	0
 𡲥	xmmm	0
@@ -96682,8 +100647,12 @@ encoder:
 𦤋	xmnl	0
 𡳺	xmnn	0
 𦧃	xmnn	0
+𫇂	xmno	0
+𪨍	xmnq	0
 𡳖	xmnr	0
+𪨠	xmnu	0
 𡳑	xmob	0
+𪨙	xmob	0
 𡰦	xmod	0
 𩧭	xmod	0
 屜	xmoe	91900
@@ -96691,11 +100660,13 @@ encoder:
 𡳥	xmoe	0
 㞞	xmoi	3900
 𤂞	xmok	0
+𪽛	xmok	0
 𡲜	xmol	0
 𡲰	xmom	0
 臋	xmoo	29900
 𡱎	xmoo	0
 𦡜	xmoo	0
+𪨊	xmoo	0
 𡲟	xmop	0
 𡳇	xmop	0
 㞕	xmoq	4350
@@ -96770,9 +100741,11 @@ encoder:
 壁	xmsb	63500000
 璧	xmsc	7470000
 𤩹	xmsc	0
+𪨚	xmsc	0
 屖	xmse	29200
 𨐢	xmse	0
 檗	xmsf	2730000
+𪨑	xmsf	0
 礕	xmsg	21400
 𣥉	xmsi	0
 𣦢	xmsi	0
@@ -96830,9 +100803,12 @@ encoder:
 屏	xmue	177000000
 屎	xmuf	24600000
 𡲚	xmuf	0
+𪨌	xmuh	0
 𠠮	xmuk	0
 属性	xmum	53700000
+𪯚	xmum	0
 尸首	xmun	949000
+𪵓	xmuq	0
 𡳉	xmur	0
 羼	xmuu	344000
 𡲴	xmuu	0
@@ -96843,6 +100819,7 @@ encoder:
 屡	xmuz	13700000
 屦	xmuz	309000
 𡱞	xmuz	0
+𪨌	xmuz	0
 𡱕	xmvh	0
 𡱤	xmvm	0
 𡱜	xmvr	0
@@ -96864,6 +100841,7 @@ encoder:
 𣙰	xmxf	0
 𡱣	xmxi	0
 𤴣	xmxi	0
+𪨡	xmxj	0
 𡳩	xmxk	0
 𡳻	xmxl	0
 𡰲	xmxm	0
@@ -96884,10 +100862,13 @@ encoder:
 㞌	xmya	4190
 㞎	xmyi	4160
 尾巴	xmyi	14200000
+𫘞	xmyi	0
 局	xmyj	648000000
 𡲢	xmyj	0
+𪨎	xmyj	0
 𠟉	xmyk	0
 𡱊	xmyk	0
+𪨔	xmyl	0
 甓	xmys	229000
 𤭸	xmys	0
 𡰳	xmyt	0
@@ -96929,6 +100910,7 @@ encoder:
 鶌	xmzr	22200
 𦅴	xmzr	0
 𫜻	xmzr	0
+𫛵	xmzr	0
 𡱄	xmzs	0
 𡲯	xmzx	0
 𠡰	xmzy	0
@@ -96940,6 +100922,7 @@ encoder:
 𡲬	xmzz	0
 𡲶	xmzz	0
 𡳡	xmzz	0
+𪨕	xmzz	0
 难于	xnad	4260000
 难堪	xnbe	4700000
 肃静	xncq	906000
@@ -96990,9 +100973,11 @@ encoder:
 艮	xoaa	5590000
 验	xobv	53400000
 𡬠	xods	0
+𪞋	xoeo	0
 履带	xoew	1330000
 验票	xofb	338000
 䫀	xogo	3910
+𫖱	xogo	0
 履历	xogy	2190000
 验车	xohe	452000
 既	xohr	142000000
@@ -97003,6 +100988,7 @@ encoder:
 验光	xokg	557000
 验算	xoml	340000
 验血	xoml	677000
+𪬒	xomw	0
 𩧦	xond	0
 驳倒	xonh	312000
 验货	xonr	2210000
@@ -97038,13 +101024,16 @@ encoder:
 堲	xoyb	26900
 𨂢	xoyj	0
 𡷦	xoyl	0
+𪟙	xoym	0
 䳭	xoyr	4690
 𪃹	xoyr	0
 验收	xozm	24400000
 𩨏	xpki	0
+𫘬	xpzg	0
 欢喜	xrbj	13800000
 欢声	xrbx	2030000
 欢聚	xrcx	3020000
+𫘦	xrez	0
 鸡西	xrfj	3110000
 尼龙	xrgm	6480000
 鸡东	xrhk	306000
@@ -97078,6 +101067,7 @@ encoder:
 𤼮	xsaz	0
 𥍠	xsaz	0
 𥍣	xsaz	0
+𪪴	xsbe	0
 頚	xsbg	353000
 颈	xsbg	20300000
 𩒍	xsbg	0
@@ -97118,6 +101108,7 @@ encoder:
 𥎘	xsfg	0
 𢎊	xsfh	0
 𢧱	xsfh	0
+𪳫	xsfk	0
 𧠸	xsfl	0
 𣮪	xsfm	0
 歠	xsfr	63600
@@ -97142,6 +101133,7 @@ encoder:
 䳫	xsgr	3850
 𠑻	xsgr	0
 𠬭	xsgr	0
+𫛼	xsgr	0
 𥎤	xsgu	0
 𥎥	xsgu	0
 尺码	xsgx	5300000
@@ -97153,6 +101145,7 @@ encoder:
 𥎕	xshs	0
 𣜽	xshy	0
 𤼸	xsia	0
+𪜝	xsie	0
 𣏗	xsif	0
 預	xsig	44500000
 预	xsig	117000000
@@ -97179,6 +101172,7 @@ encoder:
 𤼯	xsji	0
 𠭎	xsjj	0
 𪉝	xsjo	0
+𪿇	xsjq	0
 𠮄	xsjr	0
 𣤌	xsjr	0
 䜼	xsju	4060
@@ -97193,6 +101187,7 @@ encoder:
 𠚔	xsjz	0
 尽量	xska	65000000
 𩐂	xska	0
+𫘰	xska	0
 䂌	xskb	5190
 𥍽	xskb	0
 𠚫	xskd	0
@@ -97273,6 +101268,7 @@ encoder:
 𩝕	xsmo	0
 鍪	xsmp	78800
 𥍪	xsmp	0
+𪿆	xsmp	0
 𥍟	xsmq	0
 䱯	xsmr	4660
 鶩	xsmr	154000
@@ -97317,6 +101313,7 @@ encoder:
 𢄮	xspl	0
 𠮐	xspn	0
 㔇	xsqk	4510
+𪠰	xsqk	0
 𨩹	xsqp	0
 𥎒	xsqw	0
 癹	xsqx	197000
@@ -97367,8 +101364,10 @@ encoder:
 𠬴	xsuc	0
 𤼷	xsue	0
 𩔞	xsug	0
+𫊫	xsui	0
 㔁	xsuk	6000
 覴	xsul	30200
+𫘮	xsul	0
 㲪	xsum	4450
 𤉺	xsum	0
 𤊮	xsum	0
@@ -97392,6 +101391,7 @@ encoder:
 𥎙	xswl	0
 𠭺	xswm	0
 𥍯	xswx	0
+𪣽	xswy	0
 𡌭	xsxb	0
 𥍹	xsxb	0
 𩢂	xsxc	0
@@ -97428,6 +101428,7 @@ encoder:
 㕛	xsxs	4120
 双	xsxs	288000000
 𤼦	xsxs	0
+𫌵	xsxs	0
 㥤	xsxw	5980
 逫	xsxw	18700
 𥍵	xsxw	0
@@ -97437,6 +101438,7 @@ encoder:
 𤿵	xsxx	0
 𠭋	xsxy	0
 𡥍	xsxy	0
+𪠂	xsxy	0
 𡛒	xsxz	0
 𩥦	xsyc	0
 𣖶	xsyf	0
@@ -97514,6 +101516,7 @@ encoder:
 灵石	xuga	940000
 灵感	xuha	27200000
 𩨂	xujw	0
+𫘯	xulk	0
 屏山	xull	920000
 灵山	xull	2260000
 灵敏	xumz	5130000
@@ -97627,12 +101630,14 @@ encoder:
 预想	xxfl	1160000
 双柏	xxfn	352000
 桑树	xxfx	716000
+𫘝	xxgd	0
 预感	xxha	7610000
 双轨	xxhq	426000
 柔软	xxhr	16300000
 艰巨	xxhx	6290000
 双点	xxij	287000
 双频	xxik	1240000
+𫘧	xxkv	0
 双归	xxkx	41600
 预见	xxlr	7190000
 预购	xxlr	2210000
@@ -97778,6 +101783,7 @@ encoder:
 屈辱	xzgd	4590000
 骖	xzgp	404000
 𧕱	xzii	0
+𫘤	xzma	0
 屈从	xzoo	1500000
 骏	xzor	16400000
 𩨐	xzoz	0
@@ -97798,6 +101804,8 @@ encoder:
 𠄎	yaaa	0
 𤕪	yaaa	0
 𡥚	yaaj	0
+𪦿	yaax	0
+𫕖	yaax	0
 卫士	yaba	7150000
 𡤾	yabd	0
 阿城	yabh	1060000
@@ -97811,6 +101819,8 @@ encoder:
 𨸗	yaed	0
 司南	yael	174000
 𡥰	yael	0
+𪧁	yael	0
+𪦶	yaex	0
 𡦕	yafd	0
 孺	yafg	1200000
 司机	yafq	59300000
@@ -97819,6 +101829,7 @@ encoder:
 𨹙	yagj	0
 𡥢	yagz	0
 陚	yahi	26600
+𪦷	yahm	0
 卫戍	yahs	345000
 阷	yaii	26300
 𢌛	yaii	0
@@ -97831,6 +101842,7 @@ encoder:
 𨺤	yajk	0
 覗	yajl	767000
 隔	yajl	63900000
+𫕆	yajl	0
 㝃	yajr	4530
 陌路	yajr	2290000
 𣱇	yajr	0
@@ -97851,6 +101863,7 @@ encoder:
 卫星	yakm	34200000
 𡦓	yakn	0
 孙	yako	82600000
+𪦾	yako	0
 𡦀	yakq	0
 卫冕	yakr	2570000
 逊	yakw	38000000
@@ -97860,10 +101873,12 @@ encoder:
 孟	yalk	30400000
 𥁂	yalk	0
 隔山	yall	1180000
+𪧄	yaln	0
 孭	yalo	58700
 陃	yalo	57300
 勐	yaly	1120000
 孾	yalz	53100
+𪧀	yalz	0
 卫生	yamc	101000000
 陌生	yamc	43700000
 𡥊	yamh	0
@@ -97877,6 +101892,7 @@ encoder:
 𡥴	yanb	0
 𨾆	yani	0
 陌	yank	3650000
+𪦺	yank	0
 司徒	yaob	2730000
 𡤿	yaod	0
 㜾	yaon	5260
@@ -97901,6 +101917,7 @@ encoder:
 𡥵	yarr	0
 𡦒	yarr	0
 阿訇	yars	542000
+𪦼	yars	0
 𡦗	yaru	0
 司务	yary	67100
 孢	yary	5600000
@@ -97909,10 +101926,13 @@ encoder:
 𡦍	yasc	0
 隔夜	yasn	2030000
 隔离	yaso	18700000
+𪦸	yaso	0
+𪦹	yaso	0
 𡥧	yast	0
 𡦶	yate	0
 隔阂	yats	2360000
 𨸶	yaua	0
+𪪭	yaua	0
 㝆	yauj	4170
 孻	yaul	55600
 子粒	yaus	135000
@@ -97989,10 +102009,12 @@ encoder:
 陕西	ybfj	108000000
 那样	ybfu	171000000
 𩑫	ybgo	0
+𫑏	ybgw	0
 阮咸	ybha	65700
 那些	ybir	162000000
 陵园	ybjb	2730000
 隯	ybjd	39700
+𫖂	ybjk	0
 那里	ybkb	178000000
 那时	ybkd	45200000
 那曲	ybkk	1430000
@@ -98028,9 +102050,13 @@ encoder:
 𨺞	ybuz	0
 陆河	ybva	457000
 陆运	ybwb	517000
+𫑏	ybwg	0
 陆军	ybwh	9860000
 那边	ybwy	27000000
 陡壁	ybxj	240000
+𫕁	ybxj	0
+𪽖	ybyk	0
+𫛀	ybyr	0
 𦐃	ybyy	0
 陆续	ybze	22900000
 陆	ybzi	55100000
@@ -98075,12 +102101,14 @@ encoder:
 𧒢	ydai	0
 𠮞	ydaj	0
 𠮸	ydaj	0
+𪜒	ydaj	0
 乪	ydak	26900
 氹	ydak	283000
 𠃝	ydak	0
 𠃥	ydak	0
 𠃮	ydak	0
 𣄽	ydak	0
+𪜖	ydak	0
 𡶳	ydal	0
 𧠍	ydal	0
 𠃣	ydam	0
@@ -98095,10 +102123,14 @@ encoder:
 𩙱	ydan	0
 𩙺	ydao	0
 鳵	ydar	38000
+𪜐	ydar	0
+𫚮	ydar	0
+𫛊	ydar	0
 𨐾	ydas	0
 飞	ydat	278000000
 𠃧	ydat	0
 𥸦	ydau	0
+𪸍	ydau	0
 迅	ydaw	39200000
 𢝵	ydaw	0
 𩙻	ydaw	0
@@ -98169,6 +102201,7 @@ encoder:
 乙胺	ydqw	652000
 𠣫	ydrj	0
 𠝕	ydrr	0
+𪟓	ydrr	0
 鳭	ydrz	36700
 𠟀	ydrz	0
 丒	ydsa	116000
@@ -98182,8 +102215,10 @@ encoder:
 𤆕	ydsu	0
 忍	ydsw	117000000
 乙方	ydsy	2460000
+𪟀	ydsy	0
 乙类	ydug	590000
 乙烯	yduo	10400000
+𪹑	yduu	0
 乙烷	yduw	975000
 乙炔	ydux	1010000
 导游	ydvs	22000000
@@ -98192,16 +102227,19 @@ encoder:
 𠺥	ydwx	0
 𢖫	ydwz	0
 𠬛	ydxs	0
+𪠤	ydxs	0
 刀子	ydya	5020000
 𠚪	ydyd	0
 𢦝	ydyh	0
 𠝽	ydyk	0
 𥎫	ydym	0
 脋	ydyq	38400
+𫛀	ydyr	0
 刀刃	ydys	3140000
 𤭀	ydys	0
 导弹	ydyu	11100000
 𤉎	ydyu	0
+𪹃	ydyu	0
 䎄	ydyy	4120
 刕	ydyy	89300
 綤	ydyz	27800
@@ -98215,6 +102253,7 @@ encoder:
 𨼣	yeae	0
 𨼿	yeag	0
 𨻇	yeaj	0
+𫕕	yebl	0
 𨹯	yebz	0
 隫	yeel	18000
 𨼞	yeez	0
@@ -98280,6 +102319,7 @@ encoder:
 𨼏	yggl	0
 𨺖	yggr	0
 𨽀	yggs	0
+𫕔	ygkk	0
 𨺍	ygkz	0
 𨻚	ygkz	0
 陇县	yglz	434000
@@ -98289,6 +102329,7 @@ encoder:
 𨻊	ygob	0
 陜	ygoo	383000
 陝	ygoo	434000
+𫕐	ygoo	0
 隳	ygou	403000
 𡟨	ygoz	0
 𨻤	ygoz	0
@@ -98307,6 +102348,7 @@ encoder:
 𡡙	ygqz	0
 𨻢	yguo	0
 𨺕	yguy	0
+𫕇	ygyb	0
 阨	ygyy	636000
 䧅	ygyz	3470
 䧀	ygzs	3620
@@ -98317,6 +102359,7 @@ encoder:
 隇	yhaz	18800
 民工	yhbi	12800000
 陘	yhbi	122000
+𪪯	yhbi	0
 陈规	yhbo	578000
 阵地	yhbv	10700000
 民丰	yhci	466000
@@ -98385,18 +102428,23 @@ encoder:
 卍	yiai	3200000
 𧎱	yiai	0
 𧥔	yiai	0
+𪩬	yiai	0
 也可	yiaj	55100000
 𨽚	yiaj	0
 𠛋	yiak	0
+𪽡	yiak	0
 岊	yial	467000
 𢁑	yial	0
+𪩱	yial	0
 𢽼	yiam	0
 𣀟	yiam	0
 𣬷	yiam	0
 𧤭	yiam	0
+𪩭	yiao	0
 巼	yiar	69000
 𢁋	yiar	0
 𣎞	yiar	0
+𪩮	yiar	0
 𢁍	yiau	0
 𥸿	yiau	0
 𢻷	yiax	0
@@ -98605,6 +102653,7 @@ encoder:
 加以	yjzo	38400000
 隄	ykai	154000
 𢌪	ykai	0
+𫔿	ykai	0
 𨻥	ykak	0
 阳城	ykbh	1340000
 𨼥	ykcx	0
@@ -98614,6 +102663,7 @@ encoder:
 𨹂	ykgr	0
 阳历	ykgy	1400000
 廸	ykia	229000
+𫔼	ykia	0
 𨸺	ykib	0
 𨸬	ykic	0
 阳虚	ykik	774000
@@ -98638,11 +102688,13 @@ encoder:
 阳泉	yknk	3190000
 阳信	ykns	370000
 氹仔	ykny	159000
+𪤝	ykob	0
 𨻞	ykoj	0
 𨺬	ykon	0
 阳谷	ykoo	640000
 陽	ykro	23400000
 𨹎	ykrr	0
+𫕈	ykry	0
 阳新	yksf	875000
 阳高	yksj	329000
 䧤	ykuc	3840
@@ -98655,6 +102707,7 @@ encoder:
 𨺯	ykwz	0
 𨻂	ykwz	0
 𨼚	ykwz	0
+𪫽	ykwz	0
 孙子	ykya	8560000
 阳台	ykzj	14900000
 孙女	ykzm	2420000
@@ -98746,6 +102799,7 @@ encoder:
 𢽄	ymix	0
 郔	ymiy	650000
 改口	ymja	2580000
+𪟗	ymja	0
 𧻅	ymjb	0
 駕	ymjc	5380000
 架	ymjf	171000000
@@ -98766,6 +102820,7 @@ encoder:
 㖙	ymjr	3610
 力图	ymjr	7370000
 鴐	ymjr	33800
+𫛤	ymjr	0
 𧦲	ymjs	0
 𤇞	ymju	0
 𥹌	ymju	0
@@ -98800,6 +102855,7 @@ encoder:
 𣤥	ymlr	0
 延用	ymlv	503000
 改用	ymlv	8290000
+𫑊	ymlw	0
 𨜏	ymly	0
 力矩	ymmh	902000
 𨼵	ymmj	0
@@ -98847,6 +102903,7 @@ encoder:
 𠂐	ymtd	0
 延庆	ymtg	3810000
 力度	ymtv	89800000
+𫂲	ymuf	0
 延烧	ymuh	286000
 改判	ymuk	845000
 改悔	ymum	192000
@@ -98868,6 +102925,7 @@ encoder:
 延边	ymwy	4240000
 延安	ymwz	12100000
 𢖰	ymwz	0
+𫕏	ymxb	0
 𩑦	ymxg	0
 力臂	ymxj	186000
 改观	ymxl	4260000
@@ -98884,12 +102942,14 @@ encoder:
 䝱	ymyl	3500
 𠠴	ymym	0
 𨹳	ymym	0
+𫃙	ymyn	0
 脅	ymyq	2440000
 𣢩	ymyr	0
 𩸻	ymyr	0
 改建	ymyx	11400000
 劦	ymyy	813000
 姭	ymyz	482000
+𪥺	ymyz	0
 劜	ymza	101000
 延续	ymze	25900000
 改线	ymzh	326000
@@ -98966,6 +103026,7 @@ encoder:
 办报	yody	555000
 除草	yoek	2820000
 坠落	yoev	11900000
+𫅯	yofj	0
 阶梯	yofu	7500000
 险要	yofv	1610000
 办厂	yogg	7960000
@@ -98976,10 +103037,14 @@ encoder:
 队员	yojl	20800000
 険	yojo	1510000
 𨼶	yojw	0
+𫅯	yojw	0
 险别	yojy	109000
 除尘	yokb	4290000
 除非	yokc	38900000
+𫅩	yoko	0
 𨹉	yokv	0
+𫅮	yokz	0
+𫅲	yokz	0
 险峰	yolr	1440000
 险峻	yolz	2840000
 除	yomf	184000000
@@ -98998,6 +103063,7 @@ encoder:
 𨽭	yooo	0
 𨺡	yoor	0
 𢡣	yoou	0
+𫅤	yoow	0
 办公	yooz	356000000
 𢌝	yopd	0
 办妥	yopz	1680000
@@ -99030,6 +103096,7 @@ encoder:
 𨸣	yoyd	0
 羽	yoyo	0
 除了	yoyv	195000000
+𫕎	yoyy	0
 𨻔	yozq	0
 办好	yozy	7000000
 阶级	yozy	13000000
@@ -99038,11 +103105,13 @@ encoder:
 弧菌	ypej	287000
 𨺠	ypel	0
 孤本	ypfa	340000
+𫕉	ypgx	0
 𨻆	ypih	0
 𨺻	ypik	0
 𨽯	ypio	0
 弧光	ypkg	615000
 𨼠	ypki	0
+𫕋	yplb	0
 𨺄	ypmb	0
 䧟	ypnb	3930
 孤傲	ypnc	3260000
@@ -99071,6 +103140,7 @@ encoder:
 𦏲	ypyp	0
 䧦	ypyu	3960
 䧌	ypzm	3310
+𫕊	ypzx	0
 阴天	yqag	3620000
 阴魂	yqbz	1010000
 阴森	yqff	3380000
@@ -99134,6 +103204,7 @@ encoder:
 陶器	yrjj	7310000
 隆回	yrjj	522000
 隐患	yrjj	21500000
+𫕑	yrjk	0
 𨽊	yrjr	0
 𨽆	yrju	0
 隆昌	yrkk	689000
@@ -99230,6 +103301,8 @@ encoder:
 𨼨	ysly	0
 隡	ysmm	55600
 𢻮	ysmo	0
+𫕗	ysmz	0
+𫕅	ysnd	0
 𨻓	ysnj	0
 防伪	ysnu	9430000
 陪伴	ysnu	15700000
@@ -99261,6 +103334,7 @@ encoder:
 防盗	ystr	26900000
 忍痛	ystx	4360000
 防爆	ysuk	7680000
+𫕒	ysul	0
 防火	ysuo	14200000
 防污	ysvb	871000
 防洪	ysve	4160000
@@ -99301,6 +103375,7 @@ encoder:
 𦐬	ytaj	0
 𦑾	ytak	0
 𦐜	ytau	0
+𫅤	ytax	0
 𦑷	ytay	0
 弱项	ytbg	761000
 𦒏	ytbg	0
@@ -99325,6 +103400,7 @@ encoder:
 翄	ytex	50000
 𦐕	ytez	0
 䎔	ytfd	3830
+𫅯	ytfj	0
 𦑿	ytfk	0
 飞机	ytfq	55800000
 𦒊	ytfs	0
@@ -99364,16 +103440,20 @@ encoder:
 𦐖	ytjo	0
 飞跑	ytjr	659000
 𦒠	ytjr	0
+𫅯	ytjw	0
 习题	ytka	6830000
 䎓	ytkk	3520
 𠞨	ytkk	0
 𦑾	ytkk	0
 弱小	ytko	5380000
+𫅩	ytko	0
 弱水	ytkv	917000
 𠢜	ytky	0
 弱电	ytkz	2520000
 𦑎	ytkz	0
 𦑐	ytkz	0
+𫅮	ytkz	0
+𫅲	ytkz	0
 𦐘	ytlb	0
 𦑶	ytlk	0
 𦒗	ytlk	0
@@ -99409,6 +103489,7 @@ encoder:
 𣤩	ytnr	0
 𦑀	ytnr	0
 𪄶	ytnr	0
+𪴲	ytnr	0
 𨞩	ytny	0
 翠	ytoe	35900000
 飞行	ytoi	47000000
@@ -99421,6 +103502,7 @@ encoder:
 飞往	ytos	3630000
 𦐗	ytos	0
 䎆	ytow	3860
+𫅤	ytow	0
 翂	ytoy	39000
 䧪	ytoz	3310
 𡣀	ytoz	0
@@ -99432,6 +103514,7 @@ encoder:
 剹	ytpk	74000
 𥂔	ytpl	0
 𧢋	ytpl	0
+𪯖	ytpm	0
 雡	ytpn	25600
 飞船	ytpq	6010000
 𩘷	ytpq	0
@@ -99491,12 +103574,16 @@ encoder:
 𩢳	ytyc	0
 𦏽	ytyd	0
 羿	ytye	4700000
+𫖈	ytye	0
 䎍	ytyf	3700
 𦐔	ytyf	0
+𫅨	ytyf	0
 頨	ytyg	42000
 𦏵	ytyh	0
 𦐂	ytyh	0
+𫊼	ytyi	0
 䎌	ytyj	3890
+𫅪	ytyk	0
 毣	ytym	45700
 𢬙	ytym	0
 習	ytyn	4230000
@@ -99515,6 +103602,7 @@ encoder:
 𦐹	ytys	0
 羽	ytyt	90700000
 𦐭	ytyt	0
+𫅧	ytyu	0
 𪓦	ytyw	0
 翍	ytyx	139000
 䣁	ytyy	3600
@@ -99533,10 +103621,13 @@ encoder:
 弹指	yudr	2500000
 弹药	yuez	4610000
 𨺧	yufd	0
+𪪰	yufj	0
 粥样	yufu	1340000
 墜	yugb	5290000
 弹压	yugb	284000
 𨺰	yugd	0
+𫕀	yugd	0
+𪥡	yugg	0
 𩈁	yugk	0
 鐆	yugp	25400
 隊	yugq	71000000
@@ -99577,6 +103668,7 @@ encoder:
 𨸵	yway	0
 院士	ywba	17000000
 𨼈	ywbj	0
+𫕍	ywbk	0
 隨	ywbq	40500000
 院	ywbr	446000000
 随地	ywbv	12500000
@@ -99593,6 +103685,7 @@ encoder:
 𨽒	ywkk	0
 䧬	ywkl	3770
 随同	ywld	2320000
+𫕌	ywld	0
 䧮	ywlw	3230
 随手	ywmd	11800000
 𨹏	ywmh	0
@@ -99609,6 +103702,7 @@ encoder:
 𡓗	ywqb	0
 随处	ywri	6270000
 𨻮	ywrm	0
+𫕂	ywrq	0
 陀	ywrr	9890000
 𨹖	ywrr	0
 𨺋	ywry	0
@@ -99647,6 +103741,7 @@ encoder:
 限至	yxhb	42300
 建瓯	yxho	557000
 建成	yxhv	40500000
+𫕃	yxiy	0
 建国	yxjc	34000000
 𨼔	yxjd	0
 隦	yxjs	22400
@@ -99682,6 +103777,7 @@ encoder:
 建房	yxws	4750000
 𨻗	yxxf	0
 䦽	yxxi	3310
+𫕓	yxxj	0
 𢙎	yxxw	0
 𨺝	yxxx	0
 𨺽	yxxx	0
@@ -99723,6 +103819,7 @@ encoder:
 𢁅	yybm	0
 𢰞	yybm	0
 𢾞	yybm	0
+𪩯	yybm	0
 𨾧	yybn	0
 𩀃	yybn	0
 巺	yybo	187000
@@ -99757,7 +103854,9 @@ encoder:
 𣪐	yyhq	0
 𡕪	yyhr	0
 𨹸	yyjb	0
+𪬧	yyjk	0
 𠭵	yyjx	0
+𫕘	yykk	0
 㞯	yyll	3650
 𨹃	yymf	0
 羽毛	yymh	12500000
@@ -99842,6 +103941,7 @@ encoder:
 張	yzch	102000000
 𨺮	yzcr	0
 𪓯	yzcw	0
+𪪿	yzcx	0
 㢽	yzcy	3580
 𢐓	yzcy	0
 𩱨	yzda	0
@@ -99887,10 +103987,12 @@ encoder:
 䥒	yzip	6740
 𢏾	yzir	0
 謽	yzis	29300
+𪫥	yziw	0
 㢭	yzix	3720
 𢏈	yzix	0
 𢾲	yzix	0
 𢿟	yzix	0
+𪪾	yzix	0
 勥	yziy	35000
 𢏍	yziy	0
 𡠥	yziz	0
@@ -99914,7 +104016,10 @@ encoder:
 𩱲	yzjl	0
 𩱳	yzjl	0
 𩱶	yzjl	0
+𫙆	yzjl	0
+𫙇	yzjl	0
 𩎡	yzjm	0
+𪫀	yzjm	0
 𢑆	yzjn	0
 𢐀	yzjo	0
 𢐡	yzjo	0
@@ -99948,6 +104053,7 @@ encoder:
 𢐸	yzkl	0
 孔雀	yzkn	12300000
 彉	yzko	618000
+𪫂	yzko	0
 𨧮	yzkp	0
 𨯞	yzkp	0
 弰	yzkq	327000
@@ -99961,6 +104067,7 @@ encoder:
 𢑎	yzky	0
 𡝠	yzkz	0
 𡝡	yzkz	0
+𪫁	yzlb	0
 𢏕	yzld	0
 𢎭	yzli	0
 𢏎	yzlk	0
@@ -99971,6 +104078,7 @@ encoder:
 陋	yzlo	3280000
 𢏟	yzlo	0
 𨻨	yzlo	0
+𪪻	yzlo	0
 㢷	yzlr	3620
 䰜	yzly	4190
 鄪	yzly	22000
@@ -99981,6 +104089,7 @@ encoder:
 矤	yzma	52900
 𢐩	yzmi	0
 㣁	yzml	4120
+𪪽	yzml	0
 𥡀	yzmm	0
 𢎿	yzmo	0
 㢳	yzmr	3920
@@ -100021,6 +104130,7 @@ encoder:
 𤇝	yznu	0
 𢘍	yznw	0
 彏	yznx	28700
+𪫄	yznx	0
 㔗	yzny	4090
 弼	yzny	2280000
 𠡂	yzny	0
@@ -100073,6 +104183,7 @@ encoder:
 𩱠	yzra	0
 𡍵	yzrb	0
 阭	yzrd	87800
+𪪼	yzre	0
 㣅	yzrk	3780
 弥	yzrk	12300000
 𢏧	yzrl	0
@@ -100083,6 +104194,7 @@ encoder:
 𢏜	yzrr	0
 𢏤	yzrr	0
 𣩴	yzrr	0
+𪫅	yzrr	0
 㢩	yzrs	3900
 弤	yzrs	27200
 𢏉	yzrs	0
@@ -100152,6 +104264,7 @@ encoder:
 弨	yzyj	566000
 孔隙	yzyk	872000
 𤳕	yzyk	0
+𪾞	yzyl	0
 㢸	yzym	4360
 𢐅	yzyp	0
 𣫟	yzyq	0
@@ -100238,6 +104351,7 @@ encoder:
 𥾧	zali	0
 𦁥	zalk	0
 𦂲	zalk	0
+𫄥	zall	0
 䋑	zalo	3780
 纚	zalt	65400
 𥾎	zand	0
@@ -100292,6 +104406,7 @@ encoder:
 纈	zbjg	178000
 缬	zbjg	588000
 繬	zbjj	30100
+𫄱	zbjj	0
 𦁱	zbjr	0
 𪆋	zbjr	0
 絙	zbka	80300
@@ -100301,6 +104416,7 @@ encoder:
 红光	zbkg	4150000
 结晶	zbkk	14800000
 红星	zbkm	8180000
+𫃟	zbko	0
 结盟	zbkq	4930000
 结业	zbku	2400000
 结账	zblc	2370000
@@ -100356,6 +104472,7 @@ encoder:
 繥	zbuj	264000
 红火	zbuo	8760000
 𦅈	zbup	0
+𫄵	zbup	0
 红糖	zbut	1290000
 结为	zbuv	2600000
 繨	zbuw	52900
@@ -100382,6 +104499,7 @@ encoder:
 红线	zbzh	2740000
 纬线	zbzh	362000
 䊺	zbzm	3730
+𫄚	zbzm	0
 𦇍	zbzq	0
 结婚	zbzr	26900000
 䌸	zbzs	4540
@@ -100389,6 +104507,7 @@ encoder:
 紶	zbzs	774000
 纭	zbzs	810000
 𦀖	zbzy	0
+𫄦	zbzy	0
 䌰	zccc	4800
 𦄑	zccx	0
 𦀳	zcds	0
@@ -100503,6 +104622,7 @@ encoder:
 𩚓	zdox	0
 巤	zdoz	21400
 𦄃	zdpj	0
+𫃸	zdpz	0
 𡿳	zdqb	0
 𢀂	zdqk	0
 𠛱	zdrk	0
@@ -100527,6 +104647,7 @@ encoder:
 𤳲	zdxi	0
 㜽	zdya	4930
 𩔪	zdyg	0
+𪩡	zdyi	0
 雝	zdyn	58500
 𪄉	zdyr	0
 𤮲	zdys	0
@@ -100534,6 +104655,7 @@ encoder:
 𦒩	zdyy	0
 𡿭	zdzd	0
 𤳤	zdzg	0
+𫖩	zdzg	0
 𠠗	zdzk	0
 𣰫	zdzm	0
 𡗇	zdzr	0
@@ -100555,6 +104677,8 @@ encoder:
 緙	zeea	86100
 缂	zeea	5040000
 𦅠	zeeb	0
+𫃾	zefb	0
+𫄇	zefk	0
 𦇠	zefw	0
 𦂍	zegj	0
 𦄩	zehk	0
@@ -100565,10 +104689,12 @@ encoder:
 䌯	zejn	5620
 纎	zeka	67500
 縸	zekg	131000
+𫄲	zekg	0
 𦄩	zekh	0
 緢	zeki	241000
 𦄧	zekk	0
 䌙	zeko	4140
+𫄁	zekq	0
 𦅶	zekr	0
 繊	zeku	406000
 𡌴	zelb	0
@@ -100599,6 +104725,7 @@ encoder:
 繖	zeqm	693000
 䌨	zerb	5200
 纄	zerc	32200
+𫄈	zerj	0
 𦃜	zerk	0
 𦀴	zesh	0
 𦃑	zesn	0
@@ -100606,6 +104733,7 @@ encoder:
 繱	zesw	49700
 𦇎	zesw	0
 续	zetg	51700000
+𫄪	zeuh	0
 𦆇	zeuj	0
 绁	zeva	647000
 𦄂	zewl	0
@@ -100618,6 +104746,7 @@ encoder:
 绁	zeza	647000
 姑姑	zeze	2820000
 緤	zezf	296000
+𫄬	zezf	0
 𦇴	zezh	0
 妓女	zezm	10400000
 𦃮	zezo	0
@@ -100643,6 +104772,7 @@ encoder:
 𦈡	zfgl	0
 𦅰	zfke	0
 𦆙	zfki	0
+𫄒	zfkm	0
 𦄏	zfkq	0
 緗	zfla	973000
 缃	zfla	2470000
@@ -100662,6 +104792,7 @@ encoder:
 䊾	zfvv	3460
 嫖宿	zfwn	161000
 繐	zfwz	635000
+𫃽	zfxb	0
 𦇉	zfxx	0
 𦇛	zfyl	0
 𦂪	zfym	0
@@ -100720,6 +104851,7 @@ encoder:
 叁仟	zgnm	128000
 叁亿	zgny	26500
 参会	zgob	3910000
+𫄆	zgoe	0
 𦇦	zgog	0
 綊	zgoo	559000
 𦄍	zgoo	0
@@ -100735,6 +104867,7 @@ encoder:
 𦁑	zgub	0
 𦂡	zguc	0
 缅怀	zgug	3790000
+𫄖	zgul	0
 𦆡	zgum	0
 参数	zguz	67900000
 参赛	zgwe	16100000
@@ -100750,6 +104883,7 @@ encoder:
 缭绕	zgzh	2990000
 紘	zgzs	1430000
 纮	zgzs	149000
+𫃪	zgzt	0
 线形	zhae	1430000
 纯正	zhai	6390000
 緘	zhaj	173000
@@ -100781,6 +104915,7 @@ encoder:
 线路	zhjr	50400000
 𦆃	zhjr	0
 线圈	zhju	2630000
+𫄅	zhjw	0
 𦃄	zhkc	0
 𦈗	zhkc	0
 𦇰	zhkj	0
@@ -100997,6 +105132,7 @@ encoder:
 𤕯	zikv	0
 𢠞	zikw	0
 𦻇	zikw	0
+𫃬	zikx	0
 𦱶	zilb	0
 𤕲	zilc	0
 𤖤	zilg	0
@@ -101011,6 +105147,7 @@ encoder:
 𥝄	zilz	0
 𡴍	zimb	0
 𦗷	zimc	0
+𫆃	zimc	0
 𢪇	zimd	0
 𩕣	zimg	0
 𤖢	zimi	0
@@ -101088,12 +105225,15 @@ encoder:
 𤖕	zirf	0
 𨡓	zirf	0
 𧌜	ziri	0
+𪯊	ziri	0
 𤖅	zirk	0
 𤯧	zirl	0
 𧢼	zirl	0
 𪗊	zirn	0
 紪	zirr	160000
 𤖝	zirs	0
+𫃳	zirs	0
+𪺠	zirw	0
 𩿄	zirz	0
 櫱	zisf	35800
 𡘾	zisg	0
@@ -101105,8 +105245,10 @@ encoder:
 𡴫	ziso	0
 裝	zisr	44700000
 𧛬	zisr	0
+𫌏	zisr	0
 𥫋	ziss	0
 糱	zisu	32300
+𪞹	zisw	0
 㔎	zisy	4520
 孼	zisy	133000
 𤕸	zitb	0
@@ -101114,6 +105256,7 @@ encoder:
 𤖏	zitm	0
 牂	ziuc	76400
 𦆇	ziuj	0
+𪺡	ziuk	0
 𧡠	ziul	0
 𥽀	ziun	0
 𤉞	ziuu	0
@@ -101162,11 +105305,13 @@ encoder:
 𤭽	ziys	0
 𦐉	ziyy	0
 𦴘	ziyy	0
+𪞺	ziyz	0
 𦫹	ziza	0
 祟	zizb	4310000
 𡴠	zizb	0
 𤕿	zizb	0
 𦱴	zize	0
+𪞷	zize	0
 牃	zizf	170000
 𠚐	zizf	0
 𣐯	zizf	0
@@ -101186,6 +105331,7 @@ encoder:
 𡭧	zizk	0
 𣈤	zizk	0
 𣑼	zizk	0
+𪺟	zizk	0
 𦮅	zizl	0
 𧵠	zizl	0
 𩨳	zizl	0
@@ -101279,10 +105425,12 @@ encoder:
 𦄶	zjon	0
 如今	zjos	60300000
 𦂮	zjos	0
+𫄌	zjpz	0
 絹	zjqa	4120000
 绢	zjqa	3680000
 台风	zjqo	15700000
 台胞	zjqr	1600000
+𫄉	zjrj	0
 娱乐	zjrk	552000000
 𦀝	zjrl	0
 如意	zjsk	24800000
@@ -101299,6 +105447,7 @@ encoder:
 如潮	zjve	3040000
 台州	zjvn	26400000
 台湾	zjvs	71700000
+𫃜	zjvv	0
 邕宁	zjwa	301000
 织造	zjwm	2750000
 如实	zjwt	7850000
@@ -101317,6 +105466,7 @@ encoder:
 綥	zkan	26900
 𦀔	zkaz	0
 绅士	zkba	7940000
+𫄗	zkbu	0
 緋	zkca	4150000
 绯	zkca	6410000
 细长	zkch	3240000
@@ -101368,6 +105518,7 @@ encoder:
 𦆿	zkok	0
 细微	zkol	6960000
 𦃩	zkor	0
+𫄯	zkor	0
 纱锭	zkpw	178000
 绡	zkqa	834000
 细腻	zkqh	15400000
@@ -101379,6 +105530,7 @@ encoder:
 緄	zkrr	148000
 绲	zkrr	924000
 䋵	zkry	3700
+𫄕	zkrz	0
 妙语	zksb	4040000
 妙计	zkse	1900000
 绯闻	zktc	7040000
@@ -101430,6 +105582,7 @@ encoder:
 组配	zlfy	365000
 紻	zlgd	30000
 𩖂	zlgg	0
+𫄓	zlgs	0
 𦆎	zlgu	0
 组成	zlhv	71100000
 纳卡	zlia	410000
@@ -101451,6 +105604,7 @@ encoder:
 纳税	zlmu	16900000
 繀	zlni	215000
 纗	zlnl	42600
+𫄹	zlnl	0
 组件	zlnm	15600000
 组合	zloa	194000000
 納	zlod	17800000
@@ -101479,6 +105633,7 @@ encoder:
 贯注	zlvs	541000
 贯穿	zlwh	11200000
 贯通	zlwx	4600000
+𫃦	zlxs	0
 组办	zlyo	268000
 组建	zlyx	47400000
 姐妹	zlzb	35200000
@@ -101505,6 +105660,7 @@ encoder:
 𡞳	zmag	0
 𡣘	zmag	0
 𢑣	zmag	0
+𪦛	zmag	0
 奵	zmai	44500
 姃	zmai	532000
 媞	zmai	679000
@@ -101523,6 +105679,7 @@ encoder:
 婍	zmaj	70400
 𡄲	zmaj	0
 𡟵	zmaj	0
+𫄏	zmaj	0
 娅	zmak	6050000
 𡜔	zmak	0
 𡠽	zmak	0
@@ -101553,6 +105710,8 @@ encoder:
 𡜏	zmaz	0
 𡞄	zmaz	0
 𡞲	zmaz	0
+𪦁	zmaz	0
+𪦪	zmaz	0
 女士	zmba	58100000
 纴	zmba	40100
 㛻	zmbb	3860
@@ -101561,6 +105720,7 @@ encoder:
 收款	zmbb	14900000
 𡣋	zmbd	0
 𦅯	zmbd	0
+𪦇	zmbd	0
 𣕁	zmbf	0
 嬈	zmbg	133000
 女工	zmbi	4190000
@@ -101595,6 +105755,7 @@ encoder:
 纁	zmbu	87000
 𡤥	zmbu	0
 𡤭	zmbu	0
+𫄸	zmbu	0
 㜇	zmbw	4360
 㥨	zmbw	4440
 娡	zmbw	42600
@@ -101617,10 +105778,13 @@ encoder:
 𡢅	zmbz	0
 𡢯	zmbz	0
 𡤦	zmbz	0
+𪥦	zmbz	0
+𪦊	zmbz	0
 𡞗	zmcb	0
 𡤙	zmcc	0
 㛅	zmce	3770
 㛞	zmce	3610
+𪥽	zmch	0
 妦	zmci	162000
 𥿙	zmci	0
 𡟲	zmcj	0
@@ -101634,6 +105798,7 @@ encoder:
 𡣜	zmcm	0
 媋	zmco	42500
 婧	zmcq	6300000
+𪦋	zmcq	0
 㜵	zmcr	7320
 婊	zmcr	3260000
 𡛼	zmcs	0
@@ -101643,6 +105808,7 @@ encoder:
 收取	zmcx	68500000
 牟取	zmcx	1680000
 𡡔	zmcx	0
+𪥶	zmcy	0
 嫊	zmcz	77400
 𡛋	zmcz	0
 𡜯	zmcz	0
@@ -101694,6 +105860,7 @@ encoder:
 𡝅	zmer	0
 𡞁	zmer	0
 𡟉	zmer	0
+𪦀	zmes	0
 䌗	zmeu	3950
 嫬	zmeu	585000
 嫵	zmeu	1350000
@@ -101732,6 +105899,8 @@ encoder:
 孄	zmfl	31000
 孏	zmfl	36200
 𡤅	zmfl	0
+𪥱	zmfl	0
+𪦡	zmfl	0
 𡡵	zmfm	0
 㜛	zmfr	4230
 𡠇	zmfw	0
@@ -101779,6 +105948,7 @@ encoder:
 𡞋	zmgp	0
 𣂵	zmgp	0
 𤬌	zmgp	0
+𪦎	zmgp	0
 姷	zmgq	1150000
 彖	zmgq	497000
 𡝍	zmgq	0
@@ -101797,6 +105967,7 @@ encoder:
 𦂜	zmgu	0
 𦃱	zmgu	0
 嬘	zmgw	26000
+𪦆	zmgw	0
 媛	zmgx	8870000
 嫒	zmgx	471000
 𠭣	zmgx	0
@@ -101839,10 +106010,13 @@ encoder:
 𡡟	zmii	0
 𡢋	zmii	0
 𤬤	zmii	0
+𪥧	zmii	0
 㚲	zmij	4040
+𪦃	zmij	0
 劙	zmik	589000
 𠠞	zmik	0
 𡝃	zmik	0
+𪥮	zmik	0
 㜘	zmil	4720
 媜	zmil	171000
 𡟣	zmil	0
@@ -101854,12 +106028,15 @@ encoder:
 婿	zmiq	4320000
 𡜕	zmiq	0
 𡞚	zmiq	0
+𪦒	zmis	0
 𡤗	zmiu	0
 𡠛	zmiw	0
+𪥩	zmix	0
 娫	zmiy	36500
 綖	zmiy	519000
 𡜒	zmiy	0
 𡣸	zmiy	0
+𫄧	zmiy	0
 𡛔	zmiz	0
 𡜷	zmiz	0
 𡡎	zmiz	0
@@ -101894,6 +106071,7 @@ encoder:
 𡣰	zmjj	0
 𡤑	zmjj	0
 𨃢	zmjj	0
+𪦰	zmjj	0
 㜭	zmjk	4700
 婛	zmjk	68300
 媔	zmjk	128000
@@ -101912,6 +106090,7 @@ encoder:
 𡠀	zmjl	0
 𡡽	zmjl	0
 𡢠	zmjl	0
+𪥳	zmjl	0
 媁	zmjm	60100
 嫩	zmjm	28600000
 挐	zmjm	79400
@@ -101920,8 +106099,10 @@ encoder:
 𣭠	zmjm	0
 𤯥	zmjm	0
 𤯯	zmjm	0
+𪦐	zmjm	0
 孉	zmjn	63300
 𡛰	zmjo	0
+𪦅	zmjo	0
 收听	zmjp	11000000
 𨦔	zmjp	0
 娟	zmjq	13400000
@@ -101943,6 +106124,8 @@ encoder:
 𡣱	zmjr	0
 𡤎	zmjr	0
 𩶯	zmjr	0
+𪦭	zmjr	0
+𫛪	zmjr	0
 嫴	zmjs	60200
 𧧏	zmjs	0
 𨐞	zmjs	0
@@ -102018,6 +106201,7 @@ encoder:
 𡡝	zmkk	0
 𡡺	zmkk	0
 𡣲	zmkk	0
+𪦮	zmkk	0
 媢	zmkl	48300
 媪	zmkl	336000
 嬪	zmkl	2630000
@@ -102041,6 +106225,7 @@ encoder:
 㜳	zmkr	7740
 緮	zmkr	81900
 𡞪	zmkr	0
+𫄭	zmkr	0
 𡟄	zmks	0
 𡞷	zmku	0
 𡡐	zmku	0
@@ -102062,13 +106247,16 @@ encoder:
 𡞍	zmkz	0
 𡢧	zmkz	0
 𡤯	zmkz	0
+𪦈	zmkz	0
 嬣	zmla	47800
+𪥭	zmla	0
 㚩	zmlb	4100
 㛵	zmlb	3700
 姌	zmlb	390000
 媾	zmlb	839000
 𡜜	zmlb	0
 𡣈	zmlb	0
+𪦣	zmlb	0
 姐	zmlc	89300000
 姛	zmld	182000
 𡛾	zmld	0
@@ -102098,8 +106286,12 @@ encoder:
 𡣧	zmll	0
 𡤓	zmll	0
 𡤱	zmll	0
+𪦧	zmll	0
+𪦲	zmll	0
+𫌥	zmll	0
 𡛷	zmlm	0
 𡡹	zmlm	0
+𪦚	zmlm	0
 㜠	zmln	9340
 㜹	zmln	8220
 㛝	zmlo	3880
@@ -102141,10 +106333,12 @@ encoder:
 娥	zmmh	8840000
 嬟	zmmh	30400
 𡟶	zmmh	0
+𪦙	zmmh	0
 妰	zmmi	30000
 姡	zmmi	57900
 娫	zmmi	36500
 𡤌	zmmi	0
+𪥥	zmmi	0
 𡜲	zmmj	0
 𡞈	zmmj	0
 𡟐	zmmj	0
@@ -102161,6 +106355,7 @@ encoder:
 𢂬	zmml	0
 姩	zmmm	1580000
 𡝟	zmmm	0
+𪺫	zmmm	0
 㛼	zmmn	4150
 妷	zmmo	435000
 𡛇	zmmo	0
@@ -102176,6 +106371,8 @@ encoder:
 姂	zmmw	200000
 嫕	zmmw	108000
 𢟇	zmmw	0
+𪥻	zmmw	0
+𪫾	zmmw	0
 㚹	zmmy	4090
 㚺	zmmy	4000
 娇气	zmmy	859000
@@ -102246,6 +106443,7 @@ encoder:
 𡣝	zmoe	0
 𨣻	zmof	0
 𧱈	zmog	0
+𪦂	zmog	0
 㜡	zmoi	4230
 𧱤	zmoi	0
 嫆	zmoj	133000
@@ -102278,6 +106476,7 @@ encoder:
 𡠪	zmoo	0
 𡣞	zmoo	0
 𢑓	zmoo	0
+𪦳	zmoo	0
 㜗	zmop	4000
 嫪	zmop	147000
 𡛧	zmop	0
@@ -102290,6 +106489,8 @@ encoder:
 𡡷	zmor	0
 㜬	zmos	4510
 𡞬	zmos	0
+𪦦	zmos	0
+𪦟	zmot	0
 㛋	zmou	3710
 𡤚	zmou	0
 姈	zmow	442000
@@ -102321,6 +106522,7 @@ encoder:
 嫍	zmpn	85800
 娦	zmpo	41800
 嫔	zmpo	1070000
+𪦢	zmpp	0
 𡛴	zmps	0
 𡜁	zmps	0
 收受	zmpw	5800000
@@ -102348,8 +106550,10 @@ encoder:
 𡤇	zmqm	0
 㚯	zmqo	3730
 𡛪	zmqp	0
+𪥹	zmqp	0
 𡞇	zmqq	0
 𡡈	zmqq	0
+𪥪	zmqq	0
 𡚺	zmqs	0
 𡛓	zmqs	0
 𡜫	zmqs	0
@@ -102367,11 +106571,14 @@ encoder:
 𡢼	zmrf	0
 𡚼	zmrh	0
 孎	zmri	61700
+𪥾	zmri	0
+𪦨	zmri	0
 姁	zmrj	56600
 姓名	zmrj	246000000
 姳	zmrj	935000
 𡜶	zmrj	0
 𡟔	zmrj	0
+𪦫	zmrj	0
 妳	zmrk	44700000
 姰	zmrk	113000
 婚	zmrk	65000000
@@ -102415,6 +106622,7 @@ encoder:
 𡠌	zmrr	0
 𡠰	zmrr	0
 𡡷	zmrr	0
+𪦕	zmrr	0
 㜶	zmrs	8260
 奺	zmrs	54900
 妁	zmrs	158000
@@ -102427,6 +106635,7 @@ encoder:
 𡟰	zmrs	0
 𡠶	zmrs	0
 𡤹	zmrs	0
+𪦉	zmrs	0
 㚬	zmrt	3810
 㚵	zmrt	4080
 婅	zmru	487000
@@ -102450,9 +106659,11 @@ encoder:
 𡠄	zmrz	0
 𡠎	zmrz	0
 𡡅	zmrz	0
+𪦌	zmrz	0
 妵	zmsc	579000
 㛙	zmse	3740
 媇	zmsf	144000
+𪜡	zmsh	0
 𡠁	zmsi	0
 𡡟	zmsi	0
 婄	zmsj	1220000
@@ -102495,6 +106706,7 @@ encoder:
 𣁭	zmte	0
 娴	zmtf	6590000
 㚧	zmtg	3690
+𪥿	zmtg	0
 㛠	zmtk	3730
 嫉	zmtm	3830000
 女将	zmtr	2930000
@@ -102513,9 +106725,11 @@ encoder:
 嬘	zmug	26000
 𡟝	zmug	0
 𡡦	zmug	0
+𪫇	zmug	0
 嫸	zmuj	29700
 嬉	zmuj	11800000
 女单	zmuk	1210000
+𫄘	zmuk	0
 嫡	zmul	1460000
 嬧	zmul	366000
 𡡀	zmul	0
@@ -102544,25 +106758,30 @@ encoder:
 𡟜	zmuz	0
 𦃉	zmuz	0
 𡤊	zmvb	0
+𪦜	zmvb	0
 𡠖	zmve	0
 姚	zmvr	28200000
 𡡃	zmvr	0
 㛏	zmvs	3820
 𠚣	zmvv	0
 婷	zmwa	30600000
+𪥰	zmwa	0
 婃	zmwb	1660000
 收割	zmwc	3840000
 𡝬	zmwc	0
+𪦯	zmwc	0
 婝	zmwd	53900
 㜕	zmwf	4060
 媈	zmwf	28500
 嬫	zmwf	1810000
 𡜻	zmwf	0
 𡣻	zmwf	0
+𪦖	zmwf	0
 嫁	zmwg	66200000
 𡡪	zmwg	0
 𧰺	zmwg	0
 嬯	zmwh	23200
+𪦱	zmwi	0
 婶	zmwk	1220000
 㛿	zmwl	5220
 㜴	zmwl	7490
@@ -102595,10 +106814,12 @@ encoder:
 㣽	zmwz	4060
 姲	zmwz	41000
 𡚿	zmwz	0
+𪦗	zmwz	0
 妇	zmxb	69700000
 𡞹	zmxb	0
 𡟽	zmxb	0
 𡠩	zmxb	0
+𫄂	zmxb	0
 駑	zmxc	106000
 𡣟	zmxc	0
 妞	zmxe	18300000
@@ -102622,10 +106843,12 @@ encoder:
 𦀢	zmxi	0
 𧉭	zmxi	0
 𪗭	zmxi	0
+𪦄	zmxi	0
 㜍	zmxj	4500
 娢	zmxj	49700
 娪	zmxj	70400
 𡝗	zmxj	0
+𪦔	zmxj	0
 娽	zmxk	26900
 嫝	zmxk	53000
 收录	zmxk	36900000
@@ -102634,6 +106857,7 @@ encoder:
 𡠑	zmxk	0
 𡢃	zmxk	0
 𨽽	zmxk	0
+𪦴	zmxk	0
 㛚	zmxl	3840
 媚	zmxl	39200000
 嫞	zmxl	58000
@@ -102649,6 +106873,7 @@ encoder:
 𢑩	zmxl	0
 𥅄	zmxl	0
 𧲁	zmxl	0
+𪦬	zmxl	0
 娓	zmxm	5250000
 拏	zmxm	379000
 收尾	zmxm	2330000
@@ -102669,6 +106894,7 @@ encoder:
 𡛄	zmxs	0
 𡟭	zmxs	0
 𡢄	zmxs	0
+𪥲	zmxs	0
 收买	zmxt	3160000
 𡠮	zmxu	0
 𤍻	zmxu	0
@@ -102681,6 +106907,7 @@ encoder:
 𡜢	zmxx	0
 𡢷	zmxx	0
 𡤕	zmxx	0
+𪥫	zmxx	0
 㐐	zmxy	5340
 努	zmxy	23800000
 嫏	zmxy	86600
@@ -102691,6 +106918,7 @@ encoder:
 䋈	zmxz	4350
 𡝓	zmxz	0
 𡞿	zmxz	0
+𪥼	zmxz	0
 女子	zmya	113000000
 好	zmya	1780000000
 𦁳	zmya	0
@@ -102701,10 +106929,12 @@ encoder:
 彜	zmye	145000
 𢑱	zmyg	0
 姄	zmyh	70900
+𪦓	zmyh	0
 她	zmyi	340000000
 妑	zmyi	90700
 絁	zmyi	61400
 𡛅	zmyi	0
+𫄟	zmyi	0
 㚳	zmyj	3710
 妱	zmyj	65900
 𡣗	zmyj	0
@@ -102725,8 +106955,12 @@ encoder:
 嬥	zmyn	47900
 收费	zmyn	91200000
 𡛯	zmyn	0
+𪦞	zmyn	0
 𩛗	zmyo	0
+𪦝	zmyq	0
 𪀮	zmyr	0
+𫚻	zmyr	0
+𫛇	zmyr	0
 女孩	zmys	104000000
 妫	zmys	2180000
 𡛣	zmys	0
@@ -102740,6 +106974,7 @@ encoder:
 縋	zmyw	450000
 缒	zmyw	289000
 𡜱	zmyw	0
+𪫴	zmyw	0
 妃	zmyy	16000000
 嬆	zmyy	25100
 𡚱	zmyy	0
@@ -102747,6 +106982,7 @@ encoder:
 𡟸	zmyy	0
 𡤖	zmyy	0
 𦑙	zmyy	0
+𪥵	zmyy	0
 嫐	zmyz	191000
 𡝦	zmyz	0
 𡢰	zmyz	0
@@ -102777,6 +107013,7 @@ encoder:
 𡜪	zmzl	0
 𡟤	zmzl	0
 𡣨	zmzl	0
+𫌥	zmzl	0
 㚣	zmzm	4010
 㛌	zmzm	3670
 奻	zmzm	962000
@@ -102784,6 +107021,8 @@ encoder:
 緌	zmzm	98500
 𡜄	zmzm	0
 𡠯	zmzm	0
+𪦘	zmzm	0
+𪦩	zmzm	0
 收缴	zmzn	3570000
 纤维	zmzn	51100000
 𡤀	zmzn	0
@@ -102799,6 +107038,7 @@ encoder:
 姢	zmzq	222000
 㜧	zmzr	5090
 𡤻	zmzr	0
+𪥬	zmzr	0
 𡤣	zmzs	0
 嫣	zmzu	3700000
 收发	zmzv	26400000
@@ -102816,6 +107056,8 @@ encoder:
 𡝏	zmzy	0
 𡢵	zmzy	0
 𡤶	zmzy	0
+𪦏	zmzy	0
+𫄩	zmzy	0
 妶	zmzz	750000
 姦	zmzz	6520000
 娹	zmzz	43200
@@ -102827,6 +107069,7 @@ encoder:
 𡢫	zmzz	0
 𡣦	zmzz	0
 𡤡	zmzz	0
+𪦤	zmzz	0
 𦂢	znan	0
 𦆒	znaz	0
 𦁻	znbi	0
@@ -102843,6 +107086,7 @@ encoder:
 𦇈	zngb	0
 𦅳	znge	0
 絥	zngs	78200
+𫄢	zngs	0
 绵软	znhr	598000
 維	znia	25100000
 维	znia	138000000
@@ -102894,6 +107138,7 @@ encoder:
 𦃈	znxs	0
 嫂子	znya	3790000
 缎子	znya	484000
+𫃝	znyd	0
 𥿞	znyi	0
 绵阳	znyk	27800000
 绵延	znym	5310000
@@ -102918,6 +107163,7 @@ encoder:
 𥿐	zobz	0
 𦁌	zobz	0
 兦	zoda	56700
+𫄐	zodk	0
 以求	zodv	6480000
 以南	zoel	8760000
 𦅑	zoel	0
@@ -102927,6 +107173,7 @@ encoder:
 𦃏	zofq	0
 𦆧	zogb	0
 絺	zogl	147000
+𫄨	zogl	0
 以太	zogs	7200000
 𥿭	zogz	0
 以至	zohb	10500000
@@ -102935,6 +107182,7 @@ encoder:
 絎	zoia	189000
 绗	zoia	1540000
 縰	zoii	40500
+𫄳	zoii	0
 以此	zoir	21300000
 以上	zoiv	1280000000
 𢻲	zoix	0
@@ -102976,6 +107224,7 @@ encoder:
 以往	zoos	49300000
 以后	zopa	221000000
 紾	zopd	609000
+𫄑	zopz	0
 緰	zoqk	39400
 𦈕	zoqk	0
 以外	zori	172000000
@@ -102984,7 +107233,9 @@ encoder:
 纶	zorr	9010000
 𦆛	zorr	0
 纷争	zorx	4420000
+𫃮	zosc	0
 紟	zosx	551000
+𫄛	zosx	0
 𥾪	zotd	0
 以北	zotr	8110000
 以资	zotr	850000
@@ -103021,6 +107272,7 @@ encoder:
 総	zozw	67500000
 给出	zozz	19800000
 缓刑	zpae	966000
+𫃭	zpag	0
 𦁟	zpah	0
 𥿤	zpda	0
 䋸	zpel	4040
@@ -103052,6 +107304,7 @@ encoder:
 缓慢	zpuk	18700000
 绥江	zpvb	151000
 缓流	zpvs	383000
+𫃿	zpvs	0
 䋮	zpvv	3600
 绥滨	zpvw	148000
 绥宁	zpwa	171000
@@ -103075,6 +107328,7 @@ encoder:
 缓缓	zpzp	21400000
 𥾭	zpzs	0
 能干	zqae	7110000
+𫄍	zqar	0
 能动	zqbz	2100000
 能耗	zqcm	3760000
 紣	zqed	109000
@@ -103114,6 +107368,7 @@ encoder:
 纸夹	zrbu	102000
 终场	zrby	1620000
 綘	zrci	381000
+𫘖	zrcu	0
 縫	zrcw	4690000
 缝	zrcw	28200000
 绝招	zrdy	9970000
@@ -103147,6 +107402,8 @@ encoder:
 绝非	zrkc	7460000
 终归	zrkx	825000
 𦅥	zrkz	0
+𫃧	zrkz	0
+𫃴	zrlg	0
 𥿸	zrli	0
 𦀦	zrli	0
 𦃭	zrll	0
@@ -103254,10 +107511,12 @@ encoder:
 𠙃	zsaq	0
 𪈽	zsar	0
 统一	zsav	121000000
+𫄔	zsax	0
 𠫛	zsaz	0
 𠫫	zsaz	0
 𠬀	zsaz	0
 统考	zsba	6810000
+𫄋	zsbd	0
 𣠎	zsbg	0
 𠫚	zsbi	0
 𠜸	zsbk	0
@@ -103268,12 +107527,14 @@ encoder:
 𧶀	zsbz	0
 𠫽	zscc	0
 𣮟	zscm	0
+𪵎	zscq	0
 𤫜	zscs	0
 𣠏	zscx	0
 𡊅	zseb	0
 卛	zsed	38000
 𠫘	zsed	0
 𨠢	zsef	0
+𪤘	zsef	0
 䪻	zseg	3280
 𠼷	zsej	0
 𣗺	zsej	0
@@ -103299,6 +107560,8 @@ encoder:
 奱	zsgd	66500
 軬	zsgf	30900
 𨠒	zsgf	0
+𫐊	zsgh	0
+𫊲	zsgi	0
 妨碍	zsgk	9720000
 畚	zsgk	412000
 𠫭	zsgk	0
@@ -103326,11 +107589,13 @@ encoder:
 𢿈	zsix	0
 𣀵	zsix	0
 𠄩	zsjb	0
+𫄊	zsjb	0
 𩢠	zsjc	0
 𠫺	zsje	0
 枲	zsjf	68900
 𠫪	zsjg	0
 𩒎	zsjg	0
+𫖭	zsjg	0
 𢦯	zsjh	0
 𦝕	zsjj	0
 刣	zsjk	33500
@@ -103345,6 +107610,7 @@ encoder:
 𩏹	zsjm	0
 𨾱	zsjn	0
 㣍	zsjp	3860
+𪱜	zsjq	0
 㰧	zsjr	5860
 綂	zsjr	33200
 𠬍	zsjr	0
@@ -103378,8 +107644,10 @@ encoder:
 缞	zskr	54000
 𦂊	zskr	0
 灓	zskv	169000
+𪵨	zskv	0
 繶	zskw	112000
 𢛋	zskw	0
+𫄷	zskw	0
 𠮘	zskx	0
 𨝣	zsky	0
 奙	zskz	23200
@@ -103409,6 +107677,7 @@ encoder:
 统筹	zsmc	13300000
 攣	zsmd	954000
 𩓎	zsmg	0
+𪭗	zsmh	0
 统制	zsml	176000
 𠬏	zsml	0
 𣭰	zsmm	0
@@ -103456,6 +107725,7 @@ encoder:
 臠	zsoo	59000
 𠬙	zsoo	0
 𦠬	zsoo	0
+𪠡	zsoo	0
 參	zsop	12200000
 夋	zsor	1380000
 𥜷	zsor	0
@@ -103516,6 +107786,7 @@ encoder:
 鸞	zsrz	964000
 𪈮	zsrz	0
 𫜵	zsrz	0
+𫛯	zsrz	0
 统计	zsse	749000000
 𣙼	zssf	0
 缔交	zsso	22100
@@ -103550,7 +107821,10 @@ encoder:
 縴	zswm	190000
 缔造	zswm	5270000
 㓄	zswr	4050
+𪠟	zswr	0
+𫛋	zswr	0
 縍	zsws	31800
+𫄰	zsws	0
 𣟽	zswy	0
 戀	zswz	21400000
 𦆌	zsxg	0
@@ -103570,6 +107844,7 @@ encoder:
 紡	zsya	2580000
 纺	zsya	20300000
 𠠪	zsyd	0
+𫄃	zsym	0
 㽋	zsys	4030
 瓵	zsys	28500
 𠨫	zsys	0
@@ -103589,6 +107864,7 @@ encoder:
 𠫰	zszc	0
 繂	zsze	844000
 𢌹	zsze	0
+𫄴	zsze	0
 㕖	zszf	4040
 𦁛	zszf	0
 统练	zszh	32400
@@ -103615,6 +107891,7 @@ encoder:
 𦀠	zszn	0
 絯	zszo	440000
 𠫯	zszo	0
+𪠠	zszo	0
 𨥣	zszp	0
 䋭	zszq	3740
 𠫞	zszq	0
@@ -103687,6 +107964,7 @@ encoder:
 縂	zujw	351000
 𦈎	zuke	0
 断电	zukz	2950000
+𫃨	zukz	0
 繒	zulk	778000
 缯	zulk	571000
 𦂏	zumf	0
@@ -103705,6 +107983,7 @@ encoder:
 彝文	zuso	74200
 断交	zuso	506000
 彝良	zusx	184000
+𫃼	zute	0
 断头	zutg	672000
 𦅗	zutr	0
 繕	zuuj	1020000
@@ -103731,6 +108010,7 @@ encoder:
 断线	zuzh	4240000
 𥿬	zuzi	0
 缕	zuzm	13700000
+𫃵	zuzm	0
 断绝	zuzr	3260000
 縌	zuzw	756000
 发型	zvae	11500000
@@ -103779,6 +108059,7 @@ encoder:
 发狂	zvqc	2760000
 发胖	zvqu	2460000
 絩	zvrd	76700
+𫃶	zvrj	0
 发言	zvsa	132000000
 发亮	zvsj	10500000
 发音	zvsk	8380000
@@ -103812,6 +108093,7 @@ encoder:
 发函	zvxk	781000
 发难	zvxn	1890000
 䋝	zvzm	3480
+𫃤	zvzm	0
 发给	zvzo	46900000
 发怒	zvzx	4760000
 发出	zvzz	75600000
@@ -103831,6 +108113,7 @@ encoder:
 编者	zwbm	8140000
 綄	zwbr	856000
 繨	zwbu	52900
+𫄀	zwbu	0
 縖	zwcj	33700
 缩聚	zwcx	160000
 𦄎	zwcx	0
@@ -103845,9 +108128,11 @@ encoder:
 𢧰	zwfh	0
 緷	zwfk	117000
 縺	zwfk	1770000
+𫄤	zwgd	0
 𦃲	zwgq	0
 綟	zwgs	65700
 𦂽	zwgs	0
+𫄫	zwgs	0
 编码	zwgx	93900000
 綋	zwgz	399000
 婉转	zwhb	3200000
@@ -103887,6 +108172,7 @@ encoder:
 缝合	zwoa	2030000
 编入	zwod	1570000
 𦇶	zwoi	0
+𫃻	zwoj	0
 缩微	zwol	530000
 编创	zwoy	407000
 𦇶	zwoy	0
@@ -103899,6 +108185,7 @@ encoder:
 纄	zwrc	32200
 缝	zwrc	28200000
 紞	zwrd	641000
+𫄣	zwrh	0
 编外	zwri	412000
 𦂦	zwrj	0
 紽	zwrr	38000
@@ -103915,6 +108202,7 @@ encoder:
 繸	zwug	80600
 𦆥	zwui	0
 縌	zwuz	756000
+𫃹	zwvr	0
 编写	zwwa	27300000
 缩写	zwwa	6040000
 编定	zwwd	238000
@@ -103931,6 +108219,7 @@ encoder:
 𦆣	zwxs	0
 綰	zwya	174000
 绾	zwya	2470000
+𫃣	zwya	0
 编导	zwyd	2500000
 𦁅	zwyd	0
 缝隙	zwyk	5060000
@@ -103947,6 +108236,7 @@ encoder:
 缝纫	zwzy	4380000
 绽出	zwzz	415000
 绿豆	zxaj	12400000
+𫃱	zxak	0
 䋖	zxbd	4180
 绎	zxbi	1170000
 经	zxbi	423000000
@@ -103989,6 +108279,8 @@ encoder:
 緑	zxkv	31500000
 绿	zxkv	140000000
 经常	zxkw	117000000
+𫄎	zxkz	0
+𫃯	zxld	0
 经典	zxle	422000000
 𦃌	zxlx	0
 𦇹	zxlz	0
@@ -104028,6 +108320,7 @@ encoder:
 绿灯	zxua	3500000
 𦂤	zxue	0
 怒火	zxuo	6750000
+𫄄	zxuz	0
 怒江	zxvb	2030000
 绿州	zxvn	199000
 经济	zxvs	386000000
@@ -104035,6 +108328,7 @@ encoder:
 经学	zxvw	584000
 经过	zxwd	172000000
 怒视	zxwl	885000
+𫃲	zxwl	0
 綅	zxwx	247000
 经心	zxwz	362000
 𥿲	zxxe	0
@@ -104097,6 +108391,7 @@ encoder:
 紹	zyja	4040000
 绍	zyja	8910000
 繦	zyji	163000
+𫄶	zyji	0
 𦂆	zyjj	0
 好吃	zyjm	30500000
 好听	zyjp	20000000
@@ -104104,6 +108399,7 @@ encoder:
 级别	zyjy	235000000
 𦇤	zykk	0
 𣫳	zyle	0
+𪭖	zylh	0
 𥁉	zylk	0
 𦁧	zylk	0
 貫	zylo	5630000
@@ -104118,6 +108414,7 @@ encoder:
 好手	zymd	4550000
 𥿰	zymf	0
 綖	zymi	519000
+𫄧	zymi	0
 好看	zyml	48000000
 𦂹	zymn	0
 𦀻	zymo	0
@@ -104180,6 +108477,7 @@ encoder:
 好戏	zyxh	4620000
 纪录	zyxk	48500000
 䋼	zyxl	4570
+𫄮	zyxl	0
 母鸡	zyxr	2460000
 𦀩	zyxx	0
 好书	zyxy	12100000
@@ -104239,6 +108537,7 @@ encoder:
 鄊	zzcy	19300
 出事	zzdj	9180000
 出操	zzdj	334000
+𪪋	zzdm	0
 出据	zzdx	372000
 出芽	zzeh	368000
 幼芽	zzeh	247000
@@ -104256,6 +108555,7 @@ encoder:
 𣤰	zzfr	0
 𪇱	zzfr	0
 出奇	zzga	8020000
+𫃰	zzgc	0
 𡗞	zzgd	0
 𨍃	zzgf	0
 出厂	zzgg	12400000
@@ -104348,6 +108648,7 @@ encoder:
 幼体	zznf	409000
 出售	zznj	131000000
 嚮	zznj	1190000
+𪢞	zznj	0
 出自	zznl	23600000
 出任	zznm	9130000
 𩞠	zzno	0
@@ -104388,6 +108689,8 @@ encoder:
 𣢄	zzro	0
 𦀷	zzrr	0
 𠤉	zzrs	0
+𪪊	zzrs	0
+𪹩	zzru	0
 𢛭	zzrw	0
 出色	zzry	43500000
 幽怨	zzry	2360000
@@ -104431,6 +108734,7 @@ encoder:
 糺	zzvv	159000
 絲	zzvv	29800000
 𠃏	zzvv	0
+𫄙	zzvv	0
 幻觉	zzvw	6250000
 幽深	zzvw	1910000
 丝袜	zzwa	11000000
@@ -104442,6 +108746,7 @@ encoder:
 幽邃	zzww	353000
 纞	zzwz	275000
 𢇀	zzxb	0
+𫃩	zzxe	0
 继承	zzxk	21300000
 𥃍	zzxl	0
 𥃎	zzxl	0
@@ -104491,6 +108796,7 @@ encoder:
 𦂣	zzzl	0
 𦇡	zzzl	0
 幼女	zzzm	4290000
+𪦥	zzzm	0
 纠纷	zzzo	30700000
 𢇃	zzzo	0
 斷	zzzp	21500000

--- a/zhengma.dict.yaml
+++ b/zhengma.dict.yaml
@@ -835,7 +835,6 @@ encoder:
 巿	ali	2690000
 帀	ali	187000
 丽	all	115000000
-𪪇	alm	0
 丙	alo	47400000
 迊	alw	57300
 𨙶	aly	0
@@ -941,9 +940,7 @@ encoder:
 坛	bbz	81100000
 埡	bbz	539000
 𡋱	bce	0
-𪣑	bce	0
 㙊	bch	4480
-𪣁	bci	0
 𡋃	bck	0
 堾	bco	23400
 埥	bcq	583000
@@ -955,25 +952,21 @@ encoder:
 𤣪	bdf	0
 亍	bdi	903000
 亘	bdk	1820000
-𪰵	bdk	0
 井	bdn	45100000
 寺	bds	49200000
 邿	bdy	49000
 亏	bdz	21100000
 亐	bdz	84600
 坩	beb	220000
-𪤕	beb	0
 㙋	bec	4110
 𡈿	bed	0
 墳	bee	1660000
 堞	bef	306000
 𡎡	bef	0
 𡊜	bej	0
-𪣪	bek	0
 垬	beo	230000
 墙	beu	78200000
 堪	bez	28600000
-𪣊	bez	0
 𡊖	bfa	0
 埔	bfb	12200000
 堙	bfb	312000
@@ -995,7 +988,6 @@ encoder:
 垅	bgm	943000
 項	bgo	106000000
 项	bgo	494000000
-𪢽	bgq	0
 㙇	bgs	4120
 𡉩	bgs	0
 𡊀	bgs	0
@@ -1022,8 +1014,6 @@ encoder:
 𢀛	bij	0
 墟	bik	4400000
 盐	bil	37400000
-𪤳	bio	0
-𪣯	biq	0
 五	bix	796000000
 𡊊	bix	0
 𢀑	bix	0
@@ -1066,7 +1056,6 @@ encoder:
 𡊰	bki	0
 𡌩	bkk	0
 𣆇	bkk	0
-𪣭	bkk	0
 趟	bkl	29000000
 嫠	bkm	250000
 釐	bkm	2970000
@@ -1074,12 +1063,10 @@ encoder:
 㙕	bkq	4030
 趙	bkq	13200000
 𡌔	bkq	0
-𪣬	bkq	0
 埸	bkr	3410000
 𡑿	bku	0
 堤	bkv	23000000
 𡉺	bkv	0
-𪣄	bkv	0
 塌	bky	7500000
 礼	bkz	5750000
 𡏱	bkz	0
@@ -1093,7 +1080,6 @@ encoder:
 𡉅	bld	0
 𡉉	bld	0
 𡊤	bld	0
-𪣶	ble	0
 堝	blj	1920000
 圸	bll	56300
 賣	bll	88800000
@@ -1121,13 +1107,11 @@ encoder:
 趱	bmr	314000
 趲	bmr	37800
 煮	bmu	49600000
-𪣌	bmw	0
 䎞	bmx	3480
 垖	bmy	43100
 教	bmy	250000000
 都	bmy	1370000000
 𡉛	bmy	0
-𪜖	bmz	0
 𡍤	bnb	0
 堭	bnc	43600
 𡌏	bnc	0
@@ -1187,7 +1171,6 @@ encoder:
 鞏	bqe	743000
 垛	bqf	2820000
 堸	bqi	51300
-𪣍	bqj	0
 堋	bqq	586000
 坍	bqs	982000
 𡉕	bqs	0
@@ -1225,13 +1208,10 @@ encoder:
 趨	brz	4170000
 𡊲	bsc	0
 垶	bse	942000
-𪢻	bsh	0
 壠	bsi	54400
 培	bsj	26800000
-𪣦	bsj	0
 堷	bsk	51900
 境	bsk	96300000
-𪣎	bsk	0
 壞	bsl	24300000
 熬	bsm	28200000
 坟	bso	7250000
@@ -1241,7 +1221,6 @@ encoder:
 坊	bsy	123000000
 垓	bsz	602000
 𡒲	btb	0
-𪣕	btb	0
 圹	btg	316000
 壙	btg	253000
 趑	btr	98100
@@ -1275,12 +1254,10 @@ encoder:
 𥑟	bwg	0
 壶	bwk	22100000
 𡉴	bwm	0
-𪣏	bwm	0
 坹	bwo	26500
 壳	bwq	43600000
 殻	bwq	7680000
 坨	bwr	2250000
-𪣲	bwy	0
 志	bwz	122000000
 𡉾	bwz	0
 𡋀	bwz	0
@@ -1289,7 +1266,6 @@ encoder:
 𡍜	bxd	0
 坡	bxi	29500000
 吾	bxj	34000000
-𪣩	bxj	0
 墹	bxk	60000
 堳	bxl	33900
 声	bxm	391000000
@@ -1301,7 +1277,6 @@ encoder:
 馨	bxq	38600000
 坭	bxr	539000
 㘮	bxs	6050
-𪢶	bxs	0
 燾	bxu	196000
 堀	bxz	6810000
 孝	bya	17900000
@@ -1324,13 +1299,11 @@ encoder:
 起	byy	634000000
 𡉖	byz	0
 𥿚	byz	0
-𪣇	byz	0
 亞	bza	48200000
 堊	bzb	181000
 𡉵	bzb	0
 弆	bze	122000
 𡊯	bze	0
-𪣊	bze	0
 𡋠	bzf	0
 毐	bzg	231000
 凷	bzi	33600
@@ -1349,7 +1322,6 @@ encoder:
 去	bzs	695000000
 运	bzw	361000000
 迲	bzw	171000
-𪢷	bzx	0
 却	bzy	343000000
 坶	bzy	102000
 𨚫	bzy	0
@@ -1366,7 +1338,6 @@ encoder:
 玒	cbi	135000
 髻	cbj	2810000
 𤥐	cbj	0
-𪼂	cbk	0
 琽	cbm	23200
 耕	cbn	11400000
 玩	cbr	372000000
@@ -1380,7 +1351,6 @@ encoder:
 聶	ccc	1560000
 珥	cce	1430000
 聽	cce	66200000
-𪼊	cce	0
 琹	ccf	111000
 玤	cci	26500
 酆	ccl	652000
@@ -1409,7 +1379,6 @@ encoder:
 瑚	cej	1570000
 瑾	cej	5880000
 𦔻	cej	0
-𪻿	cej	0
 𤦘	cek	0
 瑛	cel	5980000
 珙	ceo	1160000
@@ -1420,7 +1389,6 @@ encoder:
 𤦧	cew	0
 耶	cey	62200000
 𨛓	cey	0
-𫆲	cey	0
 㻣	cez	4600
 玴	cez	101000
 耴	cez	52800
@@ -1443,7 +1411,6 @@ encoder:
 㺽	cga	4250
 琦	cga	13900000
 騎	cga	15200000
-𪼁	cgb	0
 㺯	cgd	4070
 耨	cgd	642000
 馱	cgd	892000
@@ -1501,7 +1468,6 @@ encoder:
 珿	cji	67000
 㻁	cjj	3810
 噩	cjj	1320000
-𪡈	cjj	0
 聖	cjm	39400000
 职	cjo	93200000
 琄	cjq	129000
@@ -1521,7 +1487,6 @@ encoder:
 𦓧	cko	0
 琑	ckq	35600
 𤦛	ckq	0
-𪼖	ckq	0
 琨	ckr	1870000
 璟	cks	3830000
 璞	cku	3210000
@@ -1541,9 +1506,6 @@ encoder:
 𤤢	cld	0
 𤤪	cld	0
 𤦇	cld	0
-𪼅	cld	0
-𪼍	cld	0
-𪼗	cld	0
 琠	cle	83800
 瑞	clg	102000000
 𤧗	clj	0
@@ -1582,9 +1544,6 @@ encoder:
 瑝	cnc	89900
 玔	cnd	43400
 髹	cnf	336000
-𪼆	cnf	0
-𪼨	cnf	0
-𪽈	cnf	0
 碧	cng	43500000
 玳	cnh	907000
 琟	cni	22300
@@ -1678,7 +1637,6 @@ encoder:
 𩡶	cub	0
 珜	cuc	535000
 班	cuc	221000000
-𪼚	cuc	0
 㻂	cue	4810
 馵	cue	50500
 𩡧	cue	0
@@ -1691,7 +1649,6 @@ encoder:
 璔	cul	27300
 耿	cuo	6740000
 𩡩	cuo	0
-𪻽	cuo	0
 𩢋	cuq	0
 璘	cur	850000
 𩥭	cur	0
@@ -1715,9 +1672,7 @@ encoder:
 耽	cwr	3330000
 琯	cwy	553000
 恥	cwz	9040000
-𪻼	cwz	0
 肆	cxb	7490000
-𪽆	cxc	0
 聚	cxg	113000000
 玻	cxi	16200000
 珺	cxj	1430000
@@ -1725,7 +1680,6 @@ encoder:
 瑂	cxl	37100
 珢	cxo	28200
 取	cxs	423000000
-𪻷	cxs	0
 玛	cxv	51300000
 聂	cxx	8410000
 𤧨	cxy	0
@@ -1733,7 +1687,6 @@ encoder:
 㺭	cya	4460
 耔	cya	927000
 𤤻	cyc	0
-𪲱	cyf	0
 契	cyg	23600000
 耙	cyi	2310000
 玿	cyj	98000
@@ -1774,11 +1727,9 @@ encoder:
 㨋	dbm	4030
 拷	dbm	6580000
 扶	dbo	31800000
-𪮋	dbo	0
 挟	dbu	5500000
 捂	dbx	22800000
 𢵋	dby	0
-𪭴	dby	0
 扝	dbz	29700
 掗	dbz	1530000
 揍	dca	9350000
@@ -1891,7 +1842,6 @@ encoder:
 挰	djc	32900
 㧢	djd	3690
 捆	djf	9700000
-𪮎	djf	0
 摑	djh	663000
 捉	dji	18000000
 𢪠	dji	0
@@ -1951,7 +1901,6 @@ encoder:
 搰	dlw	80200
 撾	dlw	106000
 擺	dlz	12300000
-𪭿	dma	0
 𢪧	dmb	0
 𢪭	dmb	0
 抙	dmd	30500
@@ -1964,7 +1913,6 @@ encoder:
 𢯙	dmj	0
 挿	dmk	867000
 攥	dml	2830000
-𪮨	dml	0
 撬	dmm	5670000
 插	dmn	148000000
 𢪛	dmo	0
@@ -2004,7 +1952,6 @@ encoder:
 𢫬	dof	0
 𢫱	doi	0
 挩	doj	92800
-𪯏	doj	0
 𢷀	dok	0
 捨	dom	5470000
 扴	don	68100
@@ -2071,7 +2018,6 @@ encoder:
 絷	dqz	155000
 捀	drc	38300
 𢳚	drf	0
-𪮜	drf	0
 擔	drg	2280000
 扺	drh	186000
 揝	dri	68600
@@ -2094,7 +2040,6 @@ encoder:
 扚	drs	35600
 抵	drs	33800000
 揈	drs	59600
-𪭳	drs	0
 搀	drt	1610000
 掬	dru	4020000
 拸	drv	757000
@@ -2130,19 +2075,16 @@ encoder:
 抖	dte	18700000
 攠	dtf	86100
 𢭩	dtf	0
-𪯖	dtf	0
 扩	dtg	16000000
 擴	dtg	3370000
 掂	dti	6310000
 扪	dtl	664000
-𪮕	dtq	0
 揹	dtr	1600000
 搁	dtr	9110000
 攗	dtu	49200
 摝	dtx	123000
 拌	dub	21000000
 𢭭	dub	0
-𪮇	duc	0
 拼	due	61600000
 撙	duf	193000
 𢬊	duf	0
@@ -2244,7 +2186,6 @@ encoder:
 𢩵	dyy	0
 㧈	dyz	4090
 𢪬	dyz	0
-𪮖	dzb	0
 拚	dze	6390000
 掺	dzg	7820000
 掾	dzg	777000
@@ -2303,7 +2244,6 @@ encoder:
 𤯆	ebs	0
 𧨅	ebs	0
 荚	ebu	1390000
-𫈞	ebx	0
 苇	eby	7530000
 邯	eby	2850000
 𦭎	eby	0
@@ -2360,9 +2300,7 @@ encoder:
 协	edy	71800000
 𠦗	edy	0
 𨙩	edy	0
-𪠀	edy	0
 𠃒	edz	0
-𪜀	edz	0
 𦬵	eea	0
 苷	eeb	2640000
 靯	eeb	24100
@@ -2398,7 +2336,6 @@ encoder:
 茜	efj	18100000
 莕	efj	92900
 𦴖	efj	0
-𫈵	efj	0
 莗	efk	26400
 菄	efk	47200
 蕾	efk	51300000
@@ -2467,7 +2404,6 @@ encoder:
 荿	ehy	153000
 藏	ehz	146000000
 𦀂	ehz	0
-𫈣	ehz	0
 䒙	eia	4140
 𦱱	eie	0
 萀	eih	29700
@@ -2475,14 +2411,12 @@ encoder:
 𧏊	eii	0
 苫	eij	1850000
 蘋	eik	2120000
-𫈦	eik	0
 夔	ein	1700000
 𧀤	eio	0
 茈	eir	336000
 茧	eiv	5390000
 𦯭	eiz	0
 難	ejb	54400000
-𪣛	ejb	0
 勤	ejc	37900000
 茵	ejd	11800000
 莡	eji	19200
@@ -2504,7 +2438,6 @@ encoder:
 𦬹	eka	0
 荲	ekb	40400
 𦯖	ekb	0
-𫈴	ekb	0
 菲	ekc	59500000
 莳	ekd	689000
 戴	eke	91800000
@@ -2553,7 +2486,6 @@ encoder:
 𦯶	eld	0
 𦱌	eld	0
 𧁧	eld	0
-𫈟	eld	0
 矗	ele	3860000
 萛	ele	55000
 𦯛	ele	0
@@ -2592,7 +2524,6 @@ encoder:
 䓡	emj	8780
 萂	emj	145000
 𦮽	emj	0
-𫉏	emj	0
 萫	emk	119000
 薰	eml	28600000
 薙	emn	1260000
@@ -2612,7 +2543,6 @@ encoder:
 𦵐	enb	0
 葟	enc	32700
 苻	end	696000
-𫈝	end	0
 萆	ene	192000
 𦻧	ene	0
 茠	enf	154000
@@ -2644,7 +2574,6 @@ encoder:
 𦱉	enz	0
 𢌰	eoa	0
 蔹	eob	182000
-𫈨	eob	0
 荃	eoc	4230000
 𦫸	eod	0
 茶	eof	154000000
@@ -2664,7 +2593,6 @@ encoder:
 苓	eow	5900000
 䓹	eox	3860
 葎	eox	437000
-𫈜	eox	0
 芬	eoy	33300000
 蓊	eoz	488000
 𦬆	eoz	0
@@ -2690,7 +2618,6 @@ encoder:
 荽	epz	1090000
 𦷲	epz	0
 十月	eqa	49800000
-𫈺	eqc	0
 芁	eqd	21700
 䒳	eqf	4260
 获	eqg	150000000
@@ -2713,7 +2640,6 @@ encoder:
 𦰔	erf	0
 芪	erh	633000
 𧊮	eri	0
-𫉎	eri	0
 苟	erj	3820000
 茖	erj	151000
 茗	erj	12200000
@@ -2762,19 +2688,16 @@ encoder:
 芠	eso	288000
 𦬩	eso	0
 裁	esr	8110000
-𫊽	ess	0
 苙	esu	73000
 蒂	esu	44700000
 芳	esy	55400000
 蓄	esz	20900000
 荘	etb	9620000
 薼	etb	38800
-𫈰	etb	0
 蔗	ete	1750000
 蘑	etf	1340000
 蘼	etf	2090000
 燕	etj	64400000
-𫉀	etk	0
 蒺	etm	116000
 蔺	etn	2400000
 茨	etr	24100000
@@ -2845,7 +2768,6 @@ encoder:
 芝	ewv	45100000
 迣	ewv	160000
 蕊	eww	7750000
-𫈛	eww	0
 𪓔	ewx	0
 劳	ewy	60000000
 勃	ewy	19100000
@@ -3062,7 +2984,6 @@ encoder:
 枻	fez	165000
 椹	fez	3000000
 櫀	fez	34500
-𪲚	ffa	0
 埜	ffb	1240000
 禁	ffb	86400000
 𣑛	ffb	0
@@ -3105,7 +3026,6 @@ encoder:
 𥒯	fgb	0
 𣒸	fgc	0
 杕	fgd	47100
-𪥍	fgd	0
 㮟	fgf	3900
 颥	fgg	54200
 桭	fgh	53900
@@ -3151,7 +3071,6 @@ encoder:
 杶	fhz	77300
 𣐋	fhz	0
 椒	fia	19800000
-𪲐	fia	0
 朴	fid	17800000
 𣖪	fif	0
 醵	fig	182000
@@ -3163,7 +3082,6 @@ encoder:
 棹	fik	1720000
 𣐤	fik	0
 楨	fil	1300000
-𪲧	fil	0
 𣔨	fiq	0
 榩	fis	22800
 枵	fja	204000
@@ -3182,7 +3100,6 @@ encoder:
 梱	fjf	10900000
 𣒛	fjf	0
 𣙳	fjf	0
-𪲶	fjf	0
 槶	fjh	359000
 樻	fji	1960000
 𣐄	fji	0
@@ -3198,7 +3115,6 @@ encoder:
 梋	fjq	36500
 𧟩	fjq	0
 露	fjr	94600000
-𫍵	fjs	0
 束	fjv	22900000
 迺	fjw	852000
 速	fjw	272000000
@@ -3247,7 +3163,6 @@ encoder:
 東	fkv	137000000
 軣	fkv	28900
 𣏶	fkv	0
-𪲗	fkv	0
 檔	fkw	56900000
 連	fkw	126000000
 档	fkx	117000000
@@ -3269,11 +3184,9 @@ encoder:
 	fld	0
 𣐒	fld	0
 𣙡	fld	0
-𪲜	fld	0
 柵	fle	3740000
 棘	flf	7550000
 𣕱	flf	0
-𪳗	flf	0
 椯	flg	34200
 𣏑	fli	0
 楇	flj	48600
@@ -3285,7 +3198,6 @@ encoder:
 椇	flo	75600
 贾	flo	52600000
 𧴿	flo	0
-𪲕	flo	0
 𣙌	flp	0
 枧	flr	289000
 梘	flr	58200
@@ -3353,7 +3265,6 @@ encoder:
 靃	fnn	52700
 霓	fnr	6130000
 檄	fns	1530000
-𪳜	fns	0
 櫆	fnt	458000
 樵	fnu	5540000
 櫋	fnw	37000
@@ -3465,7 +3376,6 @@ encoder:
 釀	fsj	2760000
 栐	fsk	98600
 靄	fsk	1660000
-𪳠	fsk	0
 柿	fsl	9480000
 敷	fsm	21500000
 霁	fsn	2280000
@@ -3489,7 +3399,6 @@ encoder:
 桩	ftb	11500000
 櫥	ftb	2330000
 枓	fte	179000
-𪲽	ftf	0
 櫎	ftg	136000
 㭣	ftj	4770
 榈	ftj	364000
@@ -3511,7 +3420,6 @@ encoder:
 梯	fuy	9290000
 楼	fuz	444000000
 霈	fva	1180000
-𫖟	fvb	0
 𩂊	fvc	0
 霮	fve	28400
 雬	fvf	32400
@@ -3526,14 +3434,11 @@ encoder:
 𣓭	fvl	0
 酬	fvn	19000000
 霪	fvp	242000
-𪲺	fvq	0
-𫖠	fvq	0
 桃	fvr	46100000
 𩅔	fvr	0
 霅	fvs	144000
 樑	fvy	2160000
 𨜄	fvy	0
-𫖞	fvy	0
 柠	fwa	14300000
 檳	fwa	872000
 棕	fwb	9960000
@@ -3605,7 +3510,6 @@ encoder:
 𣏖	fyi	0
 枷	fyj	2360000
 柖	fyj	23000
-𪲡	fyk	0
 㭁	fym	4110
 朸	fym	186000
 柫	fyn	24900
@@ -3625,7 +3529,6 @@ encoder:
 蚻	fzi	47200
 枱	fzj	505000
 輜	fzk	939000
-𪲒	fzm	0
 酸	fzo	89500000
 擊	fzq	14500000
 梭	fzr	19800000
@@ -3693,7 +3596,6 @@ encoder:
 𧥢	gds	0
 𡗜	gdu	0
 达	gdw	393000000
-𪥊	gdx	0
 𥑠	geb	0
 𥕛	geb	0
 䃆	gec	4770
@@ -3725,7 +3627,6 @@ encoder:
 圧	ggb	4590000
 礪	gge	193000
 磊	ggg	21600000
-𫀍	ggh	0
 𥐴	ggi	0
 𥑛	ggj	0
 豳	ggl	341000
@@ -3742,7 +3643,6 @@ encoder:
 燹	ggu	138000
 碱	gha	36200000
 𥒓	ghb	0
-𪣝	ghb	0
 辱	ghd	8940000
 砗	ghe	340000
 𣕥	ghf	0
@@ -3773,7 +3673,6 @@ encoder:
 甭	gil	5120000
 𥄓	gil	0
 𥗊	gio	0
-𫀉	giv	0
 还	giw	1050000000
 存	giy	175000000
 𨚀	giy	0
@@ -3784,14 +3683,12 @@ encoder:
 硘	gjj	20800
 靣	gjj	84500
 面	gjk	905000000
-𫀎	gjq	0
 䂖	gjs	5070
 碍	gka	11700000
 𥑲	gka	0
 厘	gkb	40100000
 𥓄	gkb	0
 厞	gkc	85300
-𫀖	gkc	0
 矵	gkd	27200
 䂺	gkf	5080
 𥓖	gkf	0
@@ -3904,7 +3801,6 @@ encoder:
 𥑸	gpy	0
 磎	gpz	67300
 豕	gqa	3610000
-𫏀	gqa	0
 䝅	gqb	5050
 矶	gqd	2110000
 𢍒	gqe	0
@@ -3932,7 +3828,6 @@ encoder:
 𡯥	gri	0
 硌	grj	1020000
 𥒊	grj	0
-𫀃	grj	0
 碈	grk	83300
 𡯙	grk	0
 𡯟	grk	0
@@ -3954,7 +3849,6 @@ encoder:
 䲽	grz	3900
 鴀	grz	50700
 砫	gsc	163000
-𫀐	gse	0
 飆	gsg	6300000
 飙	gsg	6810000
 𥐞	gsh	0
@@ -3995,7 +3889,6 @@ encoder:
 確	gwn	7520000
 𥑫	gwo	0
 碗	gwr	74200000
-𫀊	gwy	0
 恧	gwz	99800
 磴	gxa	970000
 硉	gxb	166000
@@ -4016,7 +3909,6 @@ encoder:
 𥐮	gxs	0
 码	gxv	274000000
 矷	gya	57200
-𫀁	gya	0
 𥐛	gyd	0
 頋	gyg	82300
 顾	gyg	41900000
@@ -4029,7 +3921,6 @@ encoder:
 𥐦	gyy	0
 夷	gyz	9030000
 𠚈	gzi	0
-𫀆	gzj	0
 碌	gzk	2560000
 耍	gzm	41300000
 雄	gzn	84700000
@@ -4047,7 +3938,6 @@ encoder:
 式	hbi	429000000
 辕	hbj	12300000
 𥘐	hbk	0
-𫀰	hbk	0
 貳	hbl	2860000
 贰	hbl	3950000
 鵛	hbr	20700
@@ -4089,7 +3979,6 @@ encoder:
 轾	hhb	78000
 𢍴	hhe	0
 𤕪	hhi	0
-𪟯	hhi	0
 盞	hhl	3080000
 𦣣	hhm	0
 戚	hia	8860000
@@ -4106,7 +3995,6 @@ encoder:
 區	hjj	323000000
 轵	hjo	368000
 𠤴	hjo	0
-𪟱	hkb	0
 匪	hkc	16500000
 划	hkd	178000000
 匣	hki	22200000
@@ -4117,10 +4005,8 @@ encoder:
 辋	hld	244000
 匝	hli	2530000
 盏	hlk	11100000
-𪩀	hll	0
 医	hma	63300000
 戌	hma	7930000
-𪭠	hma	0
 𦣠	hmb	0
 𠤵	hmc	0
 戒	hme	34500000
@@ -4142,7 +4028,6 @@ encoder:
 𧩾	hms	0
 轷	hmu	51400
 成	hmy	723000000
-𫒛	hmy	0
 戉	hmz	62400
 𦃂	hmz	0
 雅	hni	142000000
@@ -4164,7 +4049,6 @@ encoder:
 暂	hpk	298000000
 錾	hpp	408000
 七月	hqa	34900000
-𪤆	hqb	0
 朢	hqc	755000
 𠙉	hqd	0
 㔯	hqj	7100
@@ -4187,7 +4071,6 @@ encoder:
 𧈩	hsi	0
 𧈱	hsi	0
 𢎃	hsk	0
-𪫏	hsm	0
 较	hso	241000000
 𢎀	hsq	0
 辙	hsz	3040000
@@ -4256,16 +4139,13 @@ encoder:
 蚨	ibo	364000
 𧋨	ibo	0
 蛱	ibu	266000
-𫋠	ibv	0
 齬	ibx	202000
 龉	ibx	525000
 𧈯	ibz	0
-𪜉	ibz	0
 𧈵	icd	0
 𧊗	ice	0
 𧋼	ice	0
 䗅	ich	3440
-𫋥	ich	0
 蚌	ici	3830000
 蟶	icj	218000
 𧋆	ick	0
@@ -4285,7 +4165,6 @@ encoder:
 蜞	iec	198000
 蝶	ief	54600000
 蟒	ieg	5450000
-𫌞	iei	0
 蛄	iej	287000
 蜡	iek	12900000
 蠛	iel	59200
@@ -4303,13 +4182,11 @@ encoder:
 蜙	ifo	22800
 蜥	ifp	1450000
 𧉱	ifs	0
-𫋾	ifv	0
 𧉹	ifz	0
 蚽	iga	48700
 蠣	ige	263000
 蜄	igh	32600
 𧉈	igi	0
-𫌊	igj	0
 劇	igk	36300000
 蛖	igm	23600
 螈	ign	319000
@@ -4327,12 +4204,10 @@ encoder:
 虐	ihh	16000000
 蚜	ihi	778000
 蜮	ihj	145000
-𫋘	ihj	0
 䖑	ihk	3760
 蝘	ihk	542000
 𧉦	ihm	0
 𧔼	ihm	0
-𫋞	ihr	0
 𧈺	ihs	0
 𧊥	ihs	0
 蚷	ihx	42400
@@ -4434,17 +4309,14 @@ encoder:
 𧊉	imw	0
 螄	imy	30000
 𧎵	imy	0
-𫋣	imy	0
 𧋬	imz	0
 虧	inb	3830000
 𧌫	inb	0
 蝗	inc	4230000
-𫋹	inc	0
 蜵	ind	21200
 𧈶	ind	0
 蜱	ine	371000
 𣑞	inf	0
-𫌘	inf	0
 蜼	ini	35000
 䖮	inj	3480
 螝	inj	57100
@@ -4454,7 +4326,6 @@ encoder:
 齒	ioa	5400000
 齿	ioa	15400000
 𧊲	ioc	0
-𫋲	iof	0
 䶚	ioi	3500
 𧊽	ioi	0
 蛻	ioj	522000
@@ -4474,7 +4345,6 @@ encoder:
 䖣	ipv	3510
 蟋	ipw	445000
 𧊓	ipy	0
-𫋿	ipy	0
 𧋵	iqc	0
 凣	iqd	38400
 虮	iqd	191000
@@ -4488,7 +4358,6 @@ encoder:
 蜂	irc	39200000
 柴	irf	25700000
 蟂	irf	21900
-𫌂	irf	0
 蟾	irg	2890000
 蚔	irh	493000
 𧎓	iri	0
@@ -4506,7 +4375,6 @@ encoder:
 鈭	irp	835000
 處	irq	71700000
 蚍	irr	128000
-𫋟	irr	0
 虳	irs	118000
 蚳	irs	611000
 𧈷	irs	0
@@ -4538,7 +4406,6 @@ encoder:
 蛢	iue	22800
 𧏪	iuf	0
 𧑞	iui	0
-𫋡	iui	0
 蜕	iuj	1700000
 蝉	iuk	7600000
 蟻	ium	4780000
@@ -4548,7 +4415,6 @@ encoder:
 蜷	iuy	1720000
 壑	iwa	2830000
 蝊	iwd	26300
-𫋻	iwf	0
 螟	iwk	1730000
 蝙	iwl	291000
 䖩	iwm	4050
@@ -4588,7 +4454,6 @@ encoder:
 𧈣	iym	0
 𧈳	iys	0
 𧉔	iyz	0
-𫋟	iza	0
 𧉤	ize	0
 蝝	izg	86200
 虯	izi	130000
@@ -4975,7 +4840,6 @@ encoder:
 𠯯	jnx	0
 哈	joa	190000000
 㘴	job	7810
-𪠹	job	0
 跧	joc	38900
 𠱴	joc	0
 㕥	jod	4510
@@ -4983,7 +4847,6 @@ encoder:
 唏	jog	1500000
 哘	joi	186000
 𠮶	joi	0
-𪠺	joj	0
 啥	jom	94100000
 唑	joo	5080000
 嗲	joo	4040000
@@ -5011,7 +4874,6 @@ encoder:
 呱	jps	2930000
 嗳	jpw	2600000
 噯	jpw	2180000
-𪡁	jpy	0
 蹊	jpz	3170000
 叽	jqd	3170000
 哚	jqf	828000
@@ -5047,7 +4909,6 @@ encoder:
 呧	jrs	51200
 𠮭	jrs	0
 𠮻	jrs	0
-𪡥	jrs	0
 图	jrt	941000000
 哆	jrv	10100000
 咆	jry	1090000
@@ -5164,7 +5025,6 @@ encoder:
 叹	jxs	31500000
 呎	jxs	3500000
 𠽹	jxs	0
-𪠵	jxs	0
 嚍	jxu	75300
 吗	jxv	959000000
 嗓	jxx	2870000
@@ -5227,7 +5087,6 @@ encoder:
 题	kag	93700000
 町	kai	148000000
 𣄿	kai	0
-𪰩	kaj	0
 量	kak	723000000
 师	kal	416000000
 曬	kal	8860000
@@ -5237,14 +5096,11 @@ encoder:
 曉	kbb	15200000
 時	kbd	589000000
 𣄾	kbd	0
-𪰠	kbi	0
-𪰳	kbj	0
 晅	kbk	62800
 𣇖	kbk	0
 𥆤	kbl	0
 暏	kbm	169000
 暑	kbm	14500000
-𫚨	kbr	0
 里	kbv	616000000
 曀	kbw	86400
 野	kbx	90800000
@@ -5254,7 +5110,6 @@ encoder:
 昙	kbz	1780000
 𣅘	kbz	0
 𣅙	kbz	0
-𪰿	kbz	0
 韭	kca	5130000
 𡌦	kcb	0
 𤦅	kcc	0
@@ -5267,10 +5122,8 @@ encoder:
 𥇖	kcl	0
 暙	kco	474000
 晴	kcq	46600000
-𪰫	kcs	0
 旺	kcv	65500000
 最	kcx	1270000000
-𪱓	kcz	0
 刂	kda	1070000
 时	kds	850000000
 畢	keb	7450000
@@ -5286,7 +5139,6 @@ encoder:
 晎	keo	34700
 暴	keo	83300000
 𨚰	key	0
-𪰪	kfa	0
 晡	kfb	303000
 暷	kfd	29000
 晽	kff	48800
@@ -5348,12 +5200,10 @@ encoder:
 畏	kih	9940000
 𤱥	kih	0
 𤱻	kih	0
-𪰤	kii	0
 胃	kiq	30000000
 𤰾	kiq	0
 鴨	kir	9980000
 鸭	kir	25400000
-𪾌	kir	0
 思	kiw	179000000
 邮	kiy	95100000
 累	kiz	84500000
@@ -5387,7 +5237,6 @@ encoder:
 遝	kkw	133000
 㫣	kkz	6140
 𠃪	kkz	0
-𪱜	kkz	0
 𣅣	kla	0
 𣌬	kla	0
 曙	klb	7410000
@@ -5411,7 +5260,6 @@ encoder:
 曼	klx	64600000
 勖	kly	366000
 愚	klz	18100000
-𪰯	kma	0
 𣅫	kmb	0
 𤘵	kmb	0
 星	kmc	393000000
@@ -5419,15 +5267,12 @@ encoder:
 昇	kme	13300000
 𣅮	kme	0
 戥	kmh	249000
-𪰦	kmh	0
 昨	kmi	72600000
 晧	kmj	203000
 临	kmk	61500000
 监	kml	70100000
 览	kml	65800000
 𣆢	kml	0
-𪰹	kmm	0
-𪰥	kmo	0
 鉴	kmp	36400000
 𣆅	kmw	0
 劣	kmy	17500000
@@ -5451,7 +5296,6 @@ encoder:
 昑	koa	91600
 尘	kob	34400000
 𡭤	koc	0
-𪰻	koc	0
 㬰	kod	9760
 𣅁	kod	0
 𡭛	koe	0
@@ -5486,7 +5330,6 @@ encoder:
 逍	kqw	1950000
 旯	kqy	664000
 晷	kri	352000
-𪰡	kri	0
 㫥	krj	4980
 昫	krj	124000
 略	krj	77600000
@@ -5560,7 +5403,6 @@ encoder:
 沯	kvg	20200
 呇	kvj	179000
 沓	kvk	2290000
-𪰼	kvn	0
 𣱺	kvo	0
 𨥗	kvp	0
 𣍤	kvq	0
@@ -5578,7 +5420,6 @@ encoder:
 賞	kwl	55000000
 赏	kwl	81900000
 昈	kwm	43000
-𪰱	kwm	0
 党	kwr	116000000
 畹	kwr	934000
 裳	kws	5280000
@@ -5605,7 +5446,6 @@ encoder:
 㫗	kya	3930
 旫	kyd	14600
 昭	kyj	18800000
-𪰲	kyj	0
 男	kym	516000000
 𣅅	kym	0
 曊	kyn	31300
@@ -5620,7 +5460,6 @@ encoder:
 妟	kzm	51200
 曳	kzm	2710000
 𣅓	kzm	0
-𫍲	kzs	0
 电	kzv	606000000
 顯	kzz	11800000
 𣊡	kzz	0
@@ -5681,7 +5520,6 @@ encoder:
 𥉊	lcu	0
 䢸	lcy	3470
 𥆍	lcz	0
-𪿣	lcz	0
 𠀃	lda	0
 𠀇	lda	0
 𠔼	lda	0
@@ -5736,7 +5574,6 @@ encoder:
 賻	lfd	65400
 赙	lfd	161000
 𥆺	lfd	0
-𪿛	lff	0
 䀳	lfj	7130
 𥆪	lfj	0
 崠	lfk	518000
@@ -5771,7 +5608,6 @@ encoder:
 鴦	lgr	195000
 鸯	lgr	369000
 𥃺	lgr	0
-𪿏	lgr	0
 狊	lgs	34300
 炭	lgu	19400000
 販	lgx	9950000
@@ -5837,7 +5673,6 @@ encoder:
 罼	lke	36100
 髁	lkf	860000
 𥇬	lkf	0
-𫅴	lkg	0
 岬	lki	7410000
 𠰝	lkj	0
 幌	lkk	2330000
@@ -5850,7 +5685,6 @@ encoder:
 𧵁	lkm	0
 𡭨	lko	0
 𦉵	lko	0
-𫅹	lkp	0
 䁌	lkq	6230
 睄	lkq	439000
 𦊈	lkq	0
@@ -5874,7 +5708,6 @@ encoder:
 𢌲	lle	0
 崾	llf	370000
 𡵬	llf	0
-𪳰	llf	0
 岩	llg	44300000
 𡶌	llg	0
 𥇷	llg	0
@@ -5924,7 +5757,6 @@ encoder:
 幯	lmx	79100
 屹	lmy	1720000
 巍	lmz	7400000
-𪿚	lmz	0
 嶼	lna	2730000
 𥃹	lnd	0
 睥	lne	424000
@@ -5961,7 +5793,6 @@ encoder:
 嵢	los	25400
 岭	low	27200000
 嶺	low	6650000
-𪿕	low	0
 盼	loy	37400000
 郥	loy	27400
 骺	lpa	188000
@@ -6014,7 +5845,6 @@ encoder:
 𥋮	lrs	0
 𥋯	lrs	0
 𧠻	lrs	0
-𪿎	lrs	0
 眵	lrv	83300
 睁	lrx	42700000
 䀚	lry	5690
@@ -6029,7 +5859,6 @@ encoder:
 眿	lsk	86400
 罚	lsk	43000000
 罰	lsk	10100000
-𪿠	lsk	0
 𥇋	lsl	0
 嵼	lsm	32700
 盿	lso	111000
@@ -6072,7 +5901,6 @@ encoder:
 眺	lvr	5420000
 貯	lwa	1030000
 贮	lwa	4980000
-𪿑	lwa	0
 崇	lwb	33100000
 瞎	lwc	29100000
 𥇓	lwd	0
@@ -6092,7 +5920,6 @@ encoder:
 瞇	lwu	2220000
 𥋝	lwx	0
 䯆	lwz	3200
-𪬀	lwz	0
 瞪	lxa	19800000
 峄	lxb	1270000
 瞤	lxc	31900
@@ -6147,7 +5974,6 @@ encoder:
 笄	mae	871000
 秣	maf	832000
 𥬎	maf	0
-𪿶	maf	0
 舔	mag	9260000
 卸	mai	37300000
 𥫙	mai	0
@@ -6219,7 +6045,6 @@ encoder:
 毬	mdv	484000
 箨	mdx	139000
 筢	mdy	85500
-𫒗	mdy	0
 簧	mea	5340000
 䇞	meb	3490
 垂	meb	32200000
@@ -6229,7 +6054,6 @@ encoder:
 午	med	18800000
 𠀆	med	0
 簙	mef	77200
-𫂼	mef	0
 箬	meg	817000
 䇢	mej	3740
 氪	mej	880000
@@ -6242,7 +6066,6 @@ encoder:
 𠄒	mem	0
 穫	men	941000
 𥬹	meo	0
-𫃔	meq	0
 舞	mer	131000000
 無	meu	338000000
 穑	meu	376000
@@ -6278,7 +6101,6 @@ encoder:
 䄴	mfq	4890
 移	mfr	81900000
 秫	mfs	3080000
-𫁖	mfs	0
 穗	mfw	18600000
 䄦	mfy	4680
 範	mfy	3480000
@@ -6299,7 +6121,6 @@ encoder:
 𠂚	mgm	0
 乔	mgn	31400000
 筴	mgo	96700
-𫂮	mgq	0
 稽	mgr	5530000
 𥫵	mgs	0
 𥬇	mgs	0
@@ -6327,9 +6148,7 @@ encoder:
 𥄥	mhl	0
 笺	mhm	2330000
 籃	mhm	11400000
-𫂨	mhm	0
 篋	mho	211000
-𪵺	mhq	0
 簪	mhr	2350000
 𥫝	mhs	0
 矩	mhx	34000000
@@ -6341,7 +6160,6 @@ encoder:
 𨙲	mhy	0
 𦧆	mia	0
 乍	mid	14600000
-𫂠	mid	0
 甜	mie	46400000
 穢	mih	1450000
 箎	mih	53900
@@ -6395,7 +6213,6 @@ encoder:
 复	mkr	83200000
 𥬃	mks	0
 𥴼	mku	0
-𫂪	mku	0
 𥫸	mkv	0
 馝	mkw	96300
 甥	mky	3000000
@@ -6615,12 +6432,10 @@ encoder:
 𦙪	mxq	0
 簢	mxs	30000
 𥫢	mxs	0
-𫂦	mxs	0
 笃	mxv	3350000
 節	mxy	51400000
 季	mya	54000000
 𥫞	mya	0
-𫂡	mya	0
 乞	myd	5090000
 阜	mye	17600000
 頧	myg	42100
@@ -6731,7 +6546,6 @@ encoder:
 倀	nch	96700
 㒥	nci	4440
 仹	nci	52900
-𫐥	nci	0
 𨈖	ncj	0
 㑍	nck	4440
 僵	nck	7870000
@@ -6789,7 +6603,6 @@ encoder:
 俥	nfk	110000
 倲	nfk	269000
 價	nfl	87900000
-𪝍	nfl	0
 輿	nfo	1180000
 鵂	nfr	52300
 鸺	nfr	99300
@@ -6848,7 +6661,6 @@ encoder:
 僭	nhr	1240000
 𩶕	nhr	0
 代	nhs	303000000
-𫍳	nhs	0
 佢	nhx	15500000
 𠉛	nhy	0
 𠇘	nhz	0
@@ -6876,7 +6688,6 @@ encoder:
 鬼	nja	123000000
 堡	njb	36300000
 侱	njc	28400
-𪜷	njd	0
 個	nje	282000000
 𢍉	nje	0
 保	njf	166000000
@@ -6897,7 +6708,6 @@ encoder:
 𧫏	njs	0
 煲	nju	8860000
 仲	njv	61400000
-𪜮	njx	0
 𨝀	njy	0
 𩱺	njy	0
 俁	njz	76700
@@ -6909,7 +6719,6 @@ encoder:
 𠉶	nke	0
 倮	nkf	217000
 𣐩	nkf	0
-𪾨	nkf	0
 偎	nkh	2790000
 佃	nki	2190000
 𤼽	nki	0
@@ -6976,7 +6785,6 @@ encoder:
 𠇷	nmc	0
 㐿	nmd	4970
 仟	nme	4840000
-𪜱	nmf	0
 侨	nmg	14600000
 僑	nmg	6400000
 俄	nmh	47200000
@@ -7044,7 +6852,6 @@ encoder:
 㑟	npo	4450
 𠉠	npq	0
 𠇗	nps	0
-𪜳	nps	0
 僾	npw	892000
 皈	npx	2270000
 侜	npy	49500
@@ -7062,7 +6869,6 @@ encoder:
 𠈬	nrb	0
 兒	nrd	48400000
 华	nre	681000000
-𪝋	nrf	0
 倾	nrg	24400000
 傾	nrg	7260000
 𠇊	nrh	0
@@ -7077,7 +6883,6 @@ encoder:
 侚	nrk	119000
 𠉣	nrk	0
 𠐔	nrk	0
-𪜶	nrk	0
 貨	nrl	52000000
 货	nrl	240000000
 傑	nrm	21900000
@@ -7507,7 +7312,6 @@ encoder:
 忿	oyw	3270000
 邠	oyy	229000
 瓮	oza	1690000
-𪫈	oze	0
 枀	ozf	35200
 頌	ozg	3710000
 颂	ozg	9440000
@@ -7537,8 +7341,6 @@ encoder:
 銬	pba	349000
 铐	pba	1830000
 銈	pbb	1680000
-𫓓	pbb	0
-𫔭	pbb	0
 釭	pbi	164000
 銡	pbj	117000
 銾	pbk	22600
@@ -7565,7 +7367,6 @@ encoder:
 铒	pce	390000
 鋹	pch	79100
 𨰘	pci	0
-𫓈	pci	0
 鑩	pcj	24400
 銇	pck	1220000
 𨩃	pco	0
@@ -7597,7 +7398,6 @@ encoder:
 鉗	peb	1210000
 钳	peb	6140000
 錤	pec	64500
-𫔷	pec	0
 針	ped	18700000
 针	ped	49200000
 鐼	pee	33800
@@ -7637,14 +7437,12 @@ encoder:
 𠳅	pfj	0
 𨧃	pfj	0
 𨱈	pfj	0
-𫓔	pfj	0
 錬	pfk	2970000
 镭	pfk	4680000
 鍊	pfl	15000000
 錸	pfo	675000
 彩	pfp	306000000
 鉥	pfs	65800
-𫓥	pfv	0
 鏈	pfw	9290000
 䣋	pfy	3320
 錷	pfz	22200
@@ -7655,7 +7453,6 @@ encoder:
 錛	pge	292000
 锛	pge	2540000
 鋠	pgh	47100
-𫔳	pgh	0
 鈈	pgi	683000
 钚	pgi	760000
 𨥰	pgj	0
@@ -7690,7 +7487,6 @@ encoder:
 銭	phm	4740000
 钱	phm	333000000
 𨱆	phm	0
-𫔦	phm	0
 鐕	phr	430000
 釴	phs	68100
 鋮	phv	165000
@@ -7706,7 +7502,6 @@ encoder:
 鉞	phz	306000
 钺	phz	708000
 鉲	pia	172000
-𫓄	pia	0
 釙	pid	47300
 钋	pid	275000
 鐻	pig	34800
@@ -7738,7 +7533,6 @@ encoder:
 锅	pjl	29400000
 鉙	pjo	30300
 鋗	pjq	65100
-𫔴	pjq	0
 钟	pjv	244000000
 鉭	pka	99700
 钽	pka	1300000
@@ -7773,7 +7567,6 @@ encoder:
 𨭥	pku	0
 淾	pkv	26700
 鍉	pkv	73300
-𫓌	pkv	0
 鏜	pkw	149000
 镗	pkw	1070000
 铛	pkx	1960000
@@ -7830,7 +7623,6 @@ encoder:
 鋯	pmj	287000
 锆	pmj	2040000
 𨨛	pmj	0
-𫔺	pmj	0
 鍾	pmk	9100000
 锺	pmk	2710000
 𨩢	pml	0
@@ -7838,7 +7630,6 @@ encoder:
 锸	pmn	184000
 鉄	pmo	14200000
 铁	pmo	137000000
-𫓉	pmo	0
 鑽	pmr	9890000
 铣	pmr	4010000
 鍬	pmu	1230000
@@ -7853,7 +7644,6 @@ encoder:
 锈	pmy	19800000
 𨥊	pmy	0
 鋂	pmz	80900
-𫓞	pmz	0
 舀	pnb	2200000
 𨦁	pnb	0
 銵	pnc	101000
@@ -7897,7 +7687,6 @@ encoder:
 锉	poo	908000
 艙	pos	2450000
 钤	pos	757000
-𫔣	pov	0
 鈴	pow	27600000
 铃	pow	165000000
 𨩭	pox	0
@@ -7967,7 +7756,6 @@ encoder:
 錉	prk	21000
 鑥	prk	29500
 镥	prk	136000
-𫔰	prk	0
 覛	prl	24000
 鉚	prm	186000
 铆	prm	2330000
@@ -8102,11 +7890,9 @@ encoder:
 悉	pwz	8270000
 鈊	pwz	1640000
 𨦂	pwz	0
-𫔱	pwz	0
 鐙	pxa	837000
 爭	pxb	17000000
 释	pxb	16700000
-𫓒	pxb	0
 𨬔	pxc	0
 鍆	pxd	115000
 鋸	pxe	2300000
@@ -8141,7 +7927,6 @@ encoder:
 釨	pya	416000
 𠔾	pya	0
 𨥂	pya	0
-𫔤	pya	0
 釖	pyd	62900
 㭧	pyf	4320
 鈱	pyh	87400
@@ -8185,7 +7970,6 @@ encoder:
 亂	pzl	43600000
 釹	pzm	988000
 钕	pzm	714000
-𫓆	pzm	0
 鋑	pzo	43800
 𨰼	pzp	0
 鏘	pzr	856000
@@ -8218,7 +8002,6 @@ encoder:
 肤	qbo	96000000
 𦛣	qbo	0
 朊	qbr	366000
-𫇋	qbs	0
 狭	qbu	5600000
 肚	qbv	40900000
 𦙗	qbx	0
@@ -8319,7 +8102,6 @@ encoder:
 胩	qia	105000
 風	qia	145000000
 𦘱	qid	0
-𪱶	qid	0
 臄	qig	31500
 𦞐	qih	0
 胋	qij	27800
@@ -8373,7 +8155,6 @@ encoder:
 胴	qld	5160000
 𦙸	qld	0
 𦝓	qld	0
-𪲀	qld	0
 腆	qle	5530000
 𦙱	qle	0
 腡	qlj	30400
@@ -8424,7 +8205,6 @@ encoder:
 𦛓	qnb	0
 𦞆	qnb	0
 凰	qnc	7190000
-𪲃	qnc	0
 𦘶	qnd	0
 脾	qne	6950000
 䏫	qnf	3260
@@ -8494,7 +8274,6 @@ encoder:
 胝	qrs	421000
 狰	qrx	6740000
 胞	qry	7840000
-𫇌	qry	0
 鳩	qrz	6340000
 鸠	qrz	4200000
 𩿊	qrz	0
@@ -8593,7 +8372,6 @@ encoder:
 𦚣	qxo	0
 𦠥	qxq	0
 肞	qxs	34800
-𪱵	qxs	0
 腿	qxw	84300000
 猱	qxx	352000
 䐚	qxy	3870
@@ -8654,7 +8432,6 @@ encoder:
 鮭	rbb	4770000
 鲑	rbb	863000
 魟	rbi	684000
-𫛏	rbi	0
 鮚	rbj	47100
 鲒	rbj	81600
 䱈	rbk	4490
@@ -8673,7 +8450,6 @@ encoder:
 𩸕	rch	0
 䰷	rci	3790
 鱷	rcj	972000
-𫚠	rck	0
 鰿	rcl	23500
 䲠	rco	27800
 鰆	rco	223000
@@ -8686,14 +8462,11 @@ encoder:
 鲰	rcx	84000
 𩸾	rcy	0
 鮿	rcz	22800
-𫛠	rcz	0
 𩵝	rdm	0
 鯄	rdv	43000
-𫄌	rdz	0
 魽	reb	50500
 鯕	rec	61000
 鲯	rec	49200
-𫚔	red	0
 鱝	ree	24600
 鲼	ree	75700
 鰈	ref	294000
@@ -8717,12 +8490,9 @@ encoder:
 鰈	rez	294000
 鲽	rez	486000
 䱁	rfa	7430
-𫛕	rfa	0
 鯆	rfb	62100
-𫛟	rfb	0
 鯂	rfd	17500
 𩺤	rff	0
-𫚝	rfj	0
 鯟	rfk	42200
 鯠	rfo	62700
 𩶄	rfs	0
@@ -8744,7 +8514,6 @@ encoder:
 顷	rgo	7280000
 鮪	rgq	2880000
 鲔	rgq	525000
-𫚥	rgq	0
 魷	rgr	1370000
 鱿	rgr	2960000
 然	rgs	97100000
@@ -8789,7 +8558,6 @@ encoder:
 象	rjg	191000000
 𩵵	rji	0
 鮰	rjj	247000
-𫛚	rjj	0
 雒	rjn	873000
 鮂	rjo	27600
 𩷫	rjq	0
@@ -8805,20 +8573,17 @@ encoder:
 𠜪	rkd	0
 鸔	rke	35100
 𩸄	rkf	0
-𫛣	rkf	0
 潁	rkg	663000
 鰃	rkh	47000
 鳂	rkh	31200
 备	rki	709000000
 甸	rki	15300000
-𫋬	rki	0
 鯧	rkk	95900
 鲳	rkk	906000
 𩷽	rkk	0
 鰻	rkl	3780000
 鳗	rkl	4050000
 魦	rkm	37400
-𫛒	rkm	0
 尔	rko	175000000
 𩵖	rko	0
 鮹	rkq	85400
@@ -8850,7 +8615,6 @@ encoder:
 𧢲	rld	0
 𩶠	rld	0
 𩸒	rld	0
-𫚖	rld	0
 𢍅	rle	0
 觫	rlf	105000
 奂	rlg	2100000
@@ -8935,7 +8699,6 @@ encoder:
 魜	rod	1030000
 𩶼	rof	0
 𩸈	roi	0
-𫚟	roi	0
 咎	roj	4640000
 刎	rok	578000
 鮽	rom	99600
@@ -8989,7 +8752,6 @@ encoder:
 𠨐	rry	0
 鷠	rrz	10700
 夊	rsa	2010000
-𪢺	rsb	0
 𩶃	rsc	0
 𢌳	rse	0
 𩷔	rse	0
@@ -9031,7 +8793,6 @@ encoder:
 麁	rtx	75000
 𩺮	rtx	0
 𩶐	rub	0
-𫚢	rub	0
 鮮	ruc	12700000
 鲜	ruc	41800000
 鮩	rue	31100
@@ -9059,9 +8820,7 @@ encoder:
 鳊	rwl	620000
 魲	rwm	56900
 鮅	rwm	28200
-𫛗	rwm	0
 鰫	rwo	34000
-𫚚	rwo	0
 鴕	rwr	77300
 鸵	rwr	400000
 迻	rwv	82700
@@ -9103,7 +8862,6 @@ encoder:
 𠣜	ryi	0
 𠤋	ryi	0
 𩵔	ryi	0
-𫚗	ryi	0
 句	ryj	179000000
 鮉	ryj	16800
 𩶛	ryj	0
@@ -9246,7 +9004,6 @@ encoder:
 𧧍	sfj	0
 諌	sfk	102000
 谭	sfk	29400000
-𫍷	sfk	0
 親	sfl	82000000
 谏	sfl	6170000
 誺	sfo	63200
@@ -9254,10 +9011,8 @@ encoder:
 訹	sfs	26700
 𣞇	sfs	0
 謰	sfw	40200
-𫍱	sga	0
 誇	sgb	1460000
 誫	sgh	21000
-𫎣	sgh	0
 㕻	sgj	3580
 斋	sgl	21400000
 產	sgm	19200000
@@ -9326,7 +9081,6 @@ encoder:
 詀	sij	115000
 𡃡	sij	0
 𧮪	sij	0
-𪜣	sik	0
 謯	sil	30300
 謼	sim	36700
 𠔂	sio	0
@@ -9336,7 +9090,6 @@ encoder:
 讋	sis	67100
 让	siv	694000000
 𧦫	six	0
-𫒮	siy	0
 誤	sja	17300000
 误	sja	92200000
 諿	sjc	28400
@@ -9394,14 +9147,12 @@ encoder:
 谡	sko	599000
 䥆	skp	5830
 銮	skp	845000
-𫓡	skp	0
 誚	skq	78400
 謂	skq	2930000
 诮	skq	408000
 谓	skq	9790000
 𠅥	skq	0
 𦚍	skq	0
-𪶙	skq	0
 竟	skr	93100000
 𧬬	sku	0
 氷	skv	9900000
@@ -9430,8 +9181,6 @@ encoder:
 𧧜	sld	0
 𧨋	sld	0
 𧨝	sld	0
-𫎞	sld	0
-𫎧	sld	0
 𢍓	sle	0
 𧧚	sle	0
 端	slg	128000000
@@ -9487,7 +9236,6 @@ encoder:
 𧪢	smy	0
 誨	smz	614000
 诲	smz	3360000
-𫍹	smz	0
 䜃	snb	4580
 譭	snb	144000
 𧧖	snb	0
@@ -9504,7 +9252,6 @@ encoder:
 褒	snj	3610000
 謉	snj	136000
 𧧦	snj	0
-𫎲	snj	0
 剂	snk	57400000
 詯	snl	25300
 亦	sno	122000000
@@ -9518,7 +9265,6 @@ encoder:
 𧧆	snx	0
 論	soa	48300000
 谕	soa	2680000
-𪣃	sob	0
 詮	soc	1390000
 诠	soc	2770000
 认	sod	63500000
@@ -9529,14 +9275,12 @@ encoder:
 蚉	soi	34900
 吝	soj	1670000
 刻	sok	70400000
-𪰨	sok	0
 离	sol	693000000
 𥄈	sol	0
 效	som	64300000
 交	soo	348000000
 診	sop	7170000
 诊	sop	8140000
-𪰀	sop	0
 𦙟	soq	0
 论	sor	132000000
 𩵳	sor	0
@@ -9633,7 +9377,6 @@ encoder:
 谚	ssm	1100000
 詨	sso	148000
 议	sso	55500000
-𫍯	sso	0
 襲	ssr	9610000
 譶	sss	32700
 辩	sss	14600000
@@ -9773,7 +9516,6 @@ encoder:
 𠲯	szj	0
 妄	szm	8510000
 娈	szm	1090000
-𫍮	szm	0
 刻	szo	70400000
 颏	szo	694000
 育	szq	70300000
@@ -9822,7 +9564,6 @@ encoder:
 闻	tce	82000000
 𤶦	tce	0
 痮	tch	23600
-𪾗	tch	0
 廒	tcr	87000
 癍	tcs	372000
 㾺	tcu	5450
@@ -9920,7 +9661,6 @@ encoder:
 阈	thj	1230000
 冻	thk	36900000
 戕	thm	372000
-𪾚	thm	0
 𤴵	ths	0
 丬	tia	283000
 壮	tib	22800000
@@ -9939,7 +9679,6 @@ encoder:
 阃	tjf	656000
 𤶭	tjf	0
 冲	tji	96900000
-𪾝	tji	0
 㾔	tjj	4820
 痐	tjj	196000
 癌	tjj	37800000
@@ -9978,7 +9717,6 @@ encoder:
 间	tlk	378000000
 疝	tll	1050000
 𤷢	tlo	0
-𫕫	tlq	0
 𤶻	tlr	0
 訚	tls	43500
 痈	tlv	845000
@@ -10040,7 +9778,6 @@ encoder:
 𤷕	tpf	0
 瘢	tpq	976000
 㽿	tps	8230
-𪾘	tpv	0
 阌	tpw	290000
 凈	tpx	2110000
 𤷸	tpy	0
@@ -10192,7 +9929,6 @@ encoder:
 𢗿	uaf	0
 关	uag	93600000
 忊	uai	280000
-𪫾	uaj	0
 粳	uak	932000
 𢘆	uak	0
 𣅑	uak	0
@@ -10204,7 +9940,6 @@ encoder:
 悽	uax	1500000
 𠔃	uaz	0
 𠔄	uaz	0
-𪫴	uaz	0
 烤	uba	30800000
 㤬	ubb	5080
 燒	ubb	28100000
@@ -10222,7 +9957,6 @@ encoder:
 鲞	ubr	236000
 誊	ubs	1260000
 悻	ubu	735000
-𪫵	ubv	0
 悟	ubx	18500000
 焐	ubx	908000
 券	uby	241000000
@@ -10237,7 +9971,6 @@ encoder:
 怅	uch	1050000
 悵	uch	973000
 𢗒	uci	0
-𪬃	uci	0
 𠲘	ucj	0
 𢙩	uck	0
 着	ucl	726000000
@@ -10279,27 +10012,23 @@ encoder:
 𢛻	ueq	0
 慌	ues	21400000
 迸	uew	3260000
-𪬖	uew	0
 忮	uex	254000
 怈	uez	22200
 愖	uez	32700
 㤓	ufa	4580
 悑	ufb	154000
 煙	ufb	16100000
-𪬠	ufb	0
 精	ufc	220000000
 尊	ufd	30600000
 𥸭	ufe	0
 惏	uff	42000
 慄	uff	1700000
 奠	ufg	2200000
-𫃪	ufg	0
 𧊾	ufi	0
 恓	ufj	148000
 悚	ufj	11100000
 𢚷	ufk	0
 𢛔	ufk	0
-𫃦	ufk	0
 煉	ufl	5740000
 慚	ufp	336000
 𥺻	ufp	0
@@ -10307,7 +10036,6 @@ encoder:
 懶	ufr	9730000
 怵	ufs	1350000
 糕	ufu	7170000
-𪫶	ufv	0
 慩	ufw	45400
 迷	ufw	119000000
 𥸬	ufy	0
@@ -10352,14 +10080,12 @@ encoder:
 炼	uhy	30900000
 怴	uhz	58600
 𢜜	uih	0
-𪫺	uii	0
 怗	uij	75100
 粘	uij	60400000
 悼	uik	3020000
 爐	uik	6660000
 夔	uin	1700000
 燦	uir	3350000
-𪫹	uiy	0
 悜	ujc	633000
 烟	ujd	96800000
 𢙫	ujd	0
@@ -10411,7 +10137,6 @@ encoder:
 惘	uld	1160000
 𢘭	uld	0
 𢜟	uld	0
-𪬁	uld	0
 惴	ulg	1890000
 𢝸	ulj	0
 怬	ulk	44500
@@ -10466,7 +10191,6 @@ encoder:
 恰	uoa	17000000
 𤆂	uoa	0
 灶	uob	12500000
-𪣂	uob	0
 恮	uoc	20900
 𤆦	uoc	0
 灷	uoe	21200
@@ -10540,7 +10264,6 @@ encoder:
 怉	ury	53100
 炮	ury	28200000
 𢗾	ury	0
-𪬃	usb	0
 炷	usc	1670000
 忙	ush	107000000
 忭	usi	163000
@@ -10704,7 +10427,6 @@ encoder:
 濤	vbx	3740000
 涍	vby	41400
 𣲗	vby	0
-𪶝	vby	0
 汚	vbz	5710000
 污	vbz	37300000
 𣲅	vbz	0
@@ -10731,7 +10453,6 @@ encoder:
 滠	vcx	142000
 潔	vcy	14400000
 𣵮	vcy	0
-𪶼	vcy	0
 㳧	vcz	9910
 溸	vcz	32300
 𣵱	vdc	0
@@ -10784,7 +10505,6 @@ encoder:
 濡	vfg	6800000
 洒	vfj	22200000
 涑	vfj	646000
-𪶢	vfj	0
 涷	vfk	165000
 潭	vfk	28800000
 𣵐	vfk	0
@@ -10822,7 +10542,6 @@ encoder:
 洧	vgq	287000
 漘	vgq	34600
 𣵠	vgq	0
-𫇡	vgq	0
 沋	vgr	52100
 𣲍	vgr	0
 𤀸	vgr	0
@@ -10853,7 +10572,6 @@ encoder:
 浳	vhq	33200
 潛	vhr	4730000
 㳚	vhs	4090
-𪶎	vhs	0
 汇	vhv	81900000
 涟	vhw	3510000
 洰	vhx	489000
@@ -10877,7 +10595,6 @@ encoder:
 滤	viw	17700000
 濬	viw	1210000
 泸	vix	2490000
-𪶖	viy	0
 潰	vja	2830000
 涠	vjb	459000
 𣳤	vjb	0
@@ -10937,7 +10654,6 @@ encoder:
 澤	vlb	9320000
 𣲹	vlb	0
 沮	vlc	1550000
-𪶥	vlc	0
 泂	vld	185000
 洞	vld	27300000
 浻	vld	75000
@@ -10960,7 +10676,6 @@ encoder:
 滑	vlw	76100000
 濄	vlw	889000
 湃	vma	1120000
-𪶗	vma	0
 汼	vmb	81600
 𡎒	vmb	0
 泩	vmc	290000
@@ -11098,12 +10813,10 @@ encoder:
 泜	vrs	38000
 渹	vrs	91300
 𣲋	vrs	0
-𪶒	vrs	0
 渔	vrv	18700000
 漁	vrv	7800000
 逃	vrw	56200000
 泡	vry	98200000
-𫒚	vry	0
 沟	vrz	26500000
 𩾯	vrz	0
 𡔆	vsb	0
@@ -11130,7 +10843,6 @@ encoder:
 汸	vsy	90700
 濟	vsy	6830000
 澈	vsz	3900000
-𪷜	vsz	0
 润	vtc	45400000
 渡	vte	74800000
 澜	vtf	9050000
@@ -11192,8 +10904,6 @@ encoder:
 澄	vxa	12900000
 泽	vxb	80000000
 𣲾	vxb	0
-𪣳	vxb	0
-𪫝	vxb	0
 潤	vxc	13400000
 浔	vxd	3700000
 𣶯	vxd	0
@@ -11242,7 +10952,6 @@ encoder:
 𥒟	vyg	0
 泯	vyh	3610000
 池	vyi	55400000
-𪶓	vyi	0
 沼	vyj	5640000
 泇	vyj	49200
 㳱	vyk	4240
@@ -11278,7 +10987,6 @@ encoder:
 灣	vzy	15800000
 𣳠	vzy	0
 滲	vzz	1670000
-𪸀	vzz	0
 迂	wad	1390000
 䢎	wae	3640
 袜	waf	18900000
@@ -11329,7 +11037,6 @@ encoder:
 㝉	wda	3840
 宇	wda	86100000
 宣	wdb	41200000
-𪧐	wdb	0
 守	wdd	67500000
 𡧅	wde	0
 宋	wdf	124000000
@@ -11360,7 +11067,6 @@ encoder:
 𨔋	wef	0
 𨔘	wef	0
 祜	wej	796000
-𫑝	wej	0
 逪	wek	26300
 遭	wek	113000000
 宽	wel	192000000
@@ -11380,7 +11086,6 @@ encoder:
 補	wfb	21900000
 逋	wfb	1110000
 𨕅	wfb	0
-𫒀	wfc	0
 逎	wfd	44900
 𨔰	wfe	0
 襟	wff	6470000
@@ -11404,7 +11109,6 @@ encoder:
 𨒩	wgl	0
 宠	wgm	22200000
 𨔞	wgo	0
-𫑰	wgo	0
 迶	wgq	250000
 逐	wgq	28100000
 𨑫	wgr	0
@@ -11425,7 +11129,6 @@ encoder:
 迓	whi	237000
 襤	whm	106000
 𨑘	whm	0
-𫑚	whs	0
 𨒑	whx	0
 窃	why	9120000
 窀	whz	210000
@@ -11635,7 +11338,6 @@ encoder:
 𨑑	wsh	0
 寵	wsi	3740000
 福	wsj	263000000
-𪠼	wsj	0
 神	wsk	295000000
 𥘗	wsk	0
 祖	wsl	41100000
@@ -11644,7 +11346,6 @@ encoder:
 这	wso	1090000000
 祈	wsp	19700000
 𨘔	wss	0
-𫀾	wss	0
 適	wsu	9670000
 祃	wsx	39100
 䢍	wsy	4250
@@ -11655,7 +11356,6 @@ encoder:
 遮	wte	22900000
 𧘬	wte	0
 褲	wtf	11600000
-𫑿	wtf	0
 实	wtg	151000000
 袥	wtg	152000
 裤	wth	67400000
@@ -11670,7 +11370,6 @@ encoder:
 裙	wtx	69900000
 襏	wtx	37800
 𧘈	wty	0
-𫌷	wtz	0
 袢	wub	1080000
 𨒃	wub	0
 祥	wuc	47900000
@@ -11697,7 +11396,6 @@ encoder:
 運	wwf	53000000
 𣎾	wwf	0
 军	wwh	142000000
-𫑴	wwh	0
 蜜	wwi	42600000
 𠕾	wwk	0
 遍	wwl	68800000
@@ -11713,14 +11411,12 @@ encoder:
 黽	wxa	89400
 迳	wxb	1560000
 遐	wxb	2470000
-𫑠	wxb	0
 裾	wxe	6640000
 袂	wxg	2430000
 被	wxi	983000000
 避	wxj	72000000
 逮	wxk	9490000
 通	wxl	521000000
-𫑵	wxl	0
 迉	wxm	80100
 退	wxo	198000000
 迟	wxs	54800000
@@ -11800,10 +11496,8 @@ encoder:
 䦒	xdg	3790
 閩	xdi	4220000
 𨷷	xdi	0
-𫕖	xdi	0
 問	xdj	124000000
 間	xdk	180000000
-𫕛	xdl	0
 閁	xdm	60600
 閉	xdm	9060000
 䦦	xdp	3880
@@ -11825,7 +11519,6 @@ encoder:
 𨙺	xey	0
 屉	xez	786000
 𩧾	xfb	0
-𫙦	xfj	0
 闌	xfl	341000
 骑	xga	87600000
 夬	xgd	322000
@@ -11834,7 +11527,6 @@ encoder:
 頗	xgo	8850000
 颇	xgo	46500000
 屋	xhb	208000000
-𫙤	xhb	0
 暨	xhk	71400000
 戏	xhm	46800000
 𢦐	xhm	0
@@ -11875,7 +11567,6 @@ encoder:
 𡭖	xko	0
 屑	xkq	11900000
 𩨅	xkq	0
-𪱺	xkq	0
 尿	xkv	29300000
 氶	xkv	1060000
 逮	xkw	9490000
@@ -11906,7 +11597,6 @@ encoder:
 迉	xmw	80100
 𡱏	xmz	0
 𦥖	xnb	0
-𫙭	xnc	0
 驯	xnd	3430000
 閥	xnh	2150000
 骓	xni	336000
@@ -11953,8 +11643,6 @@ encoder:
 𠮢	xsj	0
 昼	xsk	29200000
 甬	xsl	6570000
-𫙠	xso	0
-𪠨	xsq	0
 叉	xss	17700000
 𧦴	xss	0
 尽	xst	180000000
@@ -11965,7 +11653,6 @@ encoder:
 骇	xsz	7790000
 𠬹	xsz	0
 买	xtg	627000000
-𫎆	xtj	0
 骥	xtr	5120000
 屏	xue	177000000
 骈	xue	585000
@@ -11983,14 +11670,12 @@ encoder:
 骟	xwy	169000
 恳	xwz	4280000
 驿	xxb	7250000
-𪜞	xxe	0
 柔	xxf	36000000
 預	xxg	44500000
 预	xxg	117000000
 蝥	xxi	88700
 預	xxi	44500000
 预	xxi	117000000
-𫙣	xxi	0
 闢	xxj	1700000
 瞀	xxl	132000
 矛	xxm	8570000
@@ -12017,7 +11702,6 @@ encoder:
 孑	yaa	1550000
 𠄏	yaa	0
 𡤽	yaa	0
-𪫁	yad	0
 𨸦	yae	0
 𣏍	yaf	0
 䦺	yai	3470
@@ -12030,7 +11714,6 @@ encoder:
 彌	yao	5640000
 𡥀	yao	0
 𡥪	yas	0
-𪫂	yau	0
 卫	yav	99100000
 孔	yaz	63300000
 𨸑	yaz	0
@@ -12046,7 +11729,6 @@ encoder:
 陆	ybz	55100000
 𨻉	ybz	0
 弭	yce	1690000
-𫕽	yce	0
 张	ych	608000000
 彊	yck	990000
 䧞	ycu	3210
@@ -12070,7 +11752,6 @@ encoder:
 陻	yfb	25700
 𢌠	yfb	0
 𢌩	yfb	0
-𪫇	yfc	0
 孺	yfg	1200000
 䧈	yfj	3670
 廼	yfj	327000
@@ -12081,7 +11762,6 @@ encoder:
 隋	ygb	9530000
 𡏇	ygb	0
 𨻐	ygb	0
-𫕹	ygd	0
 陙	ygh	27200
 阫	ygi	22900
 𨹭	ygj	0
@@ -12133,7 +11813,6 @@ encoder:
 𨺁	ykf	0
 隈	ykh	1340000
 䧃	yki	3350
-𪫃	yki	0
 隙	ykk	7880000
 隅	ykl	8060000
 孙	yko	82600000
@@ -12153,7 +11832,6 @@ encoder:
 孟	ylk	30400000
 𡴺	yll	0
 𢌚	yll	0
-𫖃	ylo	0
 𨼅	ylp	0
 䧋	ylr	3480
 勐	yly	1120000
@@ -12172,7 +11850,6 @@ encoder:
 䧊	ymj	3460
 加	ymj	911000000
 尕	ymk	939000
-𪜍	ymk	0
 鼐	yml	643000
 办	ymo	418000000
 改	ymo	223000000
@@ -12188,7 +11865,6 @@ encoder:
 劜	ymz	101000
 孫	ymz	25800000
 隍	ync	371000
-𪫆	ync	0
 附	ynd	99900000
 陴	yne	187000
 𨻄	ynf	0
@@ -12251,7 +11927,6 @@ encoder:
 隌	ysk	34100
 障	ysk	15000000
 孩	yso	67200000
-𫕺	yso	0
 孓	ysv	1060000
 忍	ysw	117000000
 防	ysy	195000000
@@ -12282,7 +11957,6 @@ encoder:
 忌	ywz	22100000
 張韡武	yxa	26
 弪	yxb	97200
-𫕼	yxb	0
 𨼝	yxf	0
 陂	yxi	1480000
 限	yxo	317000000
@@ -12329,7 +12003,6 @@ encoder:
 𠙶	yzi	0
 𢎟	yzi	0
 𢎠	yzi	0
-𪫑	yzj	0
 𨹆	yzq	0
 𢐗	yzr	0
 弘	yzs	16300000
@@ -12366,12 +12039,10 @@ encoder:
 结	zbj	96100000
 妹	zbk	181000000
 絙	zbk	80300
-𫅒	zbk	0
 續	zbl	15900000
 緒	zbm	4630000
 緖	zbm	270000
 绪	zbm	4440000
-𫅌	zbm	0
 牆	zbo	8630000
 绫	zbo	3080000
 姥	zbr	2610000
@@ -12400,7 +12071,6 @@ encoder:
 巛	zda	709000
 𡿧	zda	0
 𥾒	zda	0
-𪲓	zdf	0
 䊷	zdm	3630
 䌶	zdm	4660
 紂	zds	194000
@@ -12459,13 +12129,11 @@ encoder:
 𦆕	zfz	0
 䋔	zga	3750
 綺	zga	6080000
-𫅐	zga	0
 绔	zgb	507000
 𦀰	zgb	0
 叁	zgc	9080000
 縟	zgd	60100
 缛	zgd	764000
-𫄜	zge	0
 娠	zgh	291000
 𦁄	zgh	0
 紑	zgi	928000
@@ -12511,7 +12179,6 @@ encoder:
 𡉟	zib	0
 𤯓	zib	0
 㞷	zic	4040
-𫄋	zid	0
 牀	zif	210000
 𦁲	zih	0
 䊼	zii	4170
@@ -12520,7 +12187,6 @@ encoder:
 綽	zik	719000
 绰	zik	1770000
 𠧡	zil	0
-𪻆	zis	0
 𥿓	zix	0
 𡳾	ziz	0
 娱	zja	22400000
@@ -12531,8 +12197,6 @@ encoder:
 絪	zjd	624000
 綑	zjf	690000
 繢	zji	52200
-𫄏	zji	0
-𫄖	zji	0
 絗	zjj	92000
 絽	zjj	910000
 绳	zjk	19000000
@@ -12542,7 +12206,6 @@ encoder:
 絹	zjq	4120000
 绢	zjq	3680000
 𦙃	zjq	0
-𫄍	zjv	0
 恕	zjw	20000000
 邕	zjy	3000000
 絮	zjz	9070000
@@ -12601,7 +12264,6 @@ encoder:
 纲	zld	7140000
 𥿑	zld	0
 𦂴	zld	0
-𫅓	zld	0
 姍	zle	1780000
 緺	zlj	85600
 緲	zlk	748000
@@ -12639,7 +12301,6 @@ encoder:
 𦀽	zmj	0
 姝	zmk	3030000
 媞	zmk	679000
-𪥱	zmk	0
 姐	zml	89300000
 娥	zmm	8840000
 收	zmo	459000000
@@ -12663,20 +12324,17 @@ encoder:
 姊	zmz	20500000
 𠃔	zmz	0
 𦂳	zmz	0
-𪨔	zmz	0
 𥿥	znb	0
 𦁴	znb	0
 緞	znc	2680000
 缎	znc	3870000
 紃	znd	44600
 𥾖	znd	0
-𫄬	znd	0
 婢	zne	3710000
 𦂖	zne	0
 䌖	znf	4290
 𦃨	znf	0
 𦈜	znf	0
-𫄓	znf	0
 𦃧	zng	0
 䗽	zni	3440
 維	zni	25100000
@@ -12742,7 +12400,6 @@ encoder:
 允	zrd	16900000
 將	zrd	171000000
 𠃔	zrd	0
-𪨔	zrd	0
 绦	zrf	1060000
 紙	zrh	75100000
 纸	zrh	137000000
@@ -12762,7 +12419,6 @@ encoder:
 䊻	zro	3610
 妣	zrr	381000
 纔	zrr	2350000
-𪟪	zrr	0
 約	zrs	156000000
 约	zrs	180000000
 𥿄	zrs	0
@@ -12783,7 +12439,6 @@ encoder:
 𦀓	zse	0
 欒	zsf	1240000
 𠫡	zsf	0
-𪜢	zsh	0
 㐃	zsi	5730
 䌬	zsi	4340
 蠻	zsi	15100000
@@ -12802,7 +12457,6 @@ encoder:
 䏍	zsq	3290
 𦣏	zsq	0
 嫡	zsu	1460000
-𫄒	zsu	0
 娘	zsx	86000000
 𠁾	zsx	0
 紡	zsy	2580000
@@ -12883,7 +12537,6 @@ encoder:
 绿	zxk	140000000
 𦅘	zxk	0
 媚	zxl	39200000
-𫄨	zxl	0
 娓	zxm	5250000
 繡	zxn	4540000
 繝	zxq	2900000
@@ -12906,7 +12559,6 @@ encoder:
 紖	zyi	157000
 纼	zyi	23400
 𥾯	zyi	0
-𫅏	zyi	0
 紹	zyj	4040000
 绍	zyj	8910000
 𠰔	zyj	0
@@ -12980,12 +12632,10 @@ encoder:
 开赴	aebi	916000
 开来	aebk	16500000
 开埠	aebm	170000
-𪪖	aebn	0
 䵤	aebu	4490
 形声	aebx	400000
 刑场	aeby	1010000
 开动	aebz	3690000
-𪫡	aecb	0
 开球	aecd	745000
 开春	aeco	2180000
 干扰	aedg	21400000
@@ -13035,7 +12685,6 @@ encoder:
 刊号	aeja	5060000
 型号	aeja	126000000
 开口	aeja	28100000
-𫈉	aejq	0
 开路	aejr	1680000
 干咳	aejs	1110000
 干吗	aejx	13300000
@@ -13084,7 +12733,6 @@ encoder:
 开销	aepk	4420000
 型钢	aepl	2790000
 开盘	aepl	16800000
-𫍚	aepl	0
 开镰	aept	76800
 干脆	aeqr	23800000
 开脱	aequ	1330000
@@ -13092,7 +12740,6 @@ encoder:
 㰢	aero	4550
 鳱	aerz	27700
 鳽	aerz	35400
-𫜠	aerz	0
 𪚒	aesi	0
 干部	aesj	61600000
 开课	aesk	4590000
@@ -13126,7 +12773,6 @@ encoder:
 开炮	aeur	2150000
 干粮	aeus	2970000
 开炉	aeuw	160000
-𫈌	aeux	0
 开卷	aeuy	3980000
 刑法	aevb	16700000
 开满	aeve	576000
@@ -13196,7 +12842,6 @@ encoder:
 末端	afsl	4310000
 末	afvv	121000000
 末尾	afxm	4470000
-𪜒	afyd	0
 末了	afyv	2150000
 𣚺	afyz	0
 幵	agae	893000
@@ -13376,7 +13021,6 @@ encoder:
 无愧	agun	7850000
 𡚑	agun	0
 无益	aguo	3040000
-𪸷	aguo	0
 无恙	aguw	3190000
 无数	aguz	41400000
 无法	agvb	281000000
@@ -13399,7 +13043,6 @@ encoder:
 蚕桑	agxx	849000
 天子	agya	10300000
 无异	agye	6920000
-𪥒	agyi	0
 无力	agym	26400000
 天险	agyo	548000
 无限	agyx	107000000
@@ -13433,7 +13076,6 @@ encoder:
 𧹁	ahil	0
 鵡	ahir	180000
 鹉	ahir	183000
-𫜇	ahir	0
 武器	ahjj	67200000
 武鸣	ahjr	457000
 武昌	ahkk	7940000
@@ -13474,7 +13116,6 @@ encoder:
 下列	aiar	60600000
 𡕣	aiar	0
 𠾥	aiax	0
-𫒘	aiay	0
 𡿰	aiaz	0
 𡿴	aiaz	0
 正巧	aiba	2780000
@@ -13491,7 +13132,6 @@ encoder:
 下去	aibz	105000000
 𠳊	aibz	0
 𡿰	aibz	0
-𪵛	aibz	0
 𢧎	aich	0
 正职	aicj	730000
 𧶷	aicl	0
@@ -13553,7 +13193,6 @@ encoder:
 𢦪	aijh	0
 下颚	aijj	882000
 正品	aijj	32200000
-𪾺	aijl	0
 下跌	aijm	27500000
 𢼔	aijm	0
 㪼	aijp	3960
@@ -13564,7 +13203,6 @@ encoder:
 𥘱	aijr	0
 𪀉	aijr	0
 𪃿	aijr	0
-𫜒	aijr	0
 𧭳	aijs	0
 正中	aijv	6600000
 𠄙	aijx	0
@@ -13618,7 +13256,6 @@ encoder:
 𥙳	ainf	0
 𢧖	ainh	0
 𨾖	aini	0
-𪶣	aink	0
 𥘲	ainl	0
 𧹚	aino	0
 𣂘	ainp	0
@@ -13634,7 +13271,6 @@ encoder:
 𩳮	aion	0
 夒	aior	69700
 蘷	aior	25500
-𪤾	aior	0
 下令	aiow	14900000
 政令	aiow	3070000
 𠾥	aiow	0
@@ -13656,7 +13292,6 @@ encoder:
 𠶘	airk	0
 正负	airl	1250000
 𣀋	airm	0
-𪢪	airm	0
 𠀵	airo	0
 正比	airr	4290000
 𠀢	airr	0
@@ -13707,7 +13342,6 @@ encoder:
 𠃎	aivv	0
 下沉	aivw	3520000
 政治	aivz	321000000
-𪡕	aivz	0
 正宁	aiwa	107000
 正宗	aiwb	18900000
 正割	aiwc	28500
@@ -13846,7 +13480,6 @@ encoder:
 𣟏	ajjf	0
 可贵	ajji	6990000
 𧏋	ajji	0
-𫚈	ajji	0
 副品	ajjj	47100
 㽬	ajjk	4650
 歌唱	ajjk	16200000
@@ -13877,11 +13510,9 @@ encoder:
 𩰼	ajkx	0
 𧰃	ajkz	0
 𧰗	ajla	0
-𫎿	ajla	0
 鬲	ajld	3230000
 𠀷	ajld	0
 𠁐	ajld	0
-𫚉	ajld	0
 鞷	ajle	23500
 鬴	ajlf	30000
 𦓠	ajlg	0
@@ -13889,10 +13520,8 @@ encoder:
 𩰭	ajlh	0
 融	ajli	55800000
 𧖓	ajli	0
-𫌅	ajli	0
 𧰏	ajlj	0
 䰝	ajlk	3750
-𫚉	ajll	0
 𩰫	ajlm	0
 可见	ajlr	69700000
 鷊	ajlr	27500
@@ -13935,7 +13564,6 @@ encoder:
 𠲀	ajoj	0
 𠀬	ajoo	0
 𧯲	ajoo	0
-𪫟	ajop	0
 鬷	ajor	34500
 𩰺	ajor	0
 𩱛	ajor	0
@@ -14037,7 +13665,6 @@ encoder:
 䜸	ajxm	3990
 𧰤	ajxx	0
 𩰸	ajxx	0
-𪜄	ajxz	0
 豆子	ajya	3820000
 䝀	ajyk	5010
 鬸	ajyk	17900
@@ -14144,7 +13771,6 @@ encoder:
 𣌼	akok	0
 㬲	akol	5960
 甦	akom	2340000
-𪯥	akom	0
 𩰽	akor	0
 更	akos	2310000000
 严令	akow	727000
@@ -14233,7 +13859,6 @@ encoder:
 𠕅	albd	0
 两项	albg	9600000
 再来	albk	34600000
-𪳌	albk	0
 两者	albm	25500000
 两地	albv	9180000
 再起	alby	7130000
@@ -14265,9 +13890,7 @@ encoder:
 两只	aljo	27200000
 䪟	alka	3200
 䪣	alka	3340
-𫗙	alka	0
 𠚷	alkd	0
-𫝞	alko	0
 丽水	alkv	20000000
 两党	alkw	1550000
 丽	alld	115000000
@@ -14308,7 +13931,6 @@ encoder:
 丙	alod	47400000
 𠆴	alod	0
 𡗚	alod	0
-𪥐	alog	0
 𠛥	alok	0
 𩇽	alok	0
 𧶪	alol	0
@@ -14395,7 +14017,6 @@ encoder:
 𢒣	angp	0
 𠢘	angy	0
 夏至	anhb	1680000
-𪭫	anhh	0
 戛	anhm	714000
 𢦫	anhm	0
 丣	anhx	53800
@@ -14409,7 +14030,6 @@ encoder:
 𡕾	ankr	0
 夏县	anlz	294000
 夏种	anmj	155000
-𪡰	anmj	0
 百年	anmm	96800000
 𤾋	anmm	0
 百科	anmt	77800000
@@ -14426,7 +14046,6 @@ encoder:
 百分	anoy	32300000
 𠢊	anoy	0
 𠢨	anoy	0
-𪟌	anoy	0
 百般	anpq	8040000
 𡔀	anrb	0
 𩑋	anrd	0
@@ -14486,7 +14105,6 @@ encoder:
 爾	aooo	39000000
 𨮪	aoop	0
 鸍	aoor	19100
-𫂞	aoos	0
 邇	aoow	381000
 𢣭	aoow	0
 𪓿	aoow	0
@@ -14494,11 +14112,9 @@ encoder:
 𠔀	aovv	0
 𤇟	aozu	0
 𣑨	aqaf	0
-𪜂	aqda	0
 𠀣	aqha	0
 𠁉	aqnc	0
 𠘲	aqqd	0
-𪜃	aqys	0
 死于	arad	7670000
 𣦿	arad	0
 死刑	arae	13000000
@@ -14509,7 +14125,6 @@ encoder:
 㱮	aral	18100
 殨	aral	70900
 	aral	0
-𪵧	aral	0
 𣩐	aran	0
 㱛	arar	4300
 殡殓	arar	43400
@@ -14657,7 +14272,6 @@ encoder:
 𣨵	arkr	0
 𣩜	arkr	0
 𣩹	arkr	0
-𫛙	arkr	0
 𣧖	arks	0
 𣨃	arks	0
 烈	arku	31900000
@@ -14688,8 +14302,6 @@ encoder:
 𣩑	arln	0
 𣧍	arlo	0
 𣧰	arlo	0
-𪵨	arlo	0
-𪵦	arlr	0
 残骸	arls	2270000
 𢤔	arlw	0
 𣨺	arlw	0
@@ -14752,7 +14364,6 @@ encoder:
 飱	arox	47800
 𣨳	aroy	0
 𣧑	aroz	0
-𪵤	aroz	0
 死后	arpa	10300000
 歽	arpd	22300
 𣧭	arpd	0
@@ -14785,7 +14396,6 @@ encoder:
 𣨍	arrl	0
 𣪁	arrl	0
 𧵲	arrl	0
-𪵩	arrl	0
 歾	arro	73000
 殤	arro	1170000
 𣧋	arro	0
@@ -14798,7 +14408,6 @@ encoder:
 𣧩	arrt	0
 㱝	arry	3690
 㱧	arry	4860
-𪵢	arry	0
 殦	arrz	37900
 𣧔	arrz	0
 死亡	arsh	90500000
@@ -14905,12 +14514,10 @@ encoder:
 𣩱	arzl	0
 𣩿	arzn	0
 𣨧	arzq	0
-𪵥	arzr	0
 裂纹	arzs	1870000
 𣩙	arzu	0
 𣩯	arzu	0
 裂缝	arzw	3940000
-𪵣	arzx	0
 𣧥	arzy	0
 列出	arzz	50200000
 𣦾	arzz	0
@@ -14950,7 +14557,6 @@ encoder:
 平昌	aukk	374000
 𣸞	aukk	0
 平常	aukw	35300000
-𪪚	aukz	0
 平山	aull	5090000
 平罗	aulr	346000
 平等	aumb	30500000
@@ -14979,7 +14585,6 @@ encoder:
 𡕢	aurs	0
 灭亡	aush	5840000
 平调	ausl	315000
-𪪙	ausw	0
 平方	ausy	69900000
 平装	autb	7850000
 平头	autg	1600000
@@ -15002,10 +14607,8 @@ encoder:
 𢂇	auwl	0
 平遥	auwp	1930000
 平房	auws	4980000
-𪪜	auws	0
 平通	auwx	72000
 平安	auwz	43700000
-𪪛	auxw	0
 平局	auxy	1810000
 平陆	auyb	371000
 平民	auyh	16900000
@@ -15192,7 +14795,6 @@ encoder:
 𠑺	awrd	0
 辷	awvv	439000
 𢄀	awwl	0
-𫆐	axej	0
 𧰳	axgg	0
 𨳇	axhi	0
 疌	axii	17400
@@ -15229,15 +14831,12 @@ encoder:
 万人	ayod	46400000
 万余	ayom	11400000
 𤽩	ayon	0
-𪜈	ayoo	0
 万个	ayov	18400000
 万分	ayoy	15800000
 万顷	ayrg	878000
 万象	ayrj	12500000
-𫕱	aytl	0
 万米	ayuf	1640000
 万源	ayvg	843000
-𪜁	ayvv	0
 万宁	aywa	1240000
 万家	aywg	8600000
 万户	aywm	5760000
@@ -15251,7 +14850,6 @@ encoder:
 万能	ayzq	22200000
 𢌱	azae	0
 𤮠	azag	0
-𪠟	azal	0
 𢪓	azam	0
 𢮠	azam	0
 瓸	azan	35900
@@ -15290,9 +14888,6 @@ encoder:
 𤮑	azkw	0
 𨚸	azky	0
 𤬲	azlo	0
-𪽨	azlo	0
-𫏞	azlq	0
-𪽬	azlz	0
 瓦特	azmb	1270000
 瓦罐	azme	443000
 𤭚	azmj	0
@@ -15307,7 +14902,6 @@ encoder:
 瓰	azoy	34000
 瓪	azpx	35500
 𤭷	azqk	0
-𪟈	azqk	0
 𨿾	azqn	0
 𣪟	azqq	0
 𨛼	azqy	0
@@ -15319,10 +14913,8 @@ encoder:
 𤮄	azsa	0
 𡊝	azsb	0
 𤭖	azsc	0
-𪽤	azsc	0
 瓧	azse	216000
 𤬧	azse	0
-𪽦	azsf	0
 𦓓	azsg	0
 𤭵	azsk	0
 𤭆	azsl	0
@@ -15331,16 +14923,12 @@ encoder:
 𤬸	azsm	0
 𤬨	azsq	0
 𩿺	azsr	0
-𪽥	azsu	0
 𤬯	azsx	0
 邷	azsy	24400
-𪰋	azsy	0
-𪽣	azsy	0
 𤮌	azsz	0
 瓦店	azti	125000
 𡋬	azub	0
 𤭅	azue	0
-𪽩	azun	0
 𢚎	azuw	0
 𤮒	azuz	0
 丂	azvv	116000
@@ -15354,7 +14942,6 @@ encoder:
 𤮂	azxj	0
 𦥼	azxo	0
 𠬣	azxs	0
-𪜇	azyb	0
 𤬫	azye	0
 𢏽	azyo	0
 瓦	azys	58500000
@@ -15394,17 +14981,14 @@ encoder:
 考核	bafs	37500000
 考研	baga	48800000
 𡐥	bagk	0
-𪢼	bagr	0
 𡍞	bagu	0
 赶车	bahe	671000
-𪣫	bahi	0
 土匪	bahk	3700000
 赶到	bahk	20000000
 圷	baid	216000
 𡊕	baii	0
 考点	baij	3920000
 赶点	baij	65300
-𪣺	baim	0
 赶上	baiv	10900000
 考虑	baiw	67400000
 𡎩	baix	0
@@ -15422,7 +15006,6 @@ encoder:
 垭	baku	643000
 𤎪	baku	0
 赶紧	bakx	41300000
-𪣈	balo	0
 𡔉	balt	0
 考生	bamc	26800000
 士气	bamy	4960000
@@ -15441,7 +15024,6 @@ encoder:
 赶脚	baqb	40300
 赶印	bara	39100
 𡊻	bark	0
-𪤖	barl	0
 考证	basa	10900000
 考评	basa	5380000
 考试	bash	163000000
@@ -15450,7 +15032,6 @@ encoder:
 土族	basm	403000
 土方	basy	3180000
 坪	baua	28800000
-𪤇	baud	0
 赶忙	baus	7580000
 赶快	baux	56000000
 考卷	bauy	2680000
@@ -15522,7 +15103,6 @@ encoder:
 堵车	bbhe	2830000
 𡓖	bbhy	0
 卦	bbid	8090000
-𫚑	bbin	0
 㪈	bbix	3910
 𢿣	bbix	0
 堵口	bbja	167000
@@ -15558,7 +15138,6 @@ encoder:
 封丘	bbpd	218000
 封锁	bbpk	16500000
 𢍠	bbqe	0
-𪤹	bbqq	0
 坃	bbrd	34400
 封条	bbrf	937000
 𡌲	bbrj	0
@@ -15582,7 +15161,6 @@ encoder:
 𡒡	bbux	0
 圭	bbvv	9360000
 𡎓	bbvv	0
-𪢸	bbvv	0
 堵塞	bbwe	14300000
 𦥂	bbwh	0
 𡐉	bbwi	0
@@ -15592,7 +15170,6 @@ encoder:
 恚	bbwz	1280000
 封皮	bbxi	1660000
 𧎹	bbxi	0
-𪣙	bbxj	0
 隷	bbxk	441000
 𡊋	bbxs	0
 款子	bbya	361000
@@ -15620,7 +15197,6 @@ encoder:
 壃	bckk	83800
 𤣪	bcrd	0
 趣闻	bctc	6550000
-𪤠	bcug	0
 𡉠	bcvv	0
 𡔐	bcyi	0
 𡏼	bcym	0
@@ -15638,8 +15214,6 @@ encoder:
 𠒺	bdal	0
 二百	bdan	12000000
 二列	bdar	332000
-𪲤	bdau	0
-𪲛	bdax	0
 二万	bday	4520000
 𠃻	bday	0
 亖	bdbd	246000
@@ -15654,7 +15228,6 @@ encoder:
 𪒨	bdbu	0
 𠄥	bdbz	0
 𠝆	bdck	0
-𪜟	bdcm	0
 𩇖	bdcq	0
 𠃻	bdcy	0
 𠄽	bddk	0
@@ -15667,7 +15240,6 @@ encoder:
 𦈱	bdez	0
 𠄯	bdfa	0
 𨎑	bdff	0
-𪴏	bdfk	0
 二楼	bdfu	14200000
 鄻	bdfy	24500
 𣠕	bdgb	0
@@ -15683,7 +15255,6 @@ encoder:
 𩺸	bdgr	0
 𪅗	bdgr	0
 𣁟	bdgs	0
-𪻧	bdgs	0
 𥼋	bdgu	0
 𢟤	bdgw	0
 𢡷	bdgw	0
@@ -15708,7 +15279,6 @@ encoder:
 𢤏	bdiw	0
 𢻳	bdix	0
 𢿍	bdix	0
-𪯣	bdix	0
 𠢷	bdjf	0
 𠁩	bdji	0
 𠄸	bdjj	0
@@ -15737,9 +15307,7 @@ encoder:
 𩒢	bdkg	0
 𩓋	bdkg	0
 𩕗	bdkg	0
-𪥓	bdkg	0
 戩	bdkh	164000
-𪠁	bdki	0
 刯	bdkk	23500
 神	bdkk	0
 𠄵	bdkk	0
@@ -15758,7 +15326,6 @@ encoder:
 𠀜	bdko	0
 𠇠	bdko	0
 𠔐	bdko	0
-𫘑	bdko	0
 𣱌	bdkr	0
 𩿲	bdkr	0
 来	bdkv	2460000000
@@ -15800,7 +15367,6 @@ encoder:
 𠩺	bdmg	0
 𪘻	bdmi	0
 𣸗	bdmk	0
-𫏗	bdml	0
 㲠	bdmm	9120
 㹈	bdmm	4560
 𠄦	bdms	0
@@ -15809,11 +15375,9 @@ encoder:
 𡟋	bdmz	0
 坓	bdnb	33600
 𡉝	bdnb	0
-𪨄	bdnb	0
 亓	bdnd	1420000
 井	bdnd	45100000
 𠦈	bdne	0
-𪲔	bdnf	0
 㓝	bdnk	3880
 汬	bdnk	35000
 𣲜	bdnk	0
@@ -15832,27 +15396,21 @@ encoder:
 𠒞	bdnz	0
 𥾟	bdnz	0
 𩰿	bdoa	0
-𪥌	bdoa	0
 夫	bdod	92500000
 輦	bdof	211000
 𩖀	bdog	0
 辇	bdoh	613000
 𠴅	bdoj	0
-𫎼	bdoj	0
 替	bdok	60900000
-𪟀	bdok	0
 規	bdol	20900000
 规	bdol	46000000
 賛	bdol	608000
-𫍜	bdol	0
-𪯠	bdom	0
 𤾞	bdon	0
 𨾚	bdon	0
 斄	bdoo	33700
 𠇬	bdoo	0
 𩖬	bdoq	0
 鳺	bdor	65200
-𫜫	bdor	0
 𠄡	bdos	0
 𧥽	bdos	0
 𧭃	bdos	0
@@ -15908,9 +15466,7 @@ encoder:
 二话	bdsm	6540000
 㣋	bdsp	3850
 慭	bdsw	44300
-𪲛	bdsx	0
 𨚢	bdsy	0
-𫒕	bdsy	0
 㪴	bdte	3790
 𣂐	bdte	0
 寺庙	bdtk	4340000
@@ -15926,7 +15482,6 @@ encoder:
 𣜾	bdvb	0
 二流	bdvs	2750000
 𡌋	bdvs	0
-𫐷	bdwf	0
 𣘾	bdwq	0
 二心	bdwz	531000
 忈	bdwz	113000
@@ -15946,7 +15501,6 @@ encoder:
 𠎶	bdyo	0
 𠛝	bdys	0
 寺院	bdyw	9120000
-𫆕	bdyy	0
 亐	bdza	84600
 𠦊	bdze	0
 𣐂	bdzf	0
@@ -15959,7 +15513,6 @@ encoder:
 𧴳	bdzl	0
 互	bdzm	96000000
 𡚬	bdzm	0
-𪶆	bdzm	0
 䰟	bdzn	5340
 二维	bdzn	3110000
 魂	bdzn	74500000
@@ -16012,9 +15565,7 @@ encoder:
 壦	bejn	32600
 𡎁	bejq	0
 𡕁	bejr	0
-𪣚	bejr	0
 塻	bekg	41400
-𪣸	beki	0
 𡐋	bekk	0
 墴	beko	232000
 𡑪	bekr	0
@@ -16076,24 +15627,19 @@ encoder:
 壩	bfeq	1210000
 𡑲	bffb	0
 𡑓	bfff	0
-𪤶	bfff	0
 壖	bfgl	60900
 墰	bfke	217000
 𡐧	bfke	0
-𪤦	bfki	0
 𡒫	bflb	0
 堜	bflk	717000
 𢽓	bfmo	0
 𡓘	bfni	0
-𪤬	bfok	0
 𡐛	bfpd	0
-𪤟	bfuo	0
 𡉿	bfvv	0
 𣏅	bfvv	0
 𡐅	bfxb	0
 𡓒	bfyl	0
 㙘	bfzm	4390
-𪣉	bgae	0
 埼	bgaj	1300000
 㙽	bgan	3800
 坏死	bgar	7450000
@@ -16104,14 +15650,12 @@ encoder:
 𡍲	bgce	0
 垮掉	bgdi	958000
 𡏌	bgds	0
-𪣹	bgds	0
 𡍋	bgee	0
 堧	bggd	157000
 𡊘	bggd	0
 𡓃	bggg	0
 坯布	bggl	4450000
 𡑂	bggl	0
-𪣐	bgiy	0
 𡒜	bgjk	0
 㙩	bgkk	3800
 𡎋	bgky	0
@@ -16126,7 +15670,6 @@ encoder:
 坏人	bgod	8730000
 埉	bgoo	51700
 塽	bgoo	54500
-𪤸	bgra	0
 坏处	bgri	2600000
 𡑬	bgrm	0
 𡓺	bgsi	0
@@ -16166,7 +15709,6 @@ encoder:
 城里	bhkb	15000000
 越野	bhkb	23500000
 越界	bhko	1030000
-𪣋	bhko	0
 越是	bhkv	13000000
 堰	bhkz	5350000
 𡔑	bhll	0
@@ -16188,7 +15730,6 @@ encoder:
 𡐖	bhxb	0
 越剧	bhxe	1320000
 墭	bhyl	123000
-𪿁	bhyl	0
 城防	bhys	810000
 城建	bhyx	9680000
 𡒤	bhzh	0
@@ -16278,11 +15819,9 @@ encoder:
 𩒾	bijg	0
 敔	bijm	114000
 𥞣	bijm	0
-𫗎	bijm	0
 塷	bijo	30800
 𣣄	bijr	0
 𪁙	bijr	0
-𫗘	biju	0
 逜	bijw	81400
 𢙢	bijw	0
 㐚	bijy	4240
@@ -16307,7 +15846,6 @@ encoder:
 工党	bikw	760000
 埱	bikx	43400
 𠄲	bikz	0
-𫗗	bilb	0
 𥊾	bilg	0
 𡎍	bili	0
 盐	bilk	37400000
@@ -16320,7 +15858,6 @@ encoder:
 贡	bilo	8460000
 𡎞	bilo	0
 𩏼	bilo	0
-𪩷	bilo	0
 𢀢	bilr	0
 𪄌	bilr	0
 慐	bilw	30400
@@ -16329,7 +15866,6 @@ encoder:
 工种	bimj	5610000
 工程	bimj	468000000
 𧖬	biml	0
-𫗖	biml	0
 攻	bimo	49300000
 工科	bimt	4140000
 㙤	bimu	4300
@@ -16338,7 +15874,6 @@ encoder:
 𠄋	bimy	0
 工段	binc	436000
 𢀘	bind	0
-𫗕	bine	0
 工休	binf	65300
 𨾊	bini	0
 工作	binm	542000000
@@ -16394,10 +15929,8 @@ encoder:
 𧦬	biqs	0
 䊄	biqu	4370
 恐	biqw	57900000
-𫗔	bire	0
 𡍥	birf	0
 𡎵	birg	0
-𪩶	birj	0
 𧠱	birl	0
 𡏨	birn	0
 𣢈	biro	0
@@ -16409,7 +15942,6 @@ encoder:
 𧝣	bisr	0
 𪀛	bisr	0
 工商	bisu	117000000
-𫗓	bisx	0
 工头	bitg	1870000
 𧋳	biti	0
 工间	bitk	221000
@@ -16432,7 +15964,6 @@ encoder:
 𢖶	biwz	0
 垇	bixa	38100
 𩏽	bixb	0
-𫕗	bixd	0
 𧷱	bixf	0
 𠁰	bixh	0
 吾	bixj	34000000
@@ -16441,7 +15972,6 @@ encoder:
 垆	bixm	256000
 𢀞	bixm	0
 韨	bixs	35600
-𪢾	bixs	0
 忢	bixw	38700
 𢛤	bixw	0
 𩐀	bixx	0
@@ -16517,7 +16047,6 @@ encoder:
 喜鹊	bjek	2690000
 𪔭	bjel	0
 𪔵	bjel	0
-𪞋	bjeo	0
 喜获	bjeq	2310000
 𤋔	bjeu	0
 鼓	bjex	46300000
@@ -16546,12 +16075,10 @@ encoder:
 鼔	bjix	47800
 𢼣	bjix	0
 𧰒	bjja	0
-𪤗	bjja	0
 鼞	bjjb	25200
 𡅤	bjjb	0
 𡅸	bjjc	0
 𪔪	bjjc	0
-𪤨	bjjf	0
 𡀆	bjjg	0
 鼓足	bjji	1990000
 𧑭	bjji	0
@@ -16575,7 +16102,6 @@ encoder:
 𧰘	bjke	0
 䶁	bjkk	3670
 𣻅	bjkm	0
-𪢧	bjkq	0
 彭水	bjkv	1080000
 鼓掌	bjkw	17900000
 𥀽	bjkw	0
@@ -16658,7 +16184,6 @@ encoder:
 喜	bjuj	98600000
 囍	bjuj	1900000
 吉普	bjuk	6070000
-𪟎	bjuk	0
 𤈂	bjuo	0
 彭	bjup	37800000
 㰻	bjur	666
@@ -16683,7 +16208,6 @@ encoder:
 嘉定	bjwd	6270000
 吉达	bjwg	383000
 臺	bjwh	32600000
-𪢦	bjwl	0
 嘉宾	bjwp	24500000
 𡔧	bjwq	0
 吉它	bjwr	2150000
@@ -16716,7 +16240,6 @@ encoder:
 鼘	bjxn	28800
 𩟚	bjxo	0
 䥢	bjxp	4310
-𫔔	bjxp	0
 𩙏	bjxq	0
 喜欢	bjxr	383000000
 𪇀	bjxr	0
@@ -16735,7 +16258,6 @@ encoder:
 翓	bjyy	22600
 𡔼	bjzb	0
 𡔣	bjzg	0
-𪣞	bjzg	0
 𠚌	bjzi	0
 𪔮	bjzl	0
 𡜩	bjzm	0
@@ -16743,7 +16265,6 @@ encoder:
 𡔷	bjzx	0
 喜好	bjzy	15900000
 垾	bkae	226000
-𪣮	bkae	0
 堤	bkai	23000000
 𠟜	bkak	0
 𡏶	bkal	0
@@ -16755,7 +16276,6 @@ encoder:
 祘	bkbk	255000
 堤坝	bkbl	1240000
 来者	bkbm	5400000
-𫀿	bkbr	0
 壜	bkbz	155000
 来去	bkbz	6150000
 𥜪	bkci	0
@@ -16770,7 +16290,6 @@ encoder:
 𡐢	bkeo	0
 𡔒	bker	0
 示范	bkev	62800000
-𪤉	bkez	0
 𩓊	bkgo	0
 垙	bkgr	256000
 来历	bkgy	7490000
@@ -16789,8 +16308,6 @@ encoder:
 𡐹	bkjk	0
 𡑄	bkjm	0
 来路	bkjr	4770000
-𪤋	bkjr	0
-𪤧	bkju	0
 示踪	bkjw	203000
 𡐃	bkjz	0
 来日	bkka	6020000
@@ -16832,7 +16349,6 @@ encoder:
 𥜦	bkob	0
 𥜬	bkoc	0
 来人	bkod	16100000
-𫁏	bkom	0
 堺	bkon	7670000
 示众	bkoo	1280000
 𪇚	bkor	0
@@ -16841,13 +16357,11 @@ encoder:
 坦然	bkrg	8200000
 𥘖	bkrh	0
 未免	bkrj	7470000
-𫁉	bkrm	0
 埸	bkro	3410000
 場	bkro	230000000
 堒	bkrr	37900
 埋怨	bkry	8260000
 堨	bkry	191000
-𫀶	bkry	0
 𩿷	bkrz	0
 来讲	bksb	17700000
 坦诚	bksh	4520000
@@ -16864,7 +16378,6 @@ encoder:
 𥜟	bktg	0
 未准	bktn	324000
 未决	bktx	1480000
-𪣟	bkua	0
 𥘽	bkub	0
 墣	bkuc	812000
 埋单	bkuk	1860000
@@ -16889,7 +16402,6 @@ encoder:
 未尽	bkxs	5050000
 未加	bkyj	1350000
 𡎣	bkyj	0
-𪣒	bkym	0
 塌陷	bkyr	1640000
 堤防	bkys	3930000
 示弱	bkyt	4210000
@@ -16898,8 +16410,6 @@ encoder:
 𥜸	bkzi	0
 𧊢	bkzi	0
 塿	bkzm	47400
-𪣠	bkzm	0
-𫀱	bkzm	0
 未能	bkzq	29900000
 未婚	bkzr	27300000
 㙷	bkzu	3970
@@ -16912,8 +16422,6 @@ encoder:
 𡉱	blbd	0
 坝址	blbi	172000
 墿	blbu	693000
-𪤊	blbz	0
-𪣶	blea	0
 坝基	bleb	134000
 夁	blej	26800
 贡献	blel	95500000
@@ -16929,7 +16437,6 @@ encoder:
 𢤶	bljw	0
 𡍫	blkd	0
 𡊢	blla	0
-𪤈	bllk	0
 覿	blll	68900
 贡山	blll	226000
 𩴺	blln	0
@@ -16973,13 +16480,11 @@ encoder:
 㙮	bmaj	4080
 𦒽	bmaj	0
 考	bmaz	223000000
-𪥨	bmbg	0
 𦒳	bmbi	0
 𦓃	bmbj	0
 䎜	bmbr	3820
 𦓈	bmbr	0
 𦓋	bmbr	0
-𫆨	bmbs	0
 壎	bmbu	124000
 𡔄	bmbu	0
 𤏍	bmbu	0
@@ -17017,18 +16522,14 @@ encoder:
 墧	bmjl	34100
 𥂁	bmjl	0
 㗯	bmjr	3800
-𫆥	bmjr	0
 𦒺	bmjx	0
 𨚻	bmjy	0
 𨜞	bmjy	0
 𡒁	bmka	0
 堹	bmkb	31400
 𩥞	bmkc	0
-𪟊	bmkd	0
-𪣡	bmkd	0
 𧡺	bmkl	0
 𣯆	bmkm	0
-𪣓	bmko	0
 㙏	bmkr	4140
 𪄖	bmkr	0
 攻坚	bmkx	2810000
@@ -17041,7 +16542,6 @@ encoder:
 𡋂	bmmb	0
 𦒷	bmmh	0
 𠺛	bmmj	0
-𪤡	bmmm	0
 䬡	bmmn	3960
 𢠛	bmmw	0
 𡍪	bmnb	0
@@ -17057,7 +16557,6 @@ encoder:
 䀋	bmol	6210
 𪉹	bmol	0
 𦙩	bmoo	0
-𫘐	bmox	0
 𡎫	bmoz	0
 斱	bmpd	20100
 𡌖	bmqb	0
@@ -17087,12 +16586,10 @@ encoder:
 𡗀	bmrr	0
 𪀧	bmrr	0
 𡦳	bmru	0
-𪹋	bmru	0
 㐗	bmry	4120
 𪃙	bmrz	0
 𦒼	bmsc	0
 攻读	bmse	4520000
-𫆧	bmsm	0
 𦒹	bmso	0
 都	bmsy	0
 𣂃	bmte	0
@@ -17103,9 +16600,7 @@ encoder:
 煑	bmuo	98000
 煮	bmuo	49600000
 𤆯	bmuo	0
-𫆪	bmux	0
 𡓕	bmuy	0
-𪣌	bmwa	0
 攻守	bmwd	2340000
 𡒺	bmwl	0
 𢝬	bmwz	0
@@ -17119,9 +16614,7 @@ encoder:
 𦓁	bmyj	0
 㘯	bmym	4650
 教	bmym	250000000
-𪣢	bmym	0
 𩳔	bmyn	0
-𪵭	bmyq	0
 攻陷	bmyr	1460000
 㼥	bmys	4650
 塠	bmyw	35100
@@ -17130,16 +16623,13 @@ encoder:
 𡦊	bmyy	0
 𨛨	bmyy	0
 耉	bmzj	53700
-𪤙	bmzm	0
 𡦲	bmzu	0
-𫆦	bmzx	0
 㙁	bmzy	4920
 攻丝	bmzz	328000
 井下	bnai	2050000
 赤豆	bnaj	312000
 𧹪	bnal	0
 𧹡	bnan	0
-𪤮	bnan	0
 𡐟	bnaz	0
 𧹻	bnbb	0
 赤城	bnbh	1900000
@@ -17153,7 +16643,6 @@ encoder:
 坿	bnds	78100
 塮	bnds	49100
 埤	bned	1220000
-𫏪	bnek	0
 𧹛	bnex	0
 𧹱	bnez	0
 𧹥	bnfb	0
@@ -17169,13 +16658,11 @@ encoder:
 垘	bngs	29300
 𡏣	bngs	0
 䞓	bnhb	3590
-𪣣	bnhd	0
 𧹹	bnhk	0
 㘺	bnhm	4520
 𡏲	bnhr	0
 赪	bnil	81000
 赬	bnil	34200
-𪤭	bnio	0
 井口	bnja	2460000
 井喷	bnje	2810000
 堢	bnjf	816000
@@ -17198,7 +16685,6 @@ encoder:
 堆积	bnmj	8880000
 𧹰	bnmk	0
 𧹺	bnmm	0
-𫝅	bnmr	0
 𧹜	bnms	0
 𢟻	bnmw	0
 𠭷	bnmx	0
@@ -17208,7 +16694,6 @@ encoder:
 赭	bnob	1680000
 頳	bnog	31700
 𡘥	bnog	0
-𫏩	bnoh	0
 赨	bnoi	23200
 𧹢	bnoj	0
 𧹤	bnoj	0
@@ -17239,7 +16724,6 @@ encoder:
 𥏷	bnrm	0
 𡒠	bnro	0
 𡓻	bnrr	0
-𪣀	bnrr	0
 𡌠	bnrs	0
 𧹝	bnrt	0
 赩	bnry	78100
@@ -17258,7 +16742,6 @@ encoder:
 𡒳	bnws	0
 赤道	bnwu	3560000
 赤字	bnwy	10900000
-𫏨	bnxb	0
 赤壁	bnxj	3780000
 赯	bnxj	113000
 𧹣	bnxj	0
@@ -17276,10 +16759,8 @@ encoder:
 𠢂	bnyy	0
 井台	bnzj	153000
 𧹴	bnzk	0
-𫏫	bnzk	0
 𧹽	bnzu	0
 𡐙	boad	0
-𫏴	boad	0
 走开	boae	8870000
 赶	boae	82800000
 趕	boae	12100000
@@ -17313,8 +16794,6 @@ encoder:
 趌	bobj	36300
 𧻇	bobk	0
 𧻚	bobk	0
-𫏭	bobk	0
-𫏱	bobk	0
 𧼉	bobl	0
 𢴸	bobm	0
 𧽭	bobn	0
@@ -17389,7 +16868,6 @@ encoder:
 𧾁	bogk	0
 𧻶	bogl	0
 𧼵	bogm	0
-𫏵	bogp	0
 䞥	bogq	3400
 𧼡	bogq	0
 𧼙	bogs	0
@@ -17399,8 +16877,6 @@ encoder:
 𧽔	bogx	0
 𧻑	bogy	0
 𧻜	bogy	0
-𫏬	bogy	0
-𫏹	bogy	0
 𧻗	boha	0
 𧻔	bohc	0
 𧻪	bohg	0
@@ -17410,7 +16886,6 @@ encoder:
 𧺱	bohm	0
 䟇	boho	3150
 䞪	bohp	3300
-𫏳	bohp	0
 走软	bohr	979000
 䞖	bohs	3240
 𧺹	bohx	0
@@ -17450,7 +16925,6 @@ encoder:
 䟑	bojl	3580
 趫	bojl	97100
 𧽛	bojl	0
-𪤘	bojl	0
 𡓎	bojm	0
 𧼐	bojm	0
 𧾦	bojm	0
@@ -17461,7 +16935,6 @@ encoder:
 𧽓	bojr	0
 𧽚	bojr	0
 𧾎	bojr	0
-𫏰	bojr	0
 𧾑	bojs	0
 𧯣	boju	0
 𧻿	boju	0
@@ -17479,7 +16952,6 @@ encoder:
 𧼩	bokb	0
 𧽆	bokb	0
 𧽿	bokb	0
-𫏲	bokb	0
 𧺈	bokd	0
 趁早	boke	2330000
 趠	boke	50300
@@ -17493,7 +16965,6 @@ encoder:
 𧾃	bokk	0
 趟	bokl	29000000
 赻	bokm	722000
-𫏶	bokm	0
 𧽟	bokn	0
 趪	boko	22400
 𡊒	boko	0
@@ -17515,7 +16986,6 @@ encoder:
 趄	bolc	1070000
 𧾖	bolc	0
 𧺸	bold	0
-𫏯	bold	0
 𧼴	bolg	0
 𧼽	bolj	0
 规则	bolk	136000000
@@ -17627,7 +17097,6 @@ encoder:
 𧻵	booo	0
 𧼛	booo	0
 𧾏	booo	0
-𫏺	booo	0
 䟃	boop	3380
 趁	boop	32700000
 䞭	boor	3470
@@ -17682,7 +17151,6 @@ encoder:
 𧺎	boqy	0
 𡠦	boqz	0
 𧾡	borb	0
-𫏮	bore	0
 赿	borh	43600
 𡏜	borh	0
 䟉	bori	3200
@@ -17707,7 +17175,6 @@ encoder:
 𡑨	boro	0
 𧼮	boro	0
 𧺤	borq	0
-𫇗	borq	0
 趍	borr	43800
 𡒇	borr	0
 𣣋	borr	0
@@ -17716,7 +17183,6 @@ encoder:
 𧻌	borr	0
 𧼔	borr	0
 𧼬	borr	0
-𪥆	borr	0
 夌	bors	1360000
 趆	bors	24300
 𧺓	bors	0
@@ -17809,7 +17275,6 @@ encoder:
 䞽	bowz	3470
 𧺨	bowz	0
 𧽉	bowz	0
-𫏷	bowz	0
 𧻡	boxb	0
 𧽡	boxb	0
 赽	boxg	735000
@@ -17818,7 +17283,6 @@ encoder:
 䞫	boxj	3180
 𡌢	boxj	0
 𧽜	boxj	0
-𪤍	boxj	0
 趢	boxk	20200
 𧻹	boxl	0
 趘	boxm	18900
@@ -17868,14 +17332,12 @@ encoder:
 𧽅	bozf	0
 䞼	bozg	3540
 赳	bozi	641000
-𫏸	bozl	0
 𧺜	bozm	0
 𧻭	bozm	0
 𧽈	bozm	0
 𡏓	bozr	0
 𧽸	bozr	0
 𧽞	bozu	0
-𪤩	bozw	0
 夫妇	bozx	17500000
 䞛	bozy	3000
 䞷	bozz	3440
@@ -17905,8 +17367,6 @@ encoder:
 𡐮	bpyu	0
 𡏛	bpzg	0
 坍塌	bqbk	3240000
-𪤹	bqbq	0
-𪢹	bqda	0
 𡉻	bqed	0
 𡕀	bqfu	0
 𢀃	bqfz	0
@@ -17923,7 +17383,6 @@ encoder:
 恐怖	bqug	125000000
 恐惧	bqul	29300000
 恐怕	bqun	48200000
-𪢿	bqvv	0
 𡉕	bqya	0
 趋于	brad	9760000
 𦧄	brae	0
@@ -17976,13 +17435,11 @@ encoder:
 坎昆	brkr	142000
 埆	brld	724000
 趋同	brld	1160000
-𪣽	brlg	0
 元山	brll	431000
 𧷏	brll	0
 𧸇	brll	0
 元贝	brlo	85700
 塡	brlo	106000
-𪤯	brlr	0
 老手	brmd	3500000
 𡏝	brmf	0
 𡓡	brmg	0
@@ -18099,7 +17556,6 @@ encoder:
 坑木	bsfa	73200
 培植	bsfe	2950000
 𡌮	bsgj	0
-𪤛	bsgm	0
 𩓁	bsgo	0
 𡑌	bshk	0
 𡔋	bsix	0
@@ -18112,7 +17568,6 @@ encoder:
 壈	bsjm	478000
 𡐴	bsjq	0
 㙥	bsjr	4690
-𪤵	bsju	0
 埻	bsjy	139000
 𡏿	bsjy	0
 壇	bska	11600000
@@ -18123,13 +17578,11 @@ encoder:
 境界	bsko	34200000
 境	bskr	96300000
 壞	bskr	24300000
-𪤫	bskw	0
 𡏡	bskz	0
 㙵	bslb	3920
 𡌾	bslb	0
 𡊔	bsli	0
 境内	bslo	23900000
-𪤑	bslz	0
 𣘢	bsmf	0
 𢧴	bsmh	0
 𨅚	bsmj	0
@@ -18142,15 +17595,11 @@ encoder:
 𠢕	bsmy	0
 坑人	bsod	704000
 埣	bsoe	471000
-𪤂	bsog	0
-𪣱	bsok	0
 𡋟	bsoo	0
 𡌧	bsot	0
 垴	bsoz	170000
 坑	bsqd	29500000
 境外	bsri	15600000
-𪣷	bsri	0
-𪤰	bsrn	0
 培训	bssn	243000000
 培育	bssz	29600000
 境况	bstj	2270000
@@ -18161,7 +17610,6 @@ encoder:
 壕沟	bsvr	331000
 圡	bsvv	79600
 𡈽	bsvv	0
-𪣿	bswa	0
 坑害	bswc	830000
 壕	bswg	2840000
 境遇	bswk	3670000
@@ -18194,7 +17642,6 @@ encoder:
 𡎻	btob	0
 𡒷	btpk	0
 𡍓	btra	0
-𪣻	btrq	0
 𡍓	btrs	0
 𡔙	bttt	0
 𡍔	btub	0
@@ -18210,7 +17657,6 @@ encoder:
 𡓊	btyq	0
 增刊	buae	1260000
 增开	buae	1030000
-𪤀	buaj	0
 增殖	buar	2300000
 𡒶	buax	0
 增城	bubh	1940000
@@ -18254,7 +17700,6 @@ encoder:
 増	bukk	16700000
 𡐭	bukk	0
 𡌶	buku	0
-𪤏	bukv	0
 增幅	bula	13300000
 𡋁	buli	0
 增	bulk	288000000
@@ -18266,7 +17711,6 @@ encoder:
 𣮾	bumh	0
 增重	bumk	1250000
 盩	buml	71500
-𪯧	bumo	0
 𡓏	bumy	0
 𡏆	bund	0
 增值	bune	62600000
@@ -18275,7 +17719,6 @@ encoder:
 灻	buoa	95700
 塧	buol	24900
 𡒶	buox	0
-𫘑	buox	0
 增兵	bupo	875000
 瓡	bups	54600
 墊	buqb	9950000
@@ -18367,8 +17810,6 @@ encoder:
 𥃁	buzl	0
 增收	buzm	10300000
 𡓌	buzm	0
-𪤁	buzm	0
-𪪞	buzm	0
 夹缝	buzw	1710000
 幸好	buzy	15200000
 地形	bvae	13300000
@@ -18417,7 +17858,6 @@ encoder:
 地委	bvmz	770000
 𡐘	bvnb	0
 地段	bvnc	16600000
-𪣔	bvnd	0
 地堡	bvnj	131000
 地价	bvno	3850000
 地位	bvns	90200000
@@ -18438,7 +17878,6 @@ encoder:
 地主	bvsc	9170000
 地市	bvsl	5860000
 地产	bvsm	260000000
-𪣨	bvso	0
 地衣	bvsr	558000
 地方	bvsy	364000000
 地头	bvtg	1820000
@@ -18453,11 +17892,9 @@ encoder:
 地心	bvwz	2240000
 地层	bvxb	1430000
 地皮	bvxi	2300000
-𪣴	bvxr	0
 地线	bvzh	750000
 地级	bvzy	6520000
 㘾	bwad	4820
-𪣥	bwae	0
 塜	bwag	91900
 𡔿	bwag	0
 坾	bwai	22300
@@ -18483,17 +17920,14 @@ encoder:
 壼	bwbz	325000
 㲄	bwcq	4150
 瑴	bwcq	47400
-𫝛	bwcr	0
 壹拾	bwdo	236000
 垨	bwds	302000
 𩌊	bweq	0
 𡄜	bwer	0
-𪤚	bwfb	0
 𣝝	bwfj	0
 𧥆	bwfj	0
 堚	bwfk	191000
 𡍦	bwfk	0
-𪤔	bwfk	0
 𤜕	bwfl	0
 𥢉	bwfl	0
 榖	bwfq	452000
@@ -18515,8 +17949,6 @@ encoder:
 𢦁	bwgw	0
 㙆	bwgz	4660
 𦤼	bwhb	0
-𪣤	bwhd	0
-𪣗	bwhe	0
 毂	bwhq	510000
 壺	bwia	6800000
 𡔳	bwia	0
@@ -18544,16 +17976,13 @@ encoder:
 𡔹	bwju	0
 壷	bwka	3190000
 𡔱	bwkg	0
-𪤴	bwkk	0
 𡒨	bwkl	0
 𡐔	bwko	0
 𣹬	bwkq	0
 壶	bwku	22100000
-𪭘	bwkw	0
 𡏉	bwkz	0
 𡔩	bwkz	0
 𡔻	bwkz	0
-𪣵	bwlc	0
 𡎚	bwld	0
 𡑟	bwlj	0
 𣫪	bwlk	0
@@ -18585,7 +18014,6 @@ encoder:
 𡑮	bwob	0
 堔	bwof	163000
 塎	bwoj	25500
-𪤼	bwol	0
 𧹲	bwoq	0
 𪏙	bwoq	0
 𪍠	bwor	0
@@ -18598,7 +18026,6 @@ encoder:
 𨢋	bwqf	0
 𥔼	bwqg	0
 𧲇	bwqg	0
-𫗤	bwqg	0
 螜	bwqi	30700
 𧐜	bwqi	0
 𣪥	bwqj	0
@@ -18630,7 +18057,6 @@ encoder:
 𡔸	bwrb	0
 塳	bwrc	23100
 売	bwrd	27800000
-𪣖	bwrh	0
 𡄻	bwrj	0
 𧰝	bwrl	0
 𧹌	bwrl	0
@@ -18679,7 +18105,6 @@ encoder:
 𥗣	bwxg	0
 㚄	bwxi	4120
 𡐡	bwxk	0
-𪤪	bwxk	0
 𣰺	bwxm	0
 𥀎	bwxq	0
 𪈞	bwxr	0
@@ -18692,7 +18117,6 @@ encoder:
 𣫌	bwyq	0
 𪄽	bwyr	0
 𦐼	bwyy	0
-𪤌	bwyy	0
 𡔵	bwyz	0
 𣙲	bwzf	0
 𥃕	bwzl	0
@@ -18717,7 +18141,6 @@ encoder:
 五万	bxay	8060000
 垏	bxbd	91100
 墛	bxbd	306000
-𪤻	bxbd	0
 𡕐	bxbj	0
 块规	bxbo	53800
 𡋶	bxbs	0
@@ -18739,7 +18162,6 @@ encoder:
 𨞪	bxdy	0
 五十	bxed	63800000
 𡉜	bxed	0
-𪤓	bxeh	0
 𡍄	bxej	0
 𣫊	bxej	0
 声带	bxew	912000
@@ -18751,7 +18173,6 @@ encoder:
 块根	bxfx	286000
 块	bxgd	186000000
 五原	bxgn	348000
-𪵴	bxgn	0
 𡎔	bxhb	0
 𣫒	bxhb	0
 声区	bxho	1230000
@@ -18797,7 +18218,6 @@ encoder:
 𡎹	bxlx	0
 五千	bxme	12000000
 𥗚	bxmg	0
-𪣘	bxmh	0
 𠭐	bxmi	0
 𡄈	bxmj	0
 馨	bxmk	38600000
@@ -18830,11 +18250,9 @@ encoder:
 磬	bxqg	2870000
 𧏌	bxqi	0
 𧐡	bxqi	0
-𪡽	bxqj	0
 漀	bxqk	31900
 𣍆	bxqk	0
 𥊧	bxql	0
-𫍟	bxql	0
 䅽	bxqm	4090
 撀	bxqm	75100
 𤛗	bxqm	0
@@ -18852,7 +18270,6 @@ encoder:
 㘲	bxqy	8860
 𢐙	bxqy	0
 𣪤	bxqy	0
-𪤺	bxri	0
 声象	bxrj	168000
 𡄒	bxrj	0
 声乐	bxrk	3780000
@@ -18890,7 +18307,6 @@ encoder:
 坡道	bxwu	632000
 埐	bxwx	49100
 五官	bxwy	10100000
-𪤒	bxxf	0
 㘧	bxxi	4260
 𤍌	bxxu	0
 㙍	bxxx	3980
@@ -18920,7 +18336,6 @@ encoder:
 𡑏	bybj	0
 起来	bybk	252000000
 都未	bybk	6020000
-𪤤	bybm	0
 𡕋	bybn	0
 功夫	bybo	41600000
 教规	bybo	355000
@@ -18964,7 +18379,6 @@ encoder:
 起到	byhk	24600000
 教区	byho	686000
 都督	byia	1400000
-𪣅	byia	0
 起点	byij	36600000
 起步	byik	18500000
 教龄	byio	727000
@@ -19021,7 +18435,6 @@ encoder:
 场	byod	584000000
 功德	byoe	4740000
 教父	byoo	10300000
-𪤝	byop	0
 场馆	byow	7040000
 教令	byow	209000
 起锚	bype	317000
@@ -19108,7 +18521,6 @@ encoder:
 𡒔	byyn	0
 㙝	byyq	4070
 起飞	byyt	8210000
-𫆔	byyt	0
 场院	byyw	215000
 超限	byyx	1710000
 𡒘	byzb	0
@@ -19220,7 +18632,6 @@ encoder:
 𡏮	bzkf	0
 𤲢	bzki	0
 𠫴	bzkm	0
-𪠥	bzko	0
 朅	bzkr	84200
 专业	bzku	410000000
 却是	bzkv	61800000
@@ -19301,8 +18712,6 @@ encoder:
 击键	bzpy	113000
 动脉	bzqs	14200000
 劫狱	bzqs	276000
-𪣆	bzrd	0
-𪤜	bzrd	0
 𡊮	bzrh	0
 𡋡	bzrh	0
 𣱌	bzrh	0
@@ -19316,11 +18725,9 @@ encoder:
 击毙	bzrr	3170000
 𠫾	bzrr	0
 𡕮	bzrr	0
-𪤄	bzrr	0
 去留	bzrs	4060000
 逺	bzrw	340000
 𪚸	bzrw	0
-𫈙	bzry	0
 鵶	bzrz	50500
 𩿟	bzrz	0
 𩿹	bzrz	0
@@ -19371,7 +18778,6 @@ encoder:
 云层	bzxb	2150000
 𤿜	bzxi	0
 劫难	bzxn	2040000
-𪠠	bzxr	0
 坶	bzya	102000
 刧	bzyd	66400
 䂲	bzyg	5150
@@ -19396,7 +18802,6 @@ encoder:
 𡎭	bzzr	0
 专断	bzzu	413000
 动怒	bzzx	1560000
-𪤱	bzzx	0
 㘭	bzzy	5300
 云母	bzzy	1280000
 坳	bzzy	1480000
@@ -19409,7 +18814,6 @@ encoder:
 𤥗	cahx	0
 王国	cajc	27200000
 奏响	cajn	1620000
-𪼋	caju	0
 𤧮	cakf	0
 瑨	cakk	298000
 𤨁	cakk	0
@@ -19455,7 +18859,6 @@ encoder:
 玒	cbia	135000
 璹	cbjd	64700
 𤩖	cbjk	0
-𪼱	cbjr	0
 耕田	cbki	1050000
 𤩾	cbki	0
 玩赏	cbkw	499000
@@ -19474,7 +18877,6 @@ encoder:
 琎	cbnw	345000
 奉命	cboa	3290000
 玩命	cboa	2240000
-𪼓	cbob	0
 玞	cbod	43100
 奉行	cboi	7330000
 瓉	cbol	27600
@@ -19482,7 +18884,6 @@ encoder:
 奉令	cbow	214000
 耕翻	cbpk	152000
 𤤲	cbqd	0
-𪳨	cbqf	0
 玩	cbrd	372000000
 𤦿	cbrj	0
 珯	cbrr	399000
@@ -19529,7 +18930,6 @@ encoder:
 𩰟	ccgu	0
 𩰎	cchm	0
 𩰒	ccju	0
-𪽎	cckk	0
 𩰗	cckl	0
 𩰝	cckl	0
 彗星	cckm	5120000
@@ -19551,7 +18951,6 @@ encoder:
 𤦠	ccon	0
 𩰞	ccoo	0
 䰘	ccop	3950
-𪼠	ccop	0
 𤧂	ccow	0
 𤧲	ccoy	0
 𩰏	ccoy	0
@@ -19562,7 +18961,6 @@ encoder:
 𤪵	ccrr	0
 𩰍	ccsi	0
 鬧	ccsl	8930000
-𪯾	ccso	0
 琴	ccsx	51300000
 鬦	ccte	56700
 琴头	cctg	90500
@@ -19637,7 +19035,6 @@ encoder:
 三倍	cdns	5890000
 寿命	cdoa	28700000
 三分	cdoy	29600000
-𪼌	cdpd	0
 三月	cdqv	58400000
 三九	cdqy	6400000
 𪎍	cdri	0
@@ -19687,8 +19084,6 @@ encoder:
 𦖿	ceaj	0
 𦗞	ceaj	0
 𦗧	ceaj	0
-𪼤	ceaj	0
-𫇀	ceaj	0
 䎾	ceal	3500
 聩	ceal	210000
 聵	ceal	54600
@@ -19704,7 +19099,6 @@ encoder:
 𦖙	ceaz	0
 𦖛	ceaz	0
 𦖳	ceaz	0
-𫆴	ceaz	0
 𦔸	cebi	0
 䎻	cebj	3400
 聐	cebj	26700
@@ -19712,13 +19106,11 @@ encoder:
 𦕜	cebk	0
 𦕝	cebk	0
 𦕷	cebk	0
-𪽅	cebk	0
 䎴	cebn	3600
 𤨢	cebo	0
 𦔾	cebo	0
 𤧳	cebr	0
 𦕳	cebr	0
-𪼿	cebr	0
 𦗣	cebu	0
 𦗩	cebu	0
 耺	cebz	26600
@@ -19745,14 +19137,11 @@ encoder:
 𦕐	ceeb	0
 𦖋	ceeb	0
 𦗉	ceeb	0
-𪤅	ceeb	0
 𦗫	ceef	0
 𦖱	ceej	0
 𤩳	ceel	0
 𦕠	ceeo	0
 𦖌	ceeo	0
-𫇈	ceer	0
-𪪾	ceeu	0
 𪔠	ceex	0
 䏇	cefb	3770
 𤨳	cefb	0
@@ -19768,7 +19157,6 @@ encoder:
 𨝮	cefy	0
 𡒍	cegb	0
 耳聋	cegc	1620000
-𪼣	cegj	0
 㔌	cegk	4550
 聏	cegl	37100
 𦖁	cegl	0
@@ -19797,7 +19185,6 @@ encoder:
 𣀒	ceix	0
 𦔼	ceix	0
 𦖐	ceiy	0
-𫆷	ceiz	0
 聝	ceja	44200
 瑾	cejc	5880000
 聖	cejc	39400000
@@ -19809,7 +19196,6 @@ encoder:
 䏀	cejk	4190
 𦗴	cejk	0
 𦘆	cejl	0
-𫇀	cejl	0
 璥	cejm	61800
 𦗇	cejm	0
 瓘	cejn	488000
@@ -19827,7 +19213,6 @@ encoder:
 𦖕	cekc	0
 刵	cekd	26600
 𦗡	ceke	0
-𫇅	ceke	0
 𦖍	cekf	0
 𦗔	cekf	0
 耳光	cekg	6740000
@@ -19837,14 +19222,12 @@ encoder:
 䎶	ceki	3470
 𤲌	ceki	0
 䏆	cekk	3710
-𫇆	cekk	0
 𦕈	cekm	0
 𦖤	cekm	0
 璜	ceko	5940000
 𤩲	cekr	0
 弄堂	cekw	1260000
 𦖻	cekw	0
-𪟦	ceky	0
 𦖈	cekz	0
 𦖧	cekz	0
 𦗆	cekz	0
@@ -19856,7 +19239,6 @@ encoder:
 𦕘	celb	0
 𦕋	celd	0
 𦖉	celd	0
-𪼟	celd	0
 瑛	celg	5980000
 𦗘	celg	0
 䎺	celk	3520
@@ -19871,7 +19253,6 @@ encoder:
 珙县	celz	230000
 聅	cema	63200
 𦔽	cemb	0
-𫆸	cemb	0
 𤯩	cemc	0
 耳垂	ceme	1300000
 毦	cemh	113000
@@ -19900,8 +19281,6 @@ encoder:
 䏂	cenx	3600
 瓁	cenx	119000
 𦖚	cenx	0
-𫆹	cenz	0
-𫆵	ceoc	0
 𦖒	ceoe	0
 𤨓	ceof	0
 𦖣	ceof	0
@@ -19913,7 +19292,6 @@ encoder:
 𦗋	ceoj	0
 𤨶	ceok	0
 𦘋	ceol	0
-𫇁	ceol	0
 瑹	ceom	510000
 𦖘	ceom	0
 璊	ceoo	117000
@@ -19922,19 +19300,16 @@ encoder:
 𦖏	ceoo	0
 𦗹	ceoo	0
 𦘎	ceoo	0
-𫆿	ceoo	0
 聄	ceop	57500
 𦗖	ceop	0
 𦡠	ceoq	0
 𦖸	ceor	0
 聸	ceos	41500
 𦕻	ceos	0
-𪼄	ceos	0
 𤧴	ceou	0
 聆	ceow	7690000
 𤧍	ceow	0
 𦖟	ceow	0
-𫇇	ceow	0
 𦖪	ceox	0
 聁	ceoy	33600
 𤦈	ceoy	0
@@ -19943,7 +19318,6 @@ encoder:
 𤩐	cepd	0
 𦕄	cepd	0
 弄错	cepe	2550000
-𫆻	cepf	0
 𦗌	cepn	0
 𥪻	ceps	0
 𦖀	cepy	0
@@ -19966,7 +19340,6 @@ encoder:
 𦗈	cerm	0
 𦗲	cerm	0
 𦗸	cerm	0
-𫆳	cero	0
 𦕑	cers	0
 𦖡	cers	0
 𦗽	cers	0
@@ -19999,13 +19372,11 @@ encoder:
 耳闻	cetc	2580000
 𢌌	cetg	0
 𦘅	cetg	0
-𪼔	cetg	0
 𦗓	cetx	0
 𤪣	ceub	0
 弄懂	ceue	1370000
 聠	ceue	35800
 𦖣	ceuf	0
-𪳮	ceuf	0
 联	ceug	265000000
 𦗢	ceuj	0
 𥉔	ceul	0
@@ -20039,7 +19410,6 @@ encoder:
 𨟡	cewy	0
 恥	cewz	9040000
 𢚸	cewz	0
-𪬌	cewz	0
 埾	cexb	29800
 𤦟	cexc	0
 𦘁	cexc	0
@@ -20050,7 +19420,6 @@ encoder:
 𦘀	cexi	0
 𪘸	cexi	0
 䎸	cexj	4050
-𪽔	cexj	0
 䎼	cexk	3890
 𣷗	cexk	0
 𦗬	cexk	0
@@ -20058,7 +19427,6 @@ encoder:
 𤚉	cexm	0
 𦕨	cexo	0
 𤔛	cexp	0
-𫇂	cexq	0
 取	cexs	423000000
 𦔹	cexs	0
 𧩞	cexs	0
@@ -20081,18 +19449,15 @@ encoder:
 𦔳	ceym	0
 𦕚	ceyn	0
 𦗗	ceyn	0
-𫜏	ceyr	0
 𤭗	ceys	0
 𤭡	ceys	0
 𤭿	ceys	0
 𤮱	ceys	0
-𪠴	ceys	0
 𦖯	ceyu	0
 𦖹	ceyu	0
 聬	ceyy	44000
 𦔶	ceyy	0
 𦗒	ceyy	0
-𫆽	ceyy	0
 𦕭	cezb	0
 𦖅	cezb	0
 聨	ceze	126000
@@ -20103,7 +19468,6 @@ encoder:
 𪚁	cezi	0
 瓂	cezl	65800
 𦖬	cezl	0
-𫆺	cezm	0
 𩀳	cezn	0
 𦖶	cezs	0
 䏉	cezu	3490
@@ -20124,7 +19488,6 @@ encoder:
 瑼	cfds	50800
 𤧵	cfds	0
 𤫦	cfeq	0
-𪽙	cfff	0
 㻷	cffl	6360
 瓀	cfgl	25300
 㻝	cfjk	4040
@@ -20134,11 +19497,9 @@ encoder:
 瑓	cflk	37200
 琜	cfoo	72900
 𤫩	cfoo	0
-𪼕	cfpd	0
 𤫢	cfrj	0
 瓎	cfrl	29300
 璷	cfsm	26100
-𪽄	cfso	0
 𤩗	cfuf	0
 璤	cfwz	23900
 璴	cfxi	31700
@@ -20149,11 +19510,9 @@ encoder:
 环形	cgae	2410000
 琦	cgaj	13900000
 𤨯	cgaj	0
-𪽖	cgan	0
 𤦐	cgbb	0
 𤧊	cgbb	0
 环城	cgbh	2800000
-𪼒	cgbk	0
 㻟	cgbq	4220
 环境	cgbs	265000000
 环球	cgcd	39300000
@@ -20163,10 +19522,8 @@ encoder:
 环顾	cggy	2990000
 珔	cgiy	505000
 𤨀	cgka	0
-𪼡	cgkb	0
 璙	cgkk	23400
 𤪃	cgku	0
-𪼢	cgky	0
 𤤰	cgli	0
 𤩵	cgll	0
 环县	cglz	1160000
@@ -20174,10 +19531,8 @@ encoder:
 𤪾	cgmc	0
 瓑	cgmi	224000
 环保	cgnj	99500000
-𪼳	cgnk	0
 环行	cgoi	521000
 𤥵	cgoo	0
-𪼽	cgoo	0
 𤤒	cgos	0
 环岛	cgrl	1670000
 琢磨	cgtf	17600000
@@ -20223,7 +19578,6 @@ encoder:
 𩰈	chbg	0
 长城	chbh	33900000
 长工	chbi	1320000
-𪼃	chbi	0
 䯾	chbj	3400
 髻	chbj	2810000
 𨱻	chbj	0
@@ -20245,7 +19599,6 @@ encoder:
 𨲑	chbz	0
 𩬨	chbz	0
 𩭯	chbz	0
-𫚁	chbz	0
 𩯻	chcc	0
 𩰆	chcc	0
 长寿	chcd	9360000
@@ -20332,7 +19685,6 @@ encoder:
 𩭐	chgq	0
 髡	chgr	865000
 𩬇	chgs	0
-𫕕	chgu	0
 长在	chgv	8560000
 髪	chgx	22100000
 𨱾	chgy	0
@@ -20383,7 +19735,6 @@ encoder:
 𩮶	chjr	0
 𩯯	chjr	0
 𩯴	chjr	0
-𫚅	chjr	0
 𩮖	chju	0
 𩯇	chju	0
 长叹	chjx	4930000
@@ -20457,7 +19808,6 @@ encoder:
 𨲩	chlx	0
 长眠	chly	2220000
 𩮺	chly	0
-𫚇	chly	0
 𨲴	chlz	0
 𩮐	chlz	0
 𩮻	chlz	0
@@ -20559,23 +19909,17 @@ encoder:
 鬛	choz	34100
 鬣	choz	1120000
 𨱛	choz	0
-𫚄	chpb	0
 𩬡	chpd	0
 䰂	chpf	4750
 鬚	chpg	2260000
-𫚂	chpg	0
 𩬂	chpi	0
-𪷔	chpk	0
-𫚀	chpk	0
 𩬬	chpl	0
 鬂	chpo	31500
 鬓	chpo	2880000
 䰉	chpq	4610
 𩬐	chpv	0
 𨲌	chpx	0
-𫙼	chpy	0
 𩭏	chpz	0
-𫙾	chpz	0
 𩬥	chqa	0
 𩮊	chqb	0
 𩮓	chqb	0
@@ -20630,7 +19974,6 @@ encoder:
 𨳂	chrs	0
 𩭲	chrs	0
 𩰃	chrs	0
-𫙽	chrs	0
 鬇	chrx	29300
 髱	chry	98600
 𩮼	chry	0
@@ -20683,7 +20026,6 @@ encoder:
 鬈	chuy	813000
 𨲏	chuy	0
 𩬸	chuz	0
-𫚆	chuz	0
 长兴	chva	3350000
 长汀	chva	986000
 长河	chva	5450000
@@ -20714,9 +20056,7 @@ encoder:
 长途	chwo	21200000
 𨱤	chwq	0
 𩭠	chwq	0
-𫙿	chwq	0
 髧	chwr	28200
-𫕔	chwr	0
 䰓	chws	3910
 𨲾	chws	0
 𨳅	chws	0
@@ -20736,7 +20076,6 @@ encoder:
 𩬣	chxb	0
 𩬶	chxb	0
 𩮢	chxb	0
-𪼾	chxb	0
 𩬋	chxe	0
 𤦲	chxf	0
 𩮧	chxf	0
@@ -20744,7 +20083,6 @@ encoder:
 髲	chxi	43700
 𨱢	chxi	0
 𩮩	chxj	0
-𫚃	chxj	0
 䰁	chxk	5860
 鬝	chxk	20400
 𨲒	chxk	0
@@ -20829,14 +20167,12 @@ encoder:
 𠁳	cicl	0
 𣮝	cicm	0
 琥珀	cicn	9970000
-𫖼	cicq	0
 𢜎	cicw	0
 彗	cicx	1250000
 𦑓	cicy	0
 蠢事	cidj	1240000
 寿	cids	26600000
 焘	cidu	416000
-𪬎	cidw	0
 丰茂	cieh	415000
 丰南	ciel	377000
 𩇡	cies	0
@@ -20853,7 +20189,6 @@ encoder:
 𪃈	cigr	0
 獒	cigs	3690000
 瓛	cigs	121000
-𪻣	cigs	0
 𩇞	cigu	0
 𦅻	cigx	0
 𨜒	cigy	0
@@ -20863,11 +20198,9 @@ encoder:
 𧑨	ciii	0
 𧔄	ciii	0
 𪎋	ciij	0
-𫒠	ciji	0
 麺	cijk	18200000
 𩱏	cijl	0
 𩇢	cijm	0
-𫝙	cijq	0
 𠓆	cijr	0
 𤋒	ciju	0
 𧯮	ciju	0
@@ -20885,13 +20218,11 @@ encoder:
 瓐	cikl	25400
 𪎊	cikm	0
 㻉	ciko	3930
-𫖽	cikr	0
 𣍈	ciku	0
 琡	cikx	62000
 𠡾	ciky	0
 𤩡	cild	0
 𩔳	cilg	0
-𫗷	cilg	0
 䚍	cill	4150
 𥡯	cilm	0
 責	cilo	5750000
@@ -20902,7 +20233,6 @@ encoder:
 𪄸	cilr	0
 𠂴	cilu	0
 勣	cily	227000
-𪟟	cily	0
 丰县	cilz	3480000
 𩱏	cima	0
 聱	cimc	170000
@@ -20947,7 +20277,6 @@ encoder:
 𠢕	cimy	0
 嫯	cimz	101000
 纛	cimz	869000
-𫝚	cine	0
 丰顺	cing	517000
 幚	cinl	67600
 䨼	cinx	3780
@@ -20960,7 +20289,6 @@ encoder:
 𤪻	ciol	0
 𤪽	ciol	0
 𦚨	cioo	0
-𫇥	cioo	0
 䵅	cior	7360
 𤩁	cios	0
 𩇙	ciow	0
@@ -20975,23 +20303,17 @@ encoder:
 靚	ciql	15300000
 靔	ciqm	20000
 靝	ciqm	33200
-𫖺	ciqm	0
 丰腴	ciqn	1120000
 𨿬	ciqn	0
 𩇕	ciqp	0
-𫖼	ciqq	0
 䴖	ciqr	19800
 鶄	ciqr	71200
 	ciqr	0
-𫖻	ciqu	0
 靛	ciqw	7380000
-𪭖	ciqw	0
 郬	ciqy	58500
-𫝗	circ	0
 𩓳	cirg	0
 表	cirh	1050000000
 𪎈	cirh	0
-𫖹	ciri	0
 㗉	cirj	3830
 𠲱	cirj	0
 𦃅	cirj	0
@@ -21028,9 +20350,7 @@ encoder:
 𦤿	ciwh	0
 𪎐	ciwl	0
 𩇣	ciwm	0
-𪬞	ciwm	0
 丰裕	ciwo	370000
-𫝘	ciwr	0
 𢗣	ciwz	0
 𢑹	cixb	0
 𤥷	cixb	0
@@ -21041,7 +20361,6 @@ encoder:
 𦥆	cixh	0
 𤥩	cixi	0
 𣊄	cixk	0
-𪽯	cixm	0
 㺳	cixs	4630
 𤪨	cixs	0
 熭	cixu	23000
@@ -21061,8 +20380,6 @@ encoder:
 𩓁	ciyg	0
 蛪	ciyi	28600
 齧	ciyi	279000
-𫝮	ciyi	0
-𫝯	ciyi	0
 洯	ciyk	666000
 帮	ciyl	227000000
 㸷	ciym	4750
@@ -21090,7 +20407,6 @@ encoder:
 豔	cizl	4870000
 𩇠	cizl	0
 丰收	cizm	7770000
-𪯪	cizm	0
 𩇤	cizq	0
 𪅸	cizr	0
 𠫢	cizs	0
@@ -21098,7 +20414,6 @@ encoder:
 毒	cizy	93600000
 㻍	cjag	3960
 璝	cjal	76900
-𪼦	cjal	0
 职工	cjbi	47000000
 𤥪	cjbn	0
 职责	cjcl	34700000
@@ -21107,7 +20422,6 @@ encoder:
 噩梦	cjff	2750000
 职权	cjfx	9140000
 𤩩	cjia	0
-𪽀	cjja	0
 璪	cjjf	62400
 䫷	cjjg	3340
 噩	cjjj	1320000
@@ -21145,14 +20459,12 @@ encoder:
 䎯	ckbo	3490
 理塘	ckbt	288000
 𦔥	ckbu	0
-𪽟	ckbu	0
 䎬	ckbz	17700
 理亏	ckbz	705000
 耘	ckbz	2500000
 	ckbz	0
 𦓷	ckbz	0
 耫	ckcl	26600
-𫆯	ckco	0
 𤩛	ckcx	0
 理事	ckdj	49000000
 琐事	ckdj	4850000
@@ -21171,7 +20483,6 @@ encoder:
 理想	ckfl	111000000
 耨	ckgd	642000
 𦓶	ckgh	0
-𫆬	ckgl	0
 頛	ckgo	48200
 珖	ckgr	525000
 琐碎	ckgs	3900000
@@ -21195,7 +20506,6 @@ encoder:
 𦔐	ckjl	0
 𦓾	ckjm	0
 理喻	ckjo	1540000
-𪽇	ckjr	0
 𦔪	ckjz	0
 𦓵	ckkb	0
 𦔉	ckkb	0
@@ -21203,10 +20513,8 @@ encoder:
 𠛨	ckkd	0
 𤨆	ckkg	0
 理由	ckki	155000000
-𫆫	ckki	0
 瓃	ckkk	124000
 𤩜	ckkk	0
-𫆭	ckkk	0
 耥	ckkl	99500
 耖	ckkm	219000
 𦔈	ckkm	0
@@ -21250,7 +20558,6 @@ encoder:
 理智	ckmj	27700000
 𤥮	ckmj	0
 𦔄	ckml	0
-𪼧	ckml	0
 𢼡	ckmo	0
 𤥟	ckms	0
 理科	ckmt	25400000
@@ -21260,7 +20567,6 @@ encoder:
 𦔠	ckne	0
 理顺	ckng	3960000
 𦔑	cknj	0
-𫆱	cknl	0
 聘任	cknm	4310000
 理化	cknr	4790000
 𦓮	ckns	0
@@ -21319,7 +20625,6 @@ encoder:
 𣅨	ckvv	0
 泰宁	ckwa	511000
 𦔖	ckwf	0
-𫆮	ckwh	0
 耰	ckwr	53400
 耪	ckws	76900
 耢	ckwy	93600
@@ -21336,7 +20641,6 @@ encoder:
 耙	ckyi	2310000
 䎤	ckyj	3980
 耞	ckyj	108000
-𫆰	ckyk	0
 𦔤	ckyl	0
 𦓨	ckyy	0
 𦔣	ckyz	0
@@ -21356,7 +20660,6 @@ encoder:
 瑞丽	clal	5320000
 瑞士	clba	36900000
 琱	clbj	97800
-𪽏	clbu	0
 琠	cleo	83800
 𤫡	clez	0
 𦉦	clez	0
@@ -21386,7 +20689,6 @@ encoder:
 珼	cloa	117000
 责令	clow	9460000
 瑞金	clpa	2460000
-𪼴	clrc	0
 㻿	clri	5450
 责备	clrk	3830000
 𤨉	clrm	0
@@ -21436,7 +20738,6 @@ encoder:
 耗电	cmkz	1790000
 秦岭	cmlo	1650000
 𤩏	cmmb	0
-𪼸	cmmh	0
 珠算	cmml	635000
 𤤥	cmod	0
 瓈	cmok	51100
@@ -21477,7 +20778,6 @@ encoder:
 珻	cmzy	80700
 瑰丽	cnal	2220000
 𤦍	cnal	0
-𪽝	cnam	0
 瑖	cncq	29800
 碧玉	cncs	2090000
 𤧥	cncs	0
@@ -21485,7 +20785,6 @@ encoder:
 琕	cned	46100
 𤦞	cned	0
 碧蓝	cnek	1950000
-𪽐	cnfg	0
 𤫌	cnfo	0
 𤪩	cngb	0
 𧓮	cngi	0
@@ -21516,7 +20815,6 @@ encoder:
 瑰宝	cnwc	1860000
 𤧝	cnxm	0
 𤤱	cnxs	0
-𪼹	cnxs	0
 㻪	cnym	4060
 𤦥	cnzm	0
 𢦋	cnzw	0
@@ -21533,12 +20831,9 @@ encoder:
 奉	cobi	23400000
 𦦺	cobj	0
 𥘿	cobk	0
-𪼷	cobo	0
 䳞	cobr	3190
 𠒏	cobr	0
-𫜓	cobr	0
 㻅	cobz	4030
-𪼀	cobz	0
 春耕	cocb	1840000
 𣋕	cocb	0
 𣌠	cocc	0
@@ -21564,14 +20859,12 @@ encoder:
 珍贵	coji	21700000
 珍品	cojj	7490000
 聆听	cojp	13200000
-𪼏	cojr	0
 𠢌	cojy	0
 春旱	coka	365000
 𠝩	cokd	0
 春光	cokg	11100000
 𤨜	coko	0
 泰	cokv	211000000
-𪼰	cokv	0
 春晖	cokw	3330000
 𢢭	cokw	0
 𤪂	cokw	0
@@ -21579,13 +20872,11 @@ encoder:
 璯	colk	69700
 𧡲	colr	0
 𡏑	comb	0
-𫁌	comb	0
 㻌	comf	4980
 秦	comf	89600000
 𤦜	comi	0
 𦦜	comi	0
 珍重	comk	3790000
-𫌦	coml	0
 𥠼	comm	0
 𦦱	comn	0
 珍稀	como	3680000
@@ -21603,7 +20894,6 @@ encoder:
 𪆊	conr	0
 憃	conw	35800
 瑜伽	cony	22300000
-𪻺	cood	0
 𡙹	cooe	0
 㻜	cooi	3860
 瑽	cooi	44000
@@ -21616,7 +20906,6 @@ encoder:
 珍爱	copw	4230000
 瑜	coqk	16400000
 春风	coqo	14700000
-𪽁	coqq	0
 𤥞	coqx	0
 𤫄	corg	0
 𤪀	corr	0
@@ -21625,7 +20914,6 @@ encoder:
 𪂹	corz	0
 𪃣	corz	0
 春意	cosk	7370000
-𪥙	cosl	0
 𣁤	coss	0
 玪	cosx	83600
 春装	cotb	2520000
@@ -21651,15 +20939,11 @@ encoder:
 𤧒	coyl	0
 𦒰	coyn	0
 玱	coyy	69500
-𪩿	coyy	0
-𪽉	coyy	0
 𤦴	cozk	0
 玜	cozs	53700
 𤥼	cozw	0
 𤧏	cpai	0
 㻈	cpaj	3890
-𪼘	cpal	0
-𪼎	cpao	0
 𤤵	cpci	0
 瑶	cpez	14400000
 瑗	cpgx	1180000
@@ -21669,7 +20953,6 @@ encoder:
 瑫	cpnb	50500
 𤪊	cpow	0
 瓆	cppl	49500
-𪽗	cpqg	0
 𤩥	cprm	0
 瑶族	cpsm	2190000
 琻	cpvv	65400
@@ -21746,7 +21029,6 @@ encoder:
 𤦶	cram	0
 玖万	cray	36700
 𤥋	cray	0
-𪻸	crbd	0
 聊城	crbh	7770000
 㻮	crbk	4140
 表示	crbk	1340000000
@@ -21788,7 +21070,6 @@ encoder:
 𤤅	crod	0
 𤩞	cror	0
 𤩆	cros	0
-𪽑	cros	0
 𢜍	crow	0
 𤦏	crow	0
 𤥘	crox	0
@@ -21844,25 +21125,19 @@ encoder:
 玉树	csfx	3530000
 玉石	csga	9590000
 𤧿	csgl	0
-𪼪	csgp	0
 玣	csid	24000
 斑点	csij	8890000
-𪽞	csil	0
 玉器	csjj	11500000
 琼	csjk	23100000
 𤧼	csjl	0
 琼中	csjv	428000
-𪼐	csjy	0
 璮	cska	31200
 𤩔	cskb	0
 璋	cske	3490000
 𤨼	cske	0
-𪽊	cskg	0
-𪽋	cskh	0
 玉田	cski	2690000
 璄	cskr	62200
 瓌	cskr	52000
-𪽓	cskw	0
 玉雕	cslb	1340000
 斑岩	cslg	114000
 玉山	csll	4700000
@@ -21871,9 +21146,6 @@ encoder:
 瓋	cslw	25100
 璃	cslz	5100000
 𤩺	csmh	0
-𪽂	csmm	0
-𪼛	csmo	0
-𪼮	csmo	0
 𤧦	csmu	0
 㻢	csmy	3600
 𤦽	csmy	0
@@ -21885,11 +21157,9 @@ encoder:
 𤥿	csnr	0
 𤪿	csnr	0
 琗	csoe	31300
-𪼭	csog	0
 珓	csoo	85400
 𤥽	csot	0
 珳	cspd	38300
-𪻻	csqd	0
 斑鸠	csqr	481000
 琼脂	csqr	595000
 玉玺	csrk	783000
@@ -21912,7 +21182,6 @@ encoder:
 𤧟	cswa	0
 𤪗	cswg	0
 𤧛	cswl	0
-𪼬	cswl	0
 𤦻	cswr	0
 𤧭	csws	0
 斑马	csxa	2770000
@@ -21927,19 +21196,16 @@ encoder:
 𤥑	cszm	0
 琉	cszn	4450000
 𤫚	cszn	0
-𪼈	cszo	0
 㻙	cszq	3970
 珫	cszr	65100
 玹	cszz	683000
 𤥦	ctbs	0
 㺶	cted	3870
-𪼫	ctex	0
 𤧻	ctmb	0
 𤪮	ctob	0
 𤪮	ctrb	0
 𤦿	ctrj	0
 𤦾	ctrz	0
-𪽒	ctux	0
 瑭	ctxj	556000
 𤨭	ctxl	0
 𤨫	ctxw	0
@@ -21970,7 +21236,6 @@ encoder:
 䭶	cuan	4230
 𩢷	cuan	0
 𩥿	cuan	0
-𫙝	cuar	0
 駍	cuau	24300
 騁	cuaz	227000
 𩢆	cuaz	0
@@ -21990,7 +21255,6 @@ encoder:
 䭼	cubn	4610
 𩤻	cubo	0
 𩥲	cubo	0
-𫙊	cubo	0
 𩢄	cubr	0
 𩧝	cubr	0
 驛	cubu	1250000
@@ -22021,8 +21285,6 @@ encoder:
 𩥫	cucn	0
 䮞	cuco	3260
 𩤣	cucq	0
-𪱼	cucq	0
-𫙏	cucq	0
 𩤕	cucr	0
 𪄕	cucr	0
 𪉒	cucr	0
@@ -22056,7 +21318,6 @@ encoder:
 𩣲	cueo	0
 𩦖	cueo	0
 𩦸	cueo	0
-𫙞	cueo	0
 驤	cuer	161000
 𩦪	cuer	0
 联营	cuew	4350000
@@ -22069,10 +21330,8 @@ encoder:
 驃	cufb	57200
 㻥	cufd	3600
 𩧜	cufd	0
-𫙖	cufd	0
 𩧅	cufg	0
 駷	cufj	54200
-𫙎	cufj	0
 𩣳	cufk	0
 联想	cufl	51400000
 驦	cufl	24700
@@ -22104,7 +21363,6 @@ encoder:
 璲	cugw	66500
 𩢚	cugx	0
 䮊	cugy	3530
-𪽘	cugy	0
 𩣊	cuha	0
 駤	cuhb	24500
 𩣪	cuhb	0
@@ -22120,7 +21378,6 @@ encoder:
 駆	cuho	4370000
 𩦋	cuho	0
 𩣕	cuhp	0
-𫙋	cuhr	0
 駏	cuhx	32400
 駵	cuhx	25800
 䮅	cuhz	3420
@@ -22129,7 +21386,6 @@ encoder:
 𩢩	cuia	0
 𩡭	cuid	0
 𩤋	cuif	0
-𫙐	cuih	0
 𩤎	cuij	0
 驉	cuik	39000
 𩣝	cuik	0
@@ -22159,12 +21415,10 @@ encoder:
 䮠	cujk	6390
 𩤲	cujk	0
 𩥺	cujk	0
-𫙓	cujk	0
 䮥	cujl	6060
 䮦	cujl	3500
 驕	cujl	1740000
 𩤬	cujl	0
-𫙑	cujl	0
 𩤁	cujm	0
 𩤮	cujm	0
 𩥹	cujm	0
@@ -22186,7 +21440,6 @@ encoder:
 䣖	cujy	3160
 驙	cuka	23000
 䮵	cukb	4140
-𫙔	cukb	0
 騑	cukc	93000
 䮓	cuke	3460
 騨	cuke	102000
@@ -22266,7 +21519,6 @@ encoder:
 馲	cumh	30600
 騀	cumh	30800
 𩢵	cumh	0
-𪽜	cumh	0
 駳	cumi	18700
 𩢐	cumi	0
 𩣜	cumi	0
@@ -22331,7 +21583,6 @@ encoder:
 𩤏	cuoe	0
 𩦗	cuoe	0
 𩤞	cuof	0
-𫙘	cuoi	0
 䮿	cuoj	4030
 𩣥	cuoj	0
 𩢜	cuok	0
@@ -22341,7 +21592,6 @@ encoder:
 駼	cuom	33800
 騇	cuom	28300
 𩥽	cuom	0
-𫙗	cuom	0
 𩡺	cuon	0
 𩢯	cuon	0
 𩥒	cuon	0
@@ -22355,7 +21605,6 @@ encoder:
 𩥗	cuoo	0
 𩥾	cuoo	0
 𩧁	cuoo	0
-𫙛	cuoo	0
 駗	cuop	28800
 驂	cuop	57700
 䮚	cuor	3510
@@ -22392,7 +21641,6 @@ encoder:
 騚	cuqk	42400
 騟	cuqk	22800
 班风	cuqo	322000
-𫙌	cuqx	0
 𩣱	curb	0
 𩧇	curb	0
 𩥪	curc	0
@@ -22437,7 +21685,6 @@ encoder:
 𩥎	cury	0
 騶	curz	69900
 𩣛	curz	0
-𪼻	curz	0
 𩤑	cusb	0
 駐	cusc	11600000
 騂	cuse	38500
@@ -22468,7 +21715,6 @@ encoder:
 驣	cuuc	47500
 𩣆	cuuc	0
 駢	cuue	158000
-𫙕	cuug	0
 𤩕	cuuj	0
 𩦇	cuuj	0
 𩦐	cuuj	0
@@ -22479,7 +21725,6 @@ encoder:
 𩥍	cuum	0
 琰	cuuo	1660000
 𤊇	cuuo	0
-𫙍	cuuo	0
 䯁	cuuq	3310
 𤫙	cuuu	0
 𩧟	cuuu	0
@@ -22538,7 +21783,6 @@ encoder:
 㻩	cuxk	3840
 騄	cuxk	58400
 驑	cuxk	24300
-𫙙	cuxk	0
 𩥻	cuxl	0
 𩦿	cuxl	0
 𩤗	cuxm	0
@@ -22550,12 +21794,10 @@ encoder:
 馭	cuxs	814000
 駅	cuxs	116000000
 𤥎	cuxs	0
-𫙉	cuxs	0
 騐	cuxw	24700
 䮕	cuxx	3480
 騢	cuxx	25500
 𩢃	cuxx	0
-𪦫	cuxz	0
 班子	cuya	15100000
 𩧣	cuyb	0
 𩡰	cuye	0
@@ -22568,7 +21810,6 @@ encoder:
 𩦝	cuyl	0
 䮯	cuym	3540
 驐	cuym	22600
-𪽜	cuym	0
 騽	cuyn	30000
 联队	cuyo	2500000
 𩥩	cuyo	0
@@ -22651,12 +21892,10 @@ encoder:
 𤦮	cvzj	0
 珱	cvzm	62200
 现出	cvzz	3670000
-𪼇	cwad	0
 𤧽	cwag	0
 𤨥	cwaj	0
 琮	cwbk	1550000
 瑄	cwbk	5620000
-𪼙	cwbk	0
 𤧺	cwbl	0
 琎	cwbn	345000
 𤩼	cwbq	0
@@ -22679,10 +21918,7 @@ encoder:
 琏	cwhe	936000
 瑏	cwhi	146000
 𤫐	cwjr	0
-𪽕	cwjr	0
-𪽛	cwjr	0
 𤨖	cwjy	0
-𪼺	cwka	0
 㻘	cwki	3870
 璸	cwkl	146000
 𤫞	cwkl	0
@@ -22691,12 +21927,10 @@ encoder:
 𤦌	cwlc	0
 㻞	cwld	4130
 𤤚	cwli	0
-𪽚	cwlw	0
 𤨚	cwmi	0
 𤩻	cwmm	0
 𤧫	cwmy	0
 璡	cwni	68300
-𪽃	cwno	0
 𤧫	cwnx	0
 琛	cwof	5860000
 瑢	cwoj	218000
@@ -22707,8 +21941,6 @@ encoder:
 瑸	cwpo	40600
 𤤌	cwqd	0
 㻱	cwrc	3810
-𪻾	cwrd	0
-𪼩	cwrj	0
 鬓角	cwrl	492000
 𤨺	cwrp	0
 琬	cwry	1750000
@@ -22718,7 +21950,6 @@ encoder:
 迋	cwvv	204000
 璭	cwwf	43400
 𤥃	cwzm	0
-𪼯	cxae	0
 取下	cxai	5640000
 肆万	cxay	55300
 取巧	cxba	642000
@@ -22750,12 +21981,10 @@ encoder:
 瑋	cxjm	7720000
 璒	cxju	26200
 玛曲	cxkk	210000
-𪽌	cxkm	0
 取暖	cxkp	14300000
 取景	cxks	4210000
 㻖	cxkv	4830
 琭	cxkv	82600
-𪼝	cxkz	0
 聚赌	cxlb	207000
 𤧱	cxld	0
 𤥈	cxli	0
@@ -22809,11 +22038,9 @@ encoder:
 玛沁	cxvw	124000
 取道	cxwu	818000
 聚居	cxxe	3100000
-𪼼	cxxf	0
 𤤂	cxxi	0
 𤤏	cxxs	0
 瑕	cxxx	4330000
-𪽍	cxyq	0
 㻵	cxyy	4350
 𤪆	cxzm	0
 𤪍	cxzm	0
@@ -22831,26 +22058,21 @@ encoder:
 𤣲	cyed	0
 𤩄	cyeo	0
 契机	cyfq	9920000
-𪼉	cygl	0
-𪼲	cygq	0
 珉	cyhd	1510000
 瑉	cyhk	60500
 帮困	cyjf	953000
-𪼑	cyjr	0
 𤫋	cykl	0
 𤦕	cylk	0
 帮助	cyly	2110000000
 珽	cymb	199000
 帮手	cymd	11400000
 𤥻	cymi	0
-𪻹	cyms	0
 𤦆	cynb	0
 𤤖	cynd	0
 契合	cyoa	2920000
 帮会	cyob	2420000
 玚	cyod	59800
 璻	cyoe	26100
-𪳀	cyof	0
 璆	cyop	132000
 帮凶	cyoz	1310000
 帮腔	cyqw	420000
@@ -22898,7 +22120,6 @@ encoder:
 瑻	czlo	36500
 𤨏	czlo	0
 𤪫	czlo	0
-𪼞	czlo	0
 毒贩	czlp	989000
 𤪫	czls	0
 毒手	czmd	2770000
@@ -22913,7 +22134,6 @@ encoder:
 素食	czox	12500000
 㼃	czoz	13600
 素质	czpe	65900000
-𪼜	czqm	0
 毒犯	czqy	235000
 玧	czrd	55600
 𤨿	czrd	0
@@ -22957,7 +22177,6 @@ encoder:
 捷报	dady	1270000
 扞	daed	134000
 捷克	daej	17200000
-𪯍	daeo	0
 攮	daer	133000
 𢭅	daeu	0
 打雷	dafk	2110000
@@ -22976,8 +22195,6 @@ encoder:
 𢯞	dahi	0
 打卡	daia	3100000
 𢩹	daid	0
-𪭻	daii	0
-𪮂	dais	0
 𢯬	daix	0
 𢪪	daiz	0
 打嗝	daja	743000
@@ -23017,7 +22234,6 @@ encoder:
 𢷡	daof	0
 掚	daoo	26600
 擟	daoo	48200
-𪮌	daoo	0
 𢺕	daor	0
 扙	daos	63100
 𢰯	daot	0
@@ -23028,7 +22244,6 @@ encoder:
 𢪁	daqd	0
 打猎	daqe	2440000
 打杂	daqf	1450000
-𪮣	daqk	0
 打印	dara	687000000
 𢳗	darf	0
 𢵍	darf	0
@@ -23044,7 +22259,6 @@ encoder:
 𢸸	daug	0
 抚恤	daum	2480000
 抚养	daun	5450000
-𪮙	dauy	0
 打消	davk	4160000
 抚州	davn	3790000
 抚宁	dawa	172000
@@ -23115,7 +22329,6 @@ encoder:
 持重	dbmk	367000
 挂失	dbmo	3630000
 𢪝	dbnd	0
-𪰣	dbnd	0
 挂牌	dbnn	15600000
 捇	dbno	1020000
 𢷓	dbno	0
@@ -23139,7 +22352,6 @@ encoder:
 𢴇	dbqs	0
 抏	dbrd	45700
 搘	dbrk	73600
-𪯅	dbrk	0
 㧯	dbrr	5030
 持久	dbrs	19600000
 𢫮	dbrs	0
@@ -23148,7 +22360,6 @@ encoder:
 𢹤	dbrz	0
 𢳆	dbsm	0
 𢭷	dbso	0
-𪯄	dbuj	0
 扶养	dbun	702000
 挟	dbuo	5500000
 𢵓	dbup	0
@@ -23249,7 +22460,6 @@ encoder:
 撕扯	dedi	1500000
 摸排	dedk	339000
 撒播	dedp	770000
-𪮺	dedp	0
 搭救	dedv	1030000
 撶	deeb	939000
 𢱴	deef	0
@@ -23259,7 +22469,6 @@ encoder:
 𢱗	deej	0
 𢴢	deel	0
 𢵕	deem	0
-𪮰	deeo	0
 𢴿	deeq	0
 𢵎	dees	0
 摸索	deew	9510000
@@ -23293,7 +22502,6 @@ encoder:
 描图	dejr	183000
 𢭪	dejr	0
 𢵖	dejr	0
-𫜘	dejr	0
 㩥	deka	10300
 技师	deka	5350000
 撒旦	deka	1370000
@@ -23302,7 +22510,6 @@ encoder:
 摸	dekg	56600000
 描	deki	7280000
 𢲵	dekk	0
-𪯃	dekm	0
 撗	deko	500000
 擖	dekr	67900
 𢶭	dekr	0
@@ -23330,7 +22537,6 @@ encoder:
 𢶤	denr	0
 𢸺	denu	0
 擭	denx	148000
-𪯜	deny	0
 𢹕	deoe	0
 搽	deof	2740000
 攧	deog	79500
@@ -23364,7 +22570,6 @@ encoder:
 𢶰	desw	0
 𢮻	desx	0
 𢳑	desx	0
-𪯛	desx	0
 𢮷	desy	0
 摸底	detr	3350000
 𢴯	deuj	0
@@ -23379,7 +22584,6 @@ encoder:
 𢱢	dewz	0
 𢶬	dexc	0
 𢷟	dexi	0
-𪩆	dexl	0
 𢸳	dexn	0
 技	dexs	93600000
 𢳌	dexz	0
@@ -23402,7 +22606,6 @@ encoder:
 𢲧	dezo	0
 技能	dezq	62600000
 𢱝	dezz	0
-𪮥	dezz	0
 搟	dfae	55000
 𢰁	dfaz	0
 𢷋	dfbd	0
@@ -23437,7 +22640,6 @@ encoder:
 𢳮	dfjp	0
 摗	dfjr	61600
 揸	dfka	712000
-𪮘	dfkd	0
 撢	dfke	94600
 擂	dfki	7980000
 𢸲	dfkk	0
@@ -23456,11 +22658,9 @@ encoder:
 㩕	dfow	3870
 捕食	dfox	2840000
 摲	dfpd	111000
-𪯓	dfpk	0
 𢮴	dfqy	0
 捕鱼	dfra	2490000
 攋	dfrl	60000
-𪯎	dfrl	0
 𢺴	dfrp	0
 𢷛	dfrr	0
 𢶉	dfry	0
@@ -23482,7 +22682,6 @@ encoder:
 𢫲	dgax	0
 㨒	dgbb	4280
 捱	dgbb	2850000
-𪭼	dgbi	0
 捺	dgbk	1570000
 掩埋	dgbk	2540000
 撦	dgbm	84400
@@ -23495,7 +22694,6 @@ encoder:
 搙	dgds	51900
 掩护	dgdw	4640000
 捹	dgee	11500
-𪱅	dgee	0
 𢺌	dgef	0
 掩藏	dgeh	1460000
 掩蔽	dgek	630000
@@ -23522,7 +22720,6 @@ encoder:
 𢲅	dgkz	0
 振幅	dgla	2440000
 抪	dgli	45100
-𪮃	dgli	0
 𢴓	dglr	0
 拔罐	dgme	352000
 𢫳	dgme	0
@@ -23531,7 +22728,6 @@ encoder:
 扼制	dgml	659000
 扰乱	dgmz	8590000
 掩体	dgnf	734000
-𪮹	dgnk	0
 振作	dgnm	4140000
 拓片	dgnx	307000
 扼杀	dgof	6470000
@@ -23580,7 +22776,6 @@ encoder:
 揻	dhaz	56100
 拭	dhbi	6260000
 挳	dhbi	587000
-𪮮	dhbk	0
 𢴧	dhbl	0
 撼动	dhbz	2310000
 𢸩	dhcm	0
@@ -23612,7 +22807,6 @@ encoder:
 拒付	dhnd	815000
 㨤	dhni	5660
 抠	dhos	8560000
-𪮣	dhqk	0
 𢪑	dhrd	0
 撍	dhrk	64600
 找齐	dhsn	404000
@@ -23641,7 +22835,6 @@ encoder:
 𢺂	dibu	0
 掉换	didr	292000
 扑救	didv	1560000
-𪯆	dieh	0
 扑克	diej	7220000
 𢵎	dies	0
 據	digq	19300000
@@ -23690,7 +22883,6 @@ encoder:
 𢪊	dixs	0
 𢷂	dixu	0
 𢳌	dixz	0
-𪮛	dixz	0
 𢫋	diya	0
 掳	diym	2820000
 掉队	diyo	792000
@@ -23731,8 +22923,6 @@ encoder:
 摑	djja	663000
 𢰊	djjd	0
 操	djjf	45300000
-𪮍	djji	0
-𪮧	djjj	0
 攌	djjr	50200
 撣	djke	163000
 事由	djki	4110000
@@ -23766,16 +22956,13 @@ encoder:
 𢹡	djpn	0
 事儿	djrd	9510000
 拀	djrd	22900
-𪯇	djri	0
 𢷅	djrj	0
 𢭻	djro	0
 扣留	djrs	3710000
 事务	djry	152000000
-𪭽	djry	0
 事端	djsl	1630000
 事变	djsx	3350000
 拐弯	djsy	2430000
-𪮏	djte	0
 捐资	djtr	2900000
 事情	djuc	214000000
 损益	djuo	3440000
@@ -23818,7 +23005,6 @@ encoder:
 捑	dkas	48800
 押款	dkbb	74800
 提款	dkbb	2340000
-𪮲	dkbd	0
 提示	dkbk	393000000
 揭示	dkbk	16000000
 攩	dkbu	62000
@@ -24082,9 +23268,7 @@ encoder:
 𢫭	dloo	0
 𢳕	dloq	0
 𢴔	dlpx	0
-𪮼	dlqq	0
 摆脱	dlqu	23900000
-𪮯	dlrc	0
 擉	dlri	59300
 擺	dlrr	12300000
 摆放	dlsm	7810000
@@ -24109,7 +23293,6 @@ encoder:
 才干	dmae	2610000
 撬开	dmae	1220000
 𢭉	dmai	0
-𪮒	dmai	0
 撘	dmaj	879000
 𢭡	dmak	0
 𢲐	dmal	0
@@ -24119,14 +23302,11 @@ encoder:
 𢳾	dmby	0
 拖动	dmbz	4940000
 𢫻	dmbz	0
-𪯑	dmcb	0
 插班	dmcu	773000
 插拔	dmdg	2110000
 插播	dmdp	2300000
 挺	dmdy	96600000
 捶	dmeb	4880000
-𪭶	dmed	0
-𪮪	dmee	0
 𢭉	dmei	0
 插花	dmen	3930000
 𢹢	dmeo	0
@@ -24166,7 +23346,6 @@ encoder:
 插足	dmji	750000
 撟	dmjl	183000
 𢹣	dmjl	0
-𪮴	dmjl	0
 𢰈	dmjn	0
 插图	dmjr	16300000
 𢹀	dmjr	0
@@ -24174,7 +23353,6 @@ encoder:
 𢴈	dmka	0
 揰	dmkb	61900
 𢯔	dmkd	0
-𪮓	dmkd	0
 𢹺	dmke	0
 插曲	dmkk	7820000
 𢶌	dmkm	0
@@ -24201,7 +23379,6 @@ encoder:
 𢺮	dmml	0
 撬	dmmm	5670000
 𢵜	dmmm	0
-𪮵	dmmo	0
 托管	dmmw	22000000
 才气	dmmy	2050000
 㩯	dmmz	6690
@@ -24227,7 +23404,6 @@ encoder:
 托盘	dmpl	4850000
 拖船	dmpq	307000
 擶	dmqk	56500
-𪮳	dmrb	0
 𢸕	dmrc	0
 𢸽	dmrc	0
 㧥	dmrd	5460
@@ -24280,7 +23456,6 @@ encoder:
 𢭆	dmym	0
 𢺜	dmyn	0
 插队	dmyo	1090000
-𪯔	dmyu	0
 搥	dmyw	732000
 逰	dmyw	77800
 𢰛	dmzg	0
@@ -24294,14 +23469,12 @@ encoder:
 𢩻	dmzs	0
 挴	dmzy	106000
 𢯃	dmzy	0
-𪭵	dmzz	0
 推开	dnae	11400000
 𢬲	dnaj	0
 𢲐	dnal	0
 擤	dnan	730000
 𢰻	dnaz	0
 揑	dnbi	150000
-𪮝	dnbi	0
 𢶙	dnbq	0
 推动	dnbz	127000000
 𢹻	dncg	0
@@ -24317,7 +23490,6 @@ encoder:
 捭	dned	250000
 𢮒	dned	0
 𢲜	dned	0
-𪭸	dned	0
 推荐	dneg	956000000
 搜索	dnew	1070000000
 携带	dnew	23000000
@@ -24338,7 +23510,6 @@ encoder:
 𢷣	dnio	0
 擕	dniy	93500
 㨐	dnjf	4630
-𪮟	dnjo	0
 𢭱	dnka	0
 𢷏	dnku	0
 拍照	dnky	24900000
@@ -24423,7 +23594,6 @@ encoder:
 推断	dnzu	9050000
 𢸂	dnzu	0
 推出	dnzz	296000000
-𪮾	doad	0
 扒开	doae	852000
 拾	doaj	30600000
 𤁙	doaj	0
@@ -24438,7 +23608,6 @@ encoder:
 捡	dobv	19900000
 拾起	doby	3760000
 抢劫	dobz	22400000
-𪮆	dobz	0
 𢷸	docm	0
 扖	doda	41400
 挫折	dodp	16800000
@@ -24478,13 +23647,11 @@ encoder:
 擒拿	dooa	1170000
 挫	doob	7420000
 𢬕	doob	0
-𪭹	dood	0
 㧿	dooi	5250
 摐	dooi	169000
 𢵄	dook	0
 𢯧	doom	0
 撿	dooo	4340000
-𪮅	dooo	0
 𢯋	doop	0
 㨑	door	4200
 𢹦	door	0
@@ -24492,7 +23659,6 @@ encoder:
 抮	dopd	110000
 揄	doqk	341000
 抡	dorr	3020000
-𪮶	dorr	0
 摿	dosk	59900
 搇	dosr	75600
 扲	dosx	512000
@@ -24583,7 +23749,6 @@ encoder:
 㩊	dpld	4120
 𢂼	dpli	0
 捳	dpll	23200
-𫏓	dplo	0
 援助	dply	25800000
 拆卸	dpma	5150000
 𢳸	dpmi	0
@@ -24606,15 +23771,12 @@ encoder:
 拆分	dpoy	1900000
 㩫	dppl	3930
 𢸖	dppp	0
-𪴴	dppp	0
 𢶎	dpps	0
-𪮽	dpqj	0
 𢸔	dpql	0
 折腾	dpqu	9510000
 搬	dpqx	42400000
 折服	dpqy	5130000
 挀	dprh	520000
-𪮄	dprh	0
 援外	dpri	411000
 𧣯	dprl	0
 掀	dpro	19800000
@@ -24712,7 +23874,6 @@ encoder:
 投奔	dqge	2430000
 抛在	dqgv	1880000
 执友	dqgx	18500
-𫑆	dqhe	0
 热切	dqhy	4240000
 热轧	dqhz	2620000
 热点	dqij	491000000
@@ -24754,16 +23915,13 @@ encoder:
 抛盘	dqpl	899000
 热爱	dqpw	24600000
 热键	dqpy	3150000
-𪮁	dqqa	0
 热风	dqqo	2300000
 𢲰	dqrk	0
 𢵁	dqru	0
-𪮐	dqry	0
 鸷	dqrz	383000
 垫	dqsb	38000000
 𢬋	dqsb	0
 热诚	dqsh	3780000
-𫑆	dqsh	0
 蛰	dqsi	1150000
 热衷	dqsj	7580000
 执意	dqsk	3670000
@@ -24835,7 +23993,6 @@ encoder:
 抵押	drdk	10900000
 抵挡	drdk	7700000
 抵抗	drds	29500000
-𪮑	drds	0
 挽救	drdv	7910000
 指挥	drdw	36000000
 指控	drdw	7870000
@@ -24861,7 +24018,6 @@ encoder:
 𢭌	drii	0
 指点	drij	23700000
 揝	drik	68600
-𪯉	drjg	0
 挽回	drjj	11700000
 挽	drjr	11000000
 𢛑	drjw	0
@@ -24870,7 +24026,6 @@ encoder:
 㩩	drkg	4430
 指甲	drki	22900000
 㧰	drko	4040
-𪭾	drko	0
 指明	drkq	5040000
 抵账	drlc	45900
 捔	drld	57400
@@ -24918,7 +24073,6 @@ encoder:
 换位	drns	2240000
 搀假	drnx	51900
 𢪱	drod	0
-𪭷	drod	0
 抵御	drom	6790000
 擔	dros	2280000
 𢪣	dros	0
@@ -24995,9 +24149,7 @@ encoder:
 指导	dryd	239000000
 指引	dryi	19000000
 𢬘	dryi	0
-𪮞	dryj	0
 㨨	dryk	6260
-𪾿	dryl	0
 批改	drym	1290000
 𢶷	drym	0
 换防	drys	314000
@@ -25025,7 +24177,6 @@ encoder:
 撞球	dscd	2160000
 拉长	dsch	3510000
 擅长	dsch	13800000
-𪮠	dsci	0
 撤职	dscj	2500000
 𢴶	dscr	0
 𢸣	dscr	0
@@ -25078,7 +24229,6 @@ encoder:
 㩆	dskg	4040
 𢺀	dskg	0
 𢴠	dskh	0
-𪯋	dski	0
 𢱊	dskk	0
 摬	dskr	75700
 𢰜	dskr	0
@@ -25123,7 +24273,6 @@ encoder:
 接待	dsob	43900000
 接入	dsod	23100000
 捽	dsoe	146000
-𪮡	dsoe	0
 𢭒	dsof	0
 搞得	dsok	14700000
 𢮰	dsok	0
@@ -25131,7 +24280,6 @@ encoder:
 挍	dsoo	102000
 抗衡	dsor	10700000
 𢮁	dsot	0
-𪮷	dsow	0
 搞错	dspe	5610000
 撤销	dspk	10700000
 撤兵	dspo	474000
@@ -25193,7 +24341,6 @@ encoder:
 摘录	dsxk	4800000
 𢬠	dsxk	0
 𢭗	dsxo	0
-𪮸	dsxq	0
 𢲲	dsxy	0
 拉力	dsym	3670000
 接力	dsym	5660000
@@ -25221,7 +24368,6 @@ encoder:
 搞好	dszy	15700000
 撤出	dszz	3870000
 𢫔	dszz	0
-𪮔	dtbs	0
 抖动	dtbz	4660000
 抖擞	dtdu	1710000
 扩招	dtdy	2580000
@@ -25245,7 +24391,6 @@ encoder:
 𢵹	dtmz	0
 捬	dtnd	67700
 𢳋	dtne	0
-𪯚	dtnw	0
 𢷹	dtob	0
 𢱅	dtoz	0
 扩印	dtra	232000
@@ -25265,15 +24410,12 @@ encoder:
 搪塞	dtwe	1580000
 扩军	dtwh	661000
 扩容	dtwo	5150000
-𪯗	dtwr	0
 扩展	dtxe	45000000
-𪮈	dtxg	0
 𢭸	dtxi	0
 𢳿	dtxi	0
 搪	dtxj	1840000
 𢹲	dtxj	0
 𢳧	dtxk	0
-𪮿	dtxl	0
 掶	dtxo	66100
 扩张	dtyc	22200000
 𢺠	dtyn	0
@@ -25336,7 +24478,6 @@ encoder:
 拼音	dusk	26300000
 攁	dusx	58100
 拼凑	dutc	2270000
-𪯊	dutr	0
 𢵈	duuj	0
 掞	duuo	305000
 𢴵	duuu	0
@@ -25410,7 +24551,6 @@ encoder:
 𢴜	dvnq	0
 救命	dvoa	19000000
 救人	dvod	6270000
-𪯀	dvof	0
 求饶	dvoh	2070000
 搅得	dvok	1080000
 求得	dvok	5090000
@@ -25421,13 +24561,11 @@ encoder:
 𠂃	dvqs	0
 挑	dvrd	60700000
 𢹅	dvri	0
-𪮫	dvrj	0
 𣰐	dvrm	0
 求证	dvsa	3040000
 𡌊	dvsb	0
 𤥲	dvsc	0
 𩣗	dvsc	0
-𪫊	dvse	0
 𩒮	dvsg	0
 𧋛	dvsi	0
 𨁛	dvsj	0
@@ -25675,7 +24813,6 @@ encoder:
 揵	dxby	125000
 扭动	dxbz	3280000
 𢰰	dxci	0
-𪮉	dxci	0
 撖	dxcm	147000
 扫毒	dxcz	284000
 扫描	dxde	46900000
@@ -25696,7 +24833,6 @@ encoder:
 扫雷	dxfk	3620000
 摊档	dxfk	188000
 攔	dxfl	1720000
-𪯂	dxfv	0
 抉	dxgd	1180000
 𢷧	dxgo	0
 扭转	dxhb	9010000
@@ -25709,7 +24845,6 @@ encoder:
 摊点	dxij	2150000
 揟	dxiq	71500
 据此	dxir	12600000
-𪭺	dxis	0
 撏	dxjd	70000
 𢶝	dxji	0
 𢯷	dxjm	0
@@ -25734,7 +24869,6 @@ encoder:
 摊贩	dxlp	787000
 𢱥	dxlx	0
 𢰭	dxly	0
-𪯙	dxlz	0
 𢲕	dxma	0
 握手	dxmd	13100000
 𢰱	dxmd	0
@@ -25750,7 +24884,6 @@ encoder:
 摊	dxni	23500000
 择偶	dxnk	2070000
 摊牌	dxnn	2030000
-𪮢	dxno	0
 握住	dxns	8850000
 㨛	dxod	3950
 㩔	dxoq	4620
@@ -25778,10 +24911,8 @@ encoder:
 摒	dxue	1140000
 𢷚	dxuk	0
 披着	dxul	6810000
-𪯒	dxul	0
 𢺟	dxuu	0
 𢸞	dxuy	0
-𪯌	dxuz	0
 扫清	dxvc	1030000
 摊派	dxvp	2150000
 𢳲	dxvx	0
@@ -25792,7 +24923,6 @@ encoder:
 扫房	dxws	45100
 扭送	dxwu	376000
 𢬶	dxwx	0
-𪯈	dxwz	0
 𢬞	dxxb	0
 𢬟	dxxe	0
 𢮢	dxxe	0
@@ -25848,7 +24978,6 @@ encoder:
 𢴟	dyfk	0
 报检	dyfo	2550000
 报酬	dyfv	12900000
-𪯐	dygy	0
 挪威	dyha	25000000
 抿	dyhd	4840000
 㨉	dyhk	4170
@@ -25856,7 +24985,6 @@ encoder:
 招致	dyhm	3230000
 把	dyia	771000000
 报国	dyjc	2910000
-𪯘	dyjc	0
 𢱌	dyjf	0
 摾	dyji	74800
 招呼	dyjm	19600000
@@ -25881,7 +25009,6 @@ encoder:
 挻	dymi	999000
 报告	dymj	232000000
 报复	dymk	14100000
-𪮬	dymn	0
 报答	dymo	4340000
 𢭮	dymo	0
 扱	dyms	5850000
@@ -26036,7 +25163,6 @@ encoder:
 𢰹	dzrs	0
 𢴋	dzrt	0
 撧	dzry	162000
-𪮭	dzry	0
 拟订	dzsa	1910000
 拟请	dzsc	127000
 扎襄	dzsj	717
@@ -26114,7 +25240,6 @@ encoder:
 𪏂	eabu	0
 𦫒	eabx	0
 𦮆	eabx	0
-𪟧	eaby	0
 𦻠	eace	0
 𠞱	eack	0
 苛责	eacl	408000
@@ -26174,7 +25299,6 @@ encoder:
 𪏅	eahb	0
 𦺐	eahh	0
 𪏊	eahh	0
-𫉋	eahi	0
 𢦫	eahm	0
 𦯄	eahx	0
 𪎶	eahz	0
@@ -26204,7 +25328,6 @@ encoder:
 𦮉	eajn	0
 𩁂	eajn	0
 𦭮	eajo	0
-𫊳	eajr	0
 荳	eaju	1560000
 𪏄	eaju	0
 𪏨	eaju	0
@@ -26235,8 +25358,6 @@ encoder:
 鵲	eakr	532000
 鹊	eakr	2890000
 𣤬	eakr	0
-𪵐	eakr	0
-𫉰	eakr	0
 𦶣	eaku	0
 逪	eakw	26300
 皵	eakx	725000
@@ -26246,7 +25367,6 @@ encoder:
 𨛳	eaky	0
 𤲅	eakz	0
 𦁬	eakz	0
-𫈬	ealb	0
 𤰍	ealf	0
 𧁡	ealf	0
 䵎	ealg	4980
@@ -26301,7 +25421,6 @@ encoder:
 𪎿	eaog	0
 𪏔	eaog	0
 𪏀	eaoh	0
-𪭤	eaoh	0
 蛬	eaoi	36500
 𠍳	eaoi	0
 𪏐	eaoi	0
@@ -26354,7 +25473,6 @@ encoder:
 巷	eaoy	44900000
 𢀼	eaoy	0
 𨝴	eaoy	0
-𪯰	eaoy	0
 𦭯	eaoz	0
 𪎺	eaps	0
 𦹡	eapy	0
@@ -26419,7 +25537,6 @@ encoder:
 酀	eauy	36800
 𡤈	eauz	0
 芜湖	eave	9390000
-𪯶	eavf	0
 荆州	eavn	12200000
 𠥻	eavv	0
 𪏕	eawf	0
@@ -26439,7 +25556,6 @@ encoder:
 𤴟	eaxi	0
 𦱥	eaxi	0
 𪏢	eaxk	0
-𫉝	eaxk	0
 𠕯	eaxs	0
 萋	eaxz	1300000
 𪏖	eayg	0
@@ -26483,7 +25599,6 @@ encoder:
 𤯅	ebai	0
 𥂯	ebal	0
 𦏡	ebaz	0
-𫈭	ebaz	0
 𧁞	ebbb	0
 葑	ebbd	803000
 蕘	ebbg	55900
@@ -26570,8 +25685,6 @@ encoder:
 蘾	ebkr	158000
 𦿋	ebkr	0
 基业	ebku	2980000
-𫋇	ebku	0
-𫋏	ebku	0
 莱	ebkv	118000000
 甘当	ebkx	742000
 冓	eblb	68500
@@ -26590,7 +25703,6 @@ encoder:
 𧂣	ebmq	0
 著称	ebmr	6180000
 𢎌	ebnh	0
-𫊄	ebni	0
 甘泉	ebnk	2120000
 著作	ebnm	130000000
 䓇	ebno	5190
@@ -26609,7 +25721,6 @@ encoder:
 𦶐	ebow	0
 基金	ebpa	96000000
 𣃈	ebpd	0
-𫊲	ebqb	0
 茿	ebqd	36400
 𦵶	ebqf	0
 𧁈	ebqf	0
@@ -26618,7 +25729,6 @@ encoder:
 爇	ebqu	118000
 𦶐	ebqw	0
 基肥	ebqy	901000
-𫊠	ebqy	0
 蒆	ebqz	26700
 芫	ebrd	1270000
 𠒌	ebrd	0
@@ -26626,7 +25736,6 @@ encoder:
 𤯄	ebrh	0
 𠨊	ebri	0
 𪙐	ebri	0
-𪳃	ebri	0
 著名	ebrj	95300000
 𦰶	ebrj	0
 𦴆	ebrj	0
@@ -26652,7 +25761,6 @@ encoder:
 𦹷	ebsj	0
 基调	ebsl	3490000
 𧃳	ebsr	0
-𫊰	ebsr	0
 爇	ebsu	118000
 𤑔	ebsu	0
 𢤍	ebsw	0
@@ -26662,7 +25770,6 @@ encoder:
 基准	ebtn	9240000
 𦿖	ebtx	0
 𦱾	ebua	0
-𫉈	ebub	0
 𦵶	ebuf	0
 甘美	ebug	1420000
 𧅩	ebum	0
@@ -26726,7 +25833,6 @@ encoder:
 𦻙	ecce	0
 𧂖	eccp	0
 𦿰	eccu	0
-𫊗	eccw	0
 蔧	eccx	24300
 𦹙	eccx	0
 𧅞	eccx	0
@@ -26746,7 +25852,6 @@ encoder:
 蘁	ecjj	33000
 𧂬	ecjl	0
 𤯑	ecjm	0
-𫊡	ecjm	0
 其中	ecjv	359000000
 㫷	ecka	4230
 䒹	ecka	4480
@@ -26763,7 +25868,6 @@ encoder:
 𦶈	eclb	0
 𧂻	eclh	0
 𧒤	ecli	0
-𫋂	eclj	0
 蔶	eclo	19200
 𠔶	eclo	0
 𧂺	eclw	0
@@ -26773,7 +25877,6 @@ encoder:
 㲨	ecmh	5030
 𦶇	ecmh	0
 𠔫	ecmi	0
-𫊅	ecmk	0
 𦺹	ecmy	0
 𨿣	ecni	0
 𧀐	ecnj	0
@@ -26797,16 +25900,13 @@ encoder:
 𣃄	ecqp	0
 𡠧	ecqz	0
 𦼆	ecrc	0
-𫉊	ecrh	0
 欺	ecro	12500000
 夦	ecrr	24200
 𪅾	ecrr	0
 𧃿	ecrw	0
 𦫡	ecry	0
 䳢	ecrz	3960
-𫈶	ecrz	0
 𫜶	ecrz	0
-𫉉	ecso	0
 䔷	ecsx	4110
 𦲖	ecsx	0
 𡠧	ecsz	0
@@ -26862,10 +25962,8 @@ encoder:
 䓯	eczy	3320
 勘	eczy	11100000
 幹	edae	18500000
-𪪗	edae	0
 𦺕	edag	0
 䔶	edai	4730
-𪢵	edai	0
 𧶚	edal	0
 兡	edan	27800
 𤱿	edan	0
@@ -26900,7 +25998,6 @@ encoder:
 卋	edea	500000
 𠦔	edea	0
 𧂽	edeb	0
-𪯞	edeb	0
 𠥼	eded	0
 𠦃	edee	0
 𠦄	edee	0
@@ -26954,7 +26051,6 @@ encoder:
 𠒲	edhh	0
 𦣰	edhi	0
 𦯙	edhi	0
-𫜗	edhr	0
 十成	edhv	1060000
 㢤	edhy	4250
 𠦾	edii	0
@@ -26985,7 +26081,6 @@ encoder:
 𠧂	edjm	0
 𢪿	edjm	0
 𩏑	edjm	0
-𫗒	edjm	0
 䧸	edjn	3420
 㼋	edjp	4360
 胡	edjq	103000000
@@ -26997,7 +26092,6 @@ encoder:
 鴣	edjr	85100
 鸪	edjr	956000
 𠷫	edjr	0
-𪡠	edjr	0
 辜	edjs	4010000
 𨐒	edjs	0
 𨑀	edjs	0
@@ -27032,12 +26126,10 @@ encoder:
 𨞢	edky	0
 𥄂	edla	0
 直	edlc	170000000
-𪟵	edlc	0
 南	edld	475000000
 十四	edlk	52800000
 𧡚	edll	0
 𣯻	edlm	0
-𪪇	edlm	0
 𩀴	edln	0
 㒹	edlo	4370
 真	edlo	612000000
@@ -27065,7 +26157,6 @@ encoder:
 亁	edmy	74600
 𠄊	edmy	0
 𠢇	edmy	0
-𪟷	edmy	0
 𠒭	edmz	0
 𠦠	edna	0
 十佳	ednb	7310000
@@ -27078,7 +26169,6 @@ encoder:
 十亿	edny	7870000
 𪕮	ednz	0
 十八	edoa	59200000
-𫀲	edob	0
 䮧	edoc	31600
 𦴽	edoc	0
 𠦵	edoe	0
@@ -27108,17 +26198,14 @@ encoder:
 𩹼	edor	0
 𠓏	edos	0
 栆	edot	44000
-𪞡	edot	0
 𤌹	edou	0
 㥲	edow	4320
-𪟼	edow	0
 𥀐	edox	0
 兝	edoy	25400
 十分	edoy	191000000
 𡥇	edoy	0
 𢺺	edoy	0
 𨝊	edoy	0
-𪧀	edoz	0
 䓆	edpd	3570
 𠦉	edpd	0
 𦷀	edpf	0
@@ -27128,7 +26215,6 @@ encoder:
 𨡷	edqf	0
 𧍵	edqi	0
 𩖘	edqi	0
-𪟽	edqk	0
 𡹹	edql	0
 𩀉	edqn	0
 䭌	edqo	4120
@@ -27139,7 +26225,6 @@ encoder:
 鹕	edqr	294000
 𪆘	edqr	0
 𫜽	edqr	0
-𪟸	edqs	0
 𤒒	edqu	0
 𦶟	edqu	0
 十月	edqv	49800000
@@ -27165,8 +26250,6 @@ encoder:
 菢	edry	130000
 𦫛	edry	0
 𡒙	edsb	0
-𪤥	edsb	0
-𫝶	edsi	0
 𨆕	edsj	0
 十六	edso	61800000
 𦽲	edsr	0
@@ -27182,10 +26265,8 @@ encoder:
 𠒀	edug	0
 丧	eduh	8280000
 𦰂	eduo	0
-𫘑	eduo	0
 盚	edvl	40000
 莍	edvs	40000
-𪧭	edwd	0
 𣐁	edwf	0
 𠦹	edwg	0
 賫	edwl	23500
@@ -27193,7 +26274,6 @@ encoder:
 赍	edwl	547000
 𢄬	edwl	0
 𦾣	edwn	0
-𪞳	edwq	0
 十字	edwy	22500000
 孛	edwy	1040000
 索	edwz	148000000
@@ -27213,7 +26293,6 @@ encoder:
 𦜚	edxq	0
 鳷	edxr	53000
 𣤳	edxr	0
-𫜡	edxr	0
 支	edxs	230000000
 菝	edxs	177000
 嘏	edxx	250000
@@ -27261,7 +26340,6 @@ encoder:
 䀇	edzl	6350
 𥂩	edzl	0
 𦾃	edzl	0
-𪟺	edzm	0
 𤱑	edzo	0
 𣪺	edzq	0
 𤱑	edzs	0
@@ -27294,14 +26372,12 @@ encoder:
 𩊘	eean	0
 𩎋	eear	0
 𩊂	eeax	0
-𫋈	eeax	0
 䪈	eeay	3450
 𩊕	eeay	0
 蘳	eebb	20800
 鞋	eebb	125000000
 𩋔	eebb	0
 𩋮	eebd	0
-𫋋	eebg	0
 鞐	eebi	204000
 鞊	eebj	415000
 𩋙	eebj	0
@@ -27382,7 +26458,6 @@ encoder:
 𦴈	eegj	0
 𩊵	eegk	0
 𩊽	eegl	0
-𫗆	eegm	0
 鞒	eegn	268000
 𩔈	eego	0
 靰	eegr	50200
@@ -27470,11 +26545,9 @@ encoder:
 𩍕	eeka	0
 𩍅	eekb	0
 𩋂	eekc	0
-𪟍	eekd	0
 𦿩	eeke	0
 𩌬	eeke	0
 𩍍	eeke	0
-𫗌	eeke	0
 𩋗	eekf	0
 𩍀	eekf	0
 𩊠	eekg	0
@@ -27495,7 +26568,6 @@ encoder:
 䪄	eeko	3820
 鞕	eeko	92500
 鞭	eeko	18700000
-𫊃	eeko	0
 鞘	eekq	7620000
 𩋤	eekq	0
 𩍋	eekq	0
@@ -27536,7 +26608,6 @@ encoder:
 𩎉	eelt	0
 𧀱	eelw	0
 𩍹	eelw	0
-𪭜	eelw	0
 䩠	eemb	4280
 𩍮	eeme	0
 鞂	eemf	37700
@@ -27597,7 +26668,6 @@ encoder:
 𩍲	eeoo	0
 𩌭	eeop	0
 𩌰	eeop	0
-𫗍	eeoq	0
 䕿	eeor	4100
 𩊻	eeor	0
 𩋯	eeor	0
@@ -27638,7 +26708,6 @@ encoder:
 䩼	eerc	3380
 𩊩	eerc	0
 𧆚	eere	0
-𫗈	eere	0
 𩌜	eerf	0
 𩍘	eerf	0
 𩉬	eerh	0
@@ -27653,7 +26722,6 @@ encoder:
 𩊺	eerl	0
 𩍁	eerl	0
 𩎈	eerl	0
-𫗋	eerl	0
 𩋧	eern	0
 𩉢	eero	0
 𩋌	eero	0
@@ -27696,7 +26764,6 @@ encoder:
 𩊌	eesu	0
 𩊫	eesw	0
 靲	eesx	25000
-𫋈	eesx	0
 𩎐	eetc	0
 𧁷	eetf	0
 苦头	eetg	2810000
@@ -27825,7 +26892,6 @@ encoder:
 苦练	eezh	3640000
 𧁏	eezi	0
 𩌾	eezi	0
-𫗊	eezi	0
 𩌂	eezj	0
 𧁖	eezk	0
 𩋝	eezk	0
@@ -27849,7 +26915,6 @@ encoder:
 䩙	eezz	3620
 𩋎	eezz	0
 蓒	efae	83200
-𫉞	efaj	0
 博士	efba	69300000
 蓕	efbb	28400
 蔈	efbk	24600
@@ -27904,7 +26969,6 @@ encoder:
 𧂼	efjl	0
 𧃗	efjl	0
 䔩	efjm	3980
-𫊂	efjp	0
 𦿓	efjq	0
 蔌	efjr	168000
 𦳘	efka	0
@@ -27924,7 +26988,6 @@ encoder:
 𧃬	efku	0
 𦳏	eflc	0
 茦	efld	25700
-𫉱	efld	0
 莿	eflk	578000
 萰	eflk	29100
 𠞁	eflk	0
@@ -27940,7 +27003,6 @@ encoder:
 𦲲	efmo	0
 𦵂	efmy	0
 䔦	efmz	3910
-𫊴	efne	0
 藿	efni	2840000
 𧃝	efnj	0
 博白	efnk	652000
@@ -27956,7 +27018,6 @@ encoder:
 𦽨	efoo	0
 𦼊	efor	0
 𦾹	efor	0
-𫊇	efor	0
 某个	efov	50000000
 蕶	efow	273000
 𧀾	efoy	0
@@ -28003,7 +27064,6 @@ encoder:
 𦷢	efwz	0
 𦾄	efwz	0
 𦽯	efxa	0
-𫊈	efxj	0
 𦶠	efxo	0
 𦴡	efxs	0
 𧄁	efxx	0
@@ -28011,17 +27071,14 @@ encoder:
 博导	efyd	1250000
 薽	efys	38200
 蓜	efyy	447000
-𫉛	efyy	0
 𦼋	efzk	0
 葽	efzm	455000
-𫉴	efzo	0
 𦼷	efzq	0
 若干	egae	59800000
 𦰃	egae	0
 䓫	egaj	3710
 𦭃	egaz	0
 𦱼	egaz	0
-𫈤	egaz	0
 𦱯	egba	0
 𦲒	egbb	0
 萘	egbk	2920000
@@ -28032,11 +27089,9 @@ encoder:
 蓐	egds	211000
 𦬠	eged	0
 莾	egee	32800
-𫉜	egeh	0
 𦷔	egel	0
 𣯬	egem	0
 若需	egfg	2350000
-𫉳	egfk	0
 𧂾	egfu	0
 若要	egfv	19700000
 䓴	eggd	3700
@@ -28055,16 +27110,13 @@ encoder:
 𧍷	egji	0
 𦵀	egjk	0
 𧃦	egjn	0
-𪵒	egjr	0
 𤎗	egju	0
 惹	egjw	63300000
 逽	egjw	26700
 鄀	egjy	71600
 𦼔	egkk	0
 若是	egkv	26800000
-𫉚	egky	0
 菴	egkz	1010000
-𫉲	egkz	0
 𦯞	egld	0
 蕤	egmc	937000
 𦷃	egmc	0
@@ -28077,7 +27129,6 @@ encoder:
 䔪	egoo	4180
 莢	egoo	571000
 𦳵	egpd	0
-𫋌	egpk	0
 𦵁	egqy	0
 𦰘	egra	0
 𦱯	egra	0
@@ -28089,7 +27140,6 @@ encoder:
 𧂲	egru	0
 䒎	egry	4080
 𦰮	egry	0
-𫊆	egry	0
 𦿲	egrz	0
 莽	egse	2840000
 葢	egsl	62000
@@ -28112,7 +27162,6 @@ encoder:
 荑	egyz	924000
 𦰅	egzj	0
 𦵘	egzm	0
-𫉵	egzp	0
 若能	egzq	6080000
 蕨	egzr	4100000
 𦲘	egzr	0
@@ -28153,7 +27202,6 @@ encoder:
 菚	ehhm	28500
 茂盛	ehhy	3230000
 𢨎	ehhz	0
-𫉇	ehid	0
 𧅪	ehii	0
 𧓤	ehii	0
 𧕾	ehii	0
@@ -28169,7 +27217,6 @@ encoder:
 𦽫	ehjw	0
 𥅤	ehjx	0
 𨚵	ehjy	0
-𫊉	ehjy	0
 韯	ehka	45400
 𦿱	ehka	0
 𦷁	ehkc	0
@@ -28180,7 +27227,6 @@ encoder:
 𢨆	ehkz	0
 𦭧	ehli	0
 𦶻	ehlk	0
-𫋒	ehll	0
 蒇	ehlo	87100
 蕆	ehlo	39000
 𪈭	ehlr	0
@@ -28207,7 +27253,6 @@ encoder:
 𢧇	ehor	0
 𦴉	ehps	0
 𢦼	ehpv	0
-𪭩	ehpy	0
 藏胞	ehqr	143000
 苉	ehrd	13800
 茂名	ehrj	5600000
@@ -28231,11 +27276,8 @@ encoder:
 茂密	ehww	2960000
 𦸃	ehxb	0
 藖	ehxl	24800
-𫊱	ehxl	0
 菣	ehxs	24200
 藏书	ehxy	7780000
-𫊵	ehxz	0
-𪭢	ehya	0
 苆	ehyd	367000
 藏民	ehyh	775000
 𦼦	ehyl	0
@@ -28259,7 +27301,6 @@ encoder:
 𦴁	eiao	0
 𧃷	eibz	0
 𦺩	eieh	0
-𪡿	eiej	0
 𧃢	eieo	0
 𦸺	eifl	0
 𦿥	eige	0
@@ -28330,7 +27371,6 @@ encoder:
 勤于	ejad	1830000
 𡭆	ejad	0
 𦮣	ejad	0
-𫊘	ejad	0
 茣	ejag	38000
 𦱕	ejaj	0
 𦳬	ejaj	0
@@ -28339,10 +27379,8 @@ encoder:
 蒉	ejal	109000
 蕢	ejal	46300
 𦹛	ejaz	0
-𫈥	ejaz	0
 古城	ejbh	17600000
 菋	ejbk	1430000
-𫈸	ejbn	0
 𦰩	ejbo	0
 古老	ejbr	20400000
 故地	ejbv	1070000
@@ -28383,7 +27421,6 @@ encoder:
 𦳩	ejgq	0
 𦵣	ejgq	0
 𩙤	ejgq	0
-𫋖	ejgy	0
 𢨖	ejhh	0
 克东	ejhk	295000
 𦯁	ejhz	0
@@ -28398,12 +27435,10 @@ encoder:
 𧄤	ejjj	0
 雚	ejjn	53100
 𧁤	ejjo	0
-𫗇	ejjo	0
 薗	ejjr	483000
 𦻸	ejjr	0
 𧅧	ejjr	0
 𦾊	ejjs	0
-𪤷	ejju	0
 𦰉	ejjz	0
 故里	ejkb	4210000
 𦷗	ejkb	0
@@ -28442,7 +27477,6 @@ encoder:
 𥍊	ejnl	0
 𣰻	ejnm	0
 勤俭	ejno	5150000
-𫉷	ejno	0
 飌	ejnq	28600
 歡	ejnr	10300000
 鸛	ejnr	170000
@@ -28484,17 +27518,14 @@ encoder:
 蕗	ejrj	1080000
 辜负	ejrl	7610000
 𦮶	ejro	0
-𫈷	ejro	0
 𦵇	ejrw	0
 勤务	ejry	515000
-𫊤	ejrz	0
 古诗	ejsb	9710000
 故意	ejsk	38800000
 古文	ejso	7760000
 胡说	ejsv	9860000
 克朗	ejsx	1360000
 荶	ejsx	31300
-𪫀	ejtf	0
 胡闹	ejts	2540000
 𧃐	ejul	0
 𦸠	ejuu	0
@@ -28505,7 +27536,6 @@ encoder:
 胡涂	ejvo	958000
 𦬅	ejvv	0
 勤学	ejvw	1590000
-𫉍	ejvy	0
 𣓝	ejwf	0
 故宫	ejwj	5450000
 𧀰	ejwl	0
@@ -28567,7 +27597,6 @@ encoder:
 草地	ekbv	12500000
 草场	ekby	1730000
 𠢽	ekby	0
-𫉢	ekby	0
 䕺	ekcx	3780
 蕞	ekcx	1260000
 募捐	ekdj	2730000
@@ -28584,7 +27613,6 @@ encoder:
 𦹵	ekej	0
 𦹸	ekek	0
 黄南	ekel	604000
-𫋓	ekel	0
 草莓	ekem	20800000
 𢾳	ekem	0
 黄花	eken	9330000
@@ -28595,7 +27623,6 @@ encoder:
 菲薄	ekev	646000
 草药	ekez	6130000
 苗木	ekfa	10500000
-𫊶	ekfc	0
 𨠷	ekfd	0
 菲林	ekff	1650000
 𧅲	ekff	0
@@ -28621,7 +27648,6 @@ encoder:
 蟇	ekgi	137000
 𠻚	ekgj	0
 暮	ekgk	9920000
-𪷦	ekgk	0
 幕	ekgl	46500000
 𦷤	ekgl	0
 摹	ekgm	2380000
@@ -28652,14 +27678,12 @@ encoder:
 𧕐	ekii	0
 𧁎	ekim	0
 𦸿	ekir	0
-𫊢	ekiu	0
 韩国	ekjc	114000000
 苗圃	ekjf	4670000
 𦼕	ekjf	0
 𦼲	ekjk	0
 𦿹	ekjk	0
 𧄳	ekjl	0
-𫊌	ekjl	0
 𦺡	ekjm	0
 𦾛	ekjm	0
 𧀞	ekjo	0
@@ -28680,10 +27704,8 @@ encoder:
 蕌	ekkk	27200
 藟	ekkk	115000
 𣊛	ekkk	0
-𫉭	ekkk	0
 𡿉	ekkl	0
 𡮦	ekkm	0
-𪯬	ekkm	0
 𧅒	ekkp	0
 𨬛	ekkp	0
 䖁	ekkw	3960
@@ -28707,7 +27729,6 @@ encoder:
 乾县	eklz	275000
 曹县	eklz	488000
 萬	eklz	79400000
-𫉠	eklz	0
 黄牛	ekmb	3140000
 蓝筹	ekmc	2760000
 𦿔	ekme	0
@@ -28730,7 +27751,6 @@ encoder:
 黄牌	eknn	3910000
 摹仿	ekns	407000
 𦾠	ekob	0
-𫉡	ekon	0
 草丛	ekoo	6620000
 𦺏	ekoo	0
 茰	ekos	18600
@@ -28742,7 +27762,6 @@ encoder:
 萷	ekqk	36200
 募股	ekqq	648000
 𢡗	ekqw	0
-𫉌	ekrb	0
 苗条	ekrf	4680000
 黄昏	ekrk	28000000
 𣰌	ekrm	0
@@ -28789,7 +27808,6 @@ encoder:
 䒤	ekvv	4260
 𦾥	ekwf	0
 黄连	ekwh	1330000
-𫋗	ekwl	0
 墓穴	ekwo	1630000
 乾安	ekwz	173000
 草案	ekwz	21100000
@@ -28811,7 +27829,6 @@ encoder:
 黄陂	ekyx	1330000
 𦶑	ekyy	0
 𨟔	ekyy	0
-𫋀	ekzc	0
 𧄴	ekzg	0
 蠆	ekzi	53600
 躉	ekzj	342000
@@ -28821,14 +27838,12 @@ encoder:
 𦰇	ekzm	0
 𦽍	ekzn	0
 𧁾	ekzp	0
-𪵵	ekzq	0
 草纸	ekzr	322000
 𦿌	ekzu	0
 萌发	ekzv	4210000
 邁	ekzw	6200000
 𦽳	ekzw	0
 𧄌	ekzw	0
-𫊣	ekzx	0
 勱	ekzy	75000
 𨝥	ekzy	0
 𦰲	elad	0
@@ -28899,8 +27914,6 @@ encoder:
 直到	elhk	82000000
 𥋚	elhl	0
 𧀅	elhm	0
-𫉟	elhm	0
-𫉶	elhm	0
 南欧	elho	758000
 𪈛	elhr	0
 蔑	elhs	1110000
@@ -28953,7 +27966,6 @@ encoder:
 英籍	elmc	264000
 颠簸	elme	2870000
 献策	elmf	6490000
-𫈹	elmf	0
 𦾒	elmh	0
 南和	elmj	883000
 献血	elml	7390000
@@ -29001,7 +28013,6 @@ encoder:
 𧲎	elrg	0
 𩖎	elrg	0
 薥	elri	25000
-𫊷	elri	0
 真象	elrj	2170000
 𦶔	elrj	0
 南乐	elrk	293000
@@ -29028,7 +28039,6 @@ encoder:
 南靖	elsc	736000
 献计	else	2420000
 真诚	elsh	69200000
-𫝷	elsi	0
 南京	elsj	164000000
 南部	elsj	32700000
 藅	elsk	32700
@@ -29096,7 +28106,6 @@ encoder:
 夢	elwr	121000000
 𪅇	elwr	0
 真迹	elws	1250000
-𫊊	elws	0
 真实	elwt	304000000
 南通	elwx	25100000
 直通	elwx	39100000
@@ -29179,7 +28188,6 @@ encoder:
 𦭞	emgx	0
 𦬃	emhd	0
 莪	emhm	2080000
-𫋐	emhs	0
 苲	emid	27600
 𦷙	emij	0
 萭	emil	60900
@@ -29225,7 +28233,6 @@ encoder:
 䔉	emmf	4440
 蔾	emmf	33900
 𦳁	emmh	0
-𫈮	emmi	0
 𧗘	emml	0
 𦺙	emmm	0
 𦱒	emmo	0
@@ -29246,7 +28253,6 @@ encoder:
 𧁩	emnj	0
 䕴	emnu	4430
 𧄄	emnw	0
-𫋁	emnx	0
 𦽂	emob	0
 苵	emod	23400
 𦸸	emof	0
@@ -29267,18 +28273,15 @@ encoder:
 菞	emrm	22400
 𦳫	emro	0
 𦴙	emro	0
-𫉤	emro	0
 䔟	emrr	3840
 莵	emrs	94500
 𦱜	emrs	0
 𦲦	emrs	0
-𫋉	emsb	0
 蘖	emsf	447000
 𩕸	emsg	0
 𦱐	emsh	0
 𧕏	emsi	0
 躠	emsj	27300
-𪻞	emsm	0
 𪈟	emsr	0
 糵	emsu	85200
 𦷏	emsu	0
@@ -29301,8 +28304,6 @@ encoder:
 𦱮	emxb	0
 蒛	emxg	119000
 𦬐	emxs	0
-𫉹	emxx	0
-𫉺	emya	0
 䒗	emyd	3940
 𦰺	emye	0
 𦭥	emyi	0
@@ -29333,7 +28334,6 @@ encoder:
 芢	enbd	620000
 𦱎	enbd	0
 花项	enbg	54900
-𫉣	enbk	0
 𧂤	enbm	0
 𦽐	enbq	0
 𦼍	enbr	0
@@ -29372,7 +28372,6 @@ encoder:
 𦽻	enge	0
 𧁗	enge	0
 截面	engj	2090000
-𫈿	engj	0
 花布	engl	1060000
 茯	engs	702000
 截至	enhb	28000000
@@ -29383,7 +28382,6 @@ encoder:
 䒫	enhs	4000
 𦬙	enid	0
 截止	enii	40300000
-𫉸	enii	0
 𦾔	enik	0
 莜	enim	768000
 藇	enio	28600
@@ -29397,7 +28395,6 @@ encoder:
 茽	enji	121000
 𦵋	enji	0
 𦽌	enjk	0
-𫊎	enjm	0
 𦲺	enjo	0
 截听	enjp	77700
 㗡	enjr	3730
@@ -29430,7 +28427,6 @@ encoder:
 𦭛	enme	0
 鞭策	enmf	2110000
 莋	enmi	295000
-𫊜	enmj	0
 荷重	enmk	1750000
 花簇	enms	128000
 花季	enmy	6740000
@@ -29472,7 +28468,6 @@ encoder:
 蓧	enrf	60700
 截然	enrg	8600000
 𠝐	enrk	0
-𫈯	enro	0
 蓚	enrp	67100
 蓨	enrq	43500
 花	enrr	598000000
@@ -29482,7 +28477,6 @@ encoder:
 𦶰	enrr	0
 𦹿	enrr	0
 𧄷	enrr	0
-𫈾	enrr	0
 截留	enrs	1900000
 菂	enrs	685000
 𦯎	enrs	0
@@ -29507,7 +28501,6 @@ encoder:
 𪈟	ensr	0
 莅	ensu	771000
 𠣅	ensy	0
-𫉐	ensz	0
 𦼄	ente	0
 截瘫	entx	452000
 花灯	enua	1300000
@@ -29533,18 +28526,15 @@ encoder:
 𦭽	enxm	0
 𣤨	enxr	0
 𪇡	enxr	0
-𪵕	enxr	0
 蒦	enxs	57800
 蓃	enxs	21800
 𦲪	enxs	0
 𦹜	enxx	0
 靴子	enya	3520000
 鞭子	enya	1950000
-𫈧	enya	0
 葩	enyi	1190000
 𦭟	enyi	0
 𦯐	enyj	0
-𫈽	enyj	0
 芿	enym	46500
 花费	enyn	42300000
 蘤	enyu	39900
@@ -29553,7 +28543,6 @@ encoder:
 𦺯	enzf	0
 花絮	enzj	16400000
 𦴞	enzm	0
-𫈻	enzo	0
 𦲮	enzr	0
 花纹	enzs	5410000
 截断	enzu	1900000
@@ -29570,8 +28559,6 @@ encoder:
 蓗	eobo	22200
 苍老	eobr	3950000
 蓌	eobr	30200
-𫆩	eobr	0
-𫋊	eobu	0
 莶	eobv	158000
 茶壶	eobw	2040000
 遳	eobw	27100
@@ -29579,7 +28566,6 @@ encoder:
 荟	eobz	11800000
 𦻏	eobz	0
 藢	eocm	26100
-𫉑	eocs	0
 共事	eodj	4020000
 苍南	eoel	2880000
 恭敬	eoer	10100000
@@ -29604,7 +28590,6 @@ encoder:
 茶碗	eogw	2340000
 共感	eoha	8810000
 共轭	eohg	371000
-𫈩	eoia	0
 蓰	eoii	75400
 𦮳	eoii	0
 苍蝇	eoij	12700000
@@ -29665,7 +28650,6 @@ encoder:
 𦶎	eooe	0
 𦹬	eoog	0
 蓯	eooi	98900
-𫈼	eooj	0
 𦮓	eook	0
 𧁴	eook	0
 葅	eool	35600
@@ -29680,7 +28664,6 @@ encoder:
 葼	eoor	23100
 蘝	eoor	26900
 䒝	eoos	3960
-𫈠	eoos	0
 茶馆	eoow	28600000
 共创	eooy	11700000
 𦭏	eopd	0
@@ -29735,7 +28718,6 @@ encoder:
 棻	eoyf	795000
 𦯲	eoyg	0
 恭贺	eoyj	2690000
-𫊏	eoyj	0
 葐	eoyl	39900
 𧆀	eoyn	0
 𧂆	eoys	0
@@ -29748,7 +28730,6 @@ encoder:
 𧀈	eozk	0
 𧅔	eozl	0
 𧃸	eozm	0
-𫊥	eozm	0
 恭维	eozn	4220000
 𦹟	eozq	0
 𦮀	eozr	0
@@ -29764,7 +28745,6 @@ encoder:
 芹菜	epep	7580000
 菜蔬	epex	672000
 䔄	epez	5250
-𫋔	epfd	0
 𦹮	epfp	0
 𧂵	epge	0
 𧄭	epgl	0
@@ -29773,7 +28753,6 @@ encoder:
 𧂀	epgo	0
 𧀔	epgp	0
 萲	epgx	55400
-𫉻	epgx	0
 𧂂	ephh	0
 菜园	epjb	4580000
 𧀷	epjd	0
@@ -29798,7 +28777,6 @@ encoder:
 𦼎	eppy	0
 蒰	epqx	21800
 𦽮	epqz	0
-𫊙	eprb	0
 𦽋	eprj	0
 蕣	eprm	116000
 𦲽	epro	0
@@ -29877,9 +28855,7 @@ encoder:
 散射	eqnd	1560000
 散件	eqnm	1980000
 期货	eqnr	34400000
-𫊧	eqnx	0
 期待	eqob	149000000
-𫊛	eqoe	0
 获得	eqok	209000000
 𧀬	eqok	0
 𦷈	eqoo	0
@@ -29896,7 +28872,6 @@ encoder:
 获胜	eqqm	7870000
 𧁿	eqri	0
 葋	eqrj	23500
-𫋑	eqrn	0
 𦼳	eqro	0
 𦱔	eqrr	0
 𦺎	eqsj	0
@@ -29921,7 +28896,6 @@ encoder:
 散漫	eqvk	2600000
 期房	eqws	5090000
 𧂿	eqww	0
-𫊐	eqwy	0
 𦽇	eqxb	0
 𦘃	eqxc	0
 莥	eqxe	28500
@@ -29939,7 +28913,6 @@ encoder:
 散发	eqzv	22100000
 𪃖	erar	0
 茚	eray	295000
-𫋍	erbb	0
 蘏	erbg	23300
 𢨝	erbh	0
 𦮧	erbi	0
@@ -29958,7 +28931,6 @@ encoder:
 葡萄	erer	22100000
 萄	erez	1320000
 𦮍	erez	0
-𫅱	erez	0
 葡	erfb	6030000
 𢣋	erfw	0
 欺压	ergb	1280000
@@ -30032,7 +29004,6 @@ encoder:
 𦲇	eroe	0
 茐	eros	30500
 薝	eros	48000
-𫈡	eros	0
 䓤	erow	5260
 蕵	erox	27300
 𦭪	eroz	0
@@ -30089,7 +29060,6 @@ encoder:
 苟安	erwz	86500
 𦮤	erwz	0
 𦱩	erxa	0
-𫈪	erxb	0
 𦿙	erxg	0
 薿	erxi	44800
 蔸	erxr	632000
@@ -30098,7 +29068,6 @@ encoder:
 𦳌	erxw	0
 𦺄	erxy	0
 警卫	erya	6620000
-𫋃	eryb	0
 警民	eryh	1410000
 蒥	eryk	56700
 𦺲	eryl	0
@@ -30118,7 +29087,6 @@ encoder:
 𧅱	esbk	0
 𧆐	esbl	0
 藷	esbm	389000
-𫉾	esbm	0
 𦽡	esbr	0
 𧂕	esbr	0
 荒地	esbv	2310000
@@ -30144,7 +29112,6 @@ encoder:
 𦸰	esgm	0
 荒原	esgn	2840000
 𩓜	esgo	0
-𫉫	esgp	0
 藙	esgq	35000
 𧄘	esgq	0
 蘐	esgx	29000
@@ -30165,7 +29132,6 @@ encoder:
 蔉	esjr	50700
 𦯇	esjr	0
 𦳆	esjr	0
-𫉨	esjr	0
 蔀	esjy	457000
 䕊	eska	4110
 虀	eska	66300
@@ -30173,7 +29139,6 @@ encoder:
 𧆂	eska	0
 𧆌	eska	0
 蕫	eskb	70100
-𫊺	eskb	0
 蔁	eske	26100
 𦿤	eske	0
 芒果	eskf	5870000
@@ -30185,7 +29150,6 @@ encoder:
 蓑	eskr	1770000
 蔼	eskr	1500000
 藹	eskr	438000
-𫊩	eskr	0
 蓄水	eskv	1890000
 薪水	eskv	13200000
 薏	eskw	3750000
@@ -30208,10 +29172,8 @@ encoder:
 䔓	esme	3970
 蓄积	esmj	2550000
 芳香	esmk	13100000
-𫉥	esmk	0
 裁制	esml	251000
 蔟	esmm	321000
-𫉒	esmo	0
 𦹭	esmp	0
 𧆍	esms	0
 葹	esmy	71300
@@ -30277,7 +29239,6 @@ encoder:
 裁军	eswh	554000
 蒂	eswl	44700000
 𦹾	eswm	0
-𫊔	eswm	0
 蒡	esws	490000
 莣	eswz	827000
 蔙	esxi	62600
@@ -30326,7 +29287,6 @@ encoder:
 蘑菇	etez	7660000
 𧂷	etfb	0
 蔴	etff	208000
-𫊨	etff	0
 蘑	etfg	1340000
 蘼	etfk	2090000
 藦	etfm	149000
@@ -30336,7 +29296,6 @@ encoder:
 𦶉	etir	0
 䕲	etjb	3890
 𦾰	etjm	0
-𫊹	etjy	0
 𦳅	etko	0
 蓭	etkz	27600
 燕山	etll	6780000
@@ -30357,7 +29316,6 @@ encoder:
 薋	etrl	50700
 茨	etro	24100000
 苝	etrr	326000
-𫉂	etrr	0
 菧	etrs	78700
 𦿵	etrs	0
 𦿬	etrz	0
@@ -30374,17 +29332,14 @@ encoder:
 燕窝	etwj	1770000
 𦯅	etxi	0
 蓎	etxj	52000
-𫊒	etxl	0
 菮	etxo	24500
 燕子	etya	9640000
 䕠	etyq	4070
 薦	etzu	3100000
 蔊	euae	38200
 𧁙	euax	0
-𫊬	euax	0
 蒫	eubi	31500
 𦵕	eubr	0
-𫊚	euce	0
 𧀘	eucl	0
 蕲春	euco	457000
 𦾿	eucq	0
@@ -30402,7 +29357,6 @@ encoder:
 蕿	eugx	21400
 𧀿	eugy	0
 啬	eujj	742000
-𫋅	eujq	0
 莌	eujr	25100
 𦻐	euke	0
 𦽗	eukm	0
@@ -30432,16 +29386,13 @@ encoder:
 𧀜	eupn	0
 葥	euqk	55700
 𧆇	euri	0
-𫊦	eurl	0
 𦺸	eurm	0
 𧃮	eurm	0
 𦿯	euro	0
 䓎	eurs	4170
-𫉩	eurs	0
 蘱	eusg	41700
 𦮝	eush	0
 𧁙	eusx	0
-𫊬	eusx	0
 𧅃	eutu	0
 𦵹	euuk	0
 菼	euuo	50900
@@ -30459,7 +29410,6 @@ encoder:
 𦽓	euye	0
 𦽽	euyg	0
 𧅛	euyn	0
-𫈢	euys	0
 蒍	euyu	265000
 菤	euyy	39000
 𦯔	euyz	0
@@ -30476,7 +29426,6 @@ encoder:
 菏	evaj	1330000
 𦶒	evaj	0
 𦺘	evaj	0
-𫉪	evaj	0
 𦽘	eval	0
 萍	evau	24200000
 𧁛	evau	0
@@ -30489,7 +29438,6 @@ encoder:
 𦼥	evbm	0
 蒲圻	evbp	134000
 𦻄	evbp	0
-𫋎	evbr	0
 䕪	evbu	3780
 落地	evbv	15300000
 薄壳	evbw	229000
@@ -30498,7 +29446,6 @@ encoder:
 𦴵	evcz	0
 𦺇	evcz	0
 𧁕	evee	0
-𫊫	evee	0
 落幕	evek	7710000
 菠萝	evel	13600000
 薄荷	even	8390000
@@ -30514,14 +29461,12 @@ encoder:
 𧄩	evfe	0
 𦽼	evff	0
 𦵜	evfj	0
-𫋕	evfj	0
 𧁔	evfl	0
 薄板	evfp	4040000
 𦾶	evfp	0
 薄雾	evfr	1570000
 落榜	evfs	1980000
 𦱈	evfs	0
-𫊑	evfv	0
 𦻈	evfx	0
 𦴮	evge	0
 𦹈	evge	0
@@ -30539,7 +29484,6 @@ encoder:
 蕖	evhh	221000
 落成	evhv	5180000
 菃	evhx	34500
-𫋄	evii	0
 𦶵	evik	0
 𦶼	evik	0
 𦴢	evir	0
@@ -30551,7 +29495,6 @@ encoder:
 𦶶	evji	0
 薃	evjl	30200
 𦰪	evjo	0
-𫊝	evjq	0
 𧀌	evjr	0
 萍踪	evjw	932000
 虃	evka	27100
@@ -30562,7 +29505,6 @@ encoder:
 藫	evke	24200
 𦴝	evke	0
 薻	evkf	27400
-𫉔	evki	0
 𧀪	evkk	0
 蕰	evkl	75000
 莎	evkm	40800000
@@ -30594,7 +29536,6 @@ encoder:
 𧄻	evmi	0
 𦶡	evmj	0
 薄利	evmk	2250000
-𫉽	evmk	0
 蘫	evml	87800
 𧗎	evml	0
 落笔	evmm	1350000
@@ -30607,7 +29548,6 @@ encoder:
 𦭴	evnd	0
 薬	evnf	25000000
 𧃡	evnf	0
-𫋆	evnf	0
 世代	evnh	38300000
 𦹏	evni	0
 萡	evnk	36100
@@ -30616,7 +29556,6 @@ encoder:
 蒞	evns	424000
 𧀡	evnu	0
 薄片	evnx	2020000
-𫊪	evnx	0
 世人	evod	17400000
 落入	evod	8300000
 𦸂	evof	0
@@ -30642,7 +29581,6 @@ encoder:
 𦷰	evpy	0
 𦷪	evpz	0
 落脚	evqb	4140000
-𫈲	evqd	0
 薄膜	evqe	16900000
 蒅	evqf	50000
 蕍	evqk	28800
@@ -30661,7 +29599,6 @@ encoder:
 世贸	evrs	8420000
 𦮛	evrs	0
 𧂙	evru	0
-𫊓	evru	0
 𦿞	evrw	0
 萢	evry	266000
 茫	evsh	3140000
@@ -30672,10 +29609,8 @@ encoder:
 𦯻	evso	0
 𦲷	evsu	0
 蒗	evsx	648000
-𫉁	evsy	0
 薄冰	evtk	1590000
 薄情	evuc	878000
-𫉧	evuc	0
 蓱	evue	432000
 𦲍	evuo	0
 𦸁	evuu	0
@@ -30697,7 +29632,6 @@ encoder:
 𦴴	evwz	0
 葏	evxb	19500
 蕖	evxf	221000
-𫊼	evxf	0
 菠	evxi	1770000
 落难	evxn	1200000
 𦯊	evxo	0
@@ -30706,10 +29640,8 @@ encoder:
 蔢	evxz	41100
 𦻭	evxz	0
 𡎊	evyb	0
-𫉬	evyb	0
 𦴮	evye	0
 𧍙	evyi	0
-𫈱	evyi	0
 菬	evyj	33100
 𦽾	evyk	0
 荡	evyo	29700000
@@ -30725,7 +29657,6 @@ encoder:
 世纪	evzy	166000000
 萍乡	evzz	7610000
 𦯫	evzz	0
-𫉖	evzz	0
 荢	ewad	48400
 𦭨	ewad	0
 𦯼	ewae	0
@@ -30742,7 +29673,6 @@ encoder:
 带来	ewbk	134000000
 萗	ewbk	29300
 萱	ewbk	12100000
-𫉃	ewbo	0
 䓕	ewbr	3660
 莞	ewbr	2720000
 荣幸	ewbu	6750000
@@ -30832,11 +29762,9 @@ encoder:
 蔰	ewjy	26600
 𧅉	ewjy	0
 蒙昧	ewkb	617000
-𫉼	ewkf	0
 荣耀	ewkg	20800000
 荧光	ewkg	6790000
 𦶺	ewkg	0
-𫉓	ewki	0
 荣昌	ewkk	2170000
 藔	ewkk	25000
 𧂏	ewkk	0
@@ -30849,10 +29777,8 @@ encoder:
 带电	ewkz	1520000
 𦶳	ewkz	0
 𧂜	ewkz	0
-𫉦	ewkz	0
 薴	ewla	42900
 𦾼	ewlb	0
-𫊞	ewlb	0
 䔃	ewlc	5060
 萓	ewlc	134000
 萹	ewld	68900
@@ -30898,7 +29824,6 @@ encoder:
 芯片	ewnx	36500000
 藭	ewny	41100
 𦹇	ewob	0
-𫊭	ewob	0
 带入	ewod	4220000
 蓉	ewoj	17300000
 𧃕	ewoj	0
@@ -30924,9 +29849,7 @@ encoder:
 𦬮	ewrd	0
 𦵤	ewrd	0
 勃然	ewrg	2480000
-𫈳	ewrh	0
 𦴦	ewrj	0
-𫊻	ewrl	0
 蔲	ewrm	41900
 𦲋	ewrm	0
 𧁽	ewrm	0
@@ -30986,7 +29909,6 @@ encoder:
 蕊	ewww	7750000
 蓬安	ewwz	146000
 𧄜	ewwz	0
-𫉕	ewwz	0
 鞍马	ewxa	357000
 带劲	ewxb	693000
 蓪	ewxl	59800
@@ -31010,7 +29932,6 @@ encoder:
 𦽜	ewyn	0
 带队	ewyo	3460000
 𦴎	ewyq	0
-𫊸	ewyq	0
 营建	ewyx	1240000
 𦶋	ewyy	0
 𦲄	ewyz	0
@@ -31025,8 +29946,6 @@ encoder:
 𦹎	ewzw	0
 荥经	ewzx	174000
 𦼠	exae	0
-𫉮	exae	0
-𫊋	exae	0
 葵	exag	19200000
 𦽅	exaj	0
 𦲙	exak	0
@@ -31040,7 +29959,6 @@ encoder:
 𦼘	exbu	0
 𦵥	exbx	0
 卖场	exby	21100000
-𫉅	exby	0
 萧瑟	excc	1850000
 𦻛	excu	0
 支持	exdb	656000000
@@ -31084,7 +30002,6 @@ encoder:
 蕁	exjd	1190000
 𧃭	exjf	0
 𧄋	exjf	0
-𫊯	exji	0
 䕡	exjj	3890
 卖唱	exjk	465000
 葦	exjm	1990000
@@ -31111,7 +30028,6 @@ encoder:
 菡	exkz	1450000
 𧀓	exkz	0
 𦱲	exlb	0
-𫉆	exld	0
 𦹧	exlk	0
 萧山	exll	6380000
 蓪	exlw	59800
@@ -31256,7 +30172,6 @@ encoder:
 𦳉	eygq	0
 苠	eyhd	102000
 𦳜	eyhk	0
-𫉗	eyhk	0
 𩀔	eyhn	0
 苏区	eyho	507000
 𪃔	eyhr	0
@@ -31268,7 +30183,6 @@ encoder:
 节点	eyij	13000000
 𦬌	eyim	0
 𧁅	eyip	0
-𫉘	eyjb	0
 𦴰	eyje	0
 蔃	eyji	55200
 艺员	eyjl	631000
@@ -31306,7 +30220,6 @@ encoder:
 𧃯	eymy	0
 蓀	eymz	318000
 𦶽	eymz	0
-𫊕	eymz	0
 茀	eynd	104000
 𦱖	eynd	0
 𦹽	eyne	0
@@ -31334,7 +30247,6 @@ encoder:
 苏丹	eyqs	3430000
 𦸐	eyrb	0
 𦰴	eyrk	0
-𫊟	eyro	0
 𦶬	eyrr	0
 𦵮	eyse	0
 䔼	eysi	4060
@@ -31386,7 +30298,6 @@ encoder:
 协力	eyym	5550000
 藋	eyyn	37800
 𦸚	eyyn	0
-𫊀	eyyq	0
 蒻	eyyt	206000
 𦭳	eyyt	0
 茘	eyyy	70300
@@ -31413,7 +30324,6 @@ encoder:
 葒	ezbi	925000
 𦮨	ezbi	0
 𦺢	ezbj	0
-𫊾	ezbj	0
 𦳀	ezbk	0
 𦿎	ezbm	0
 䔴	ezbx	4600
@@ -31429,7 +30339,6 @@ encoder:
 蕴藏	ezeh	5980000
 菇	ezej	7720000
 药材	ezfd	10600000
-𫗺	ezfg	0
 勘查	ezfk	3500000
 斟酌	ezfr	3410000
 𦲞	ezgc	0
@@ -31463,7 +30372,6 @@ encoder:
 𧀒	ezjm	0
 𦱫	ezjq	0
 𦲭	ezjq	0
-𫉿	ezjw	0
 𦸖	ezjx	0
 蕠	ezjz	39700
 𧃒	ezjz	0
@@ -31486,7 +30394,6 @@ encoder:
 蒳	ezlo	73700
 𦭯	ezlo	0
 𦴁	ezlo	0
-𫊖	ezlo	0
 药用	ezlv	5460000
 蘰	ezlx	206000
 𦷵	ezly	0
@@ -31525,7 +30432,6 @@ encoder:
 𧁯	ezqi	0
 药膳	ezqu	2590000
 𦯏	ezqy	0
-𫊮	ezqy	0
 蘕	ezrc	21200
 蔣	ezrd	6440000
 𦱭	ezre	0
@@ -31542,13 +30448,11 @@ encoder:
 葯	ezrs	1050000
 𦳹	ezrs	0
 蔠	ezrt	387000
-𫉄	ezrt	0
 𧀛	ezru	0
 𧄉	ezrw	0
 蕝	ezry	182000
 𦰾	ezry	0
 𦹅	ezry	0
-𫉯	ezry	0
 𧂩	ezsi	0
 勘误	ezsj	893000
 𦽠	ezsm	0
@@ -31582,9 +30486,7 @@ encoder:
 𦵚	ezxw	0
 薌	ezxy	90600
 䒵	ezya	3980
-𫊁	ezyi	0
 𦹄	ezyj	0
-𫈫	ezym	0
 药费	ezyn	984000
 𤮀	ezys	0
 𧀼	ezys	0
@@ -31600,7 +30502,6 @@ encoder:
 𦭺	ezzi	0
 𦰯	ezzj	0
 𦾯	ezzk	0
-𫊿	ezzk	0
 𦮙	ezzl	0
 芗	ezzm	803000
 𦭺	ezzm	0
@@ -31653,7 +30554,6 @@ encoder:
 木匠	fahp	1770000
 桺	fahx	110000
 𣝄	faia	0
-𪲏	faid	0
 柾	faii	251000
 𣖀	faix	0
 𣒘	faiy	0
@@ -31666,7 +30566,6 @@ encoder:
 𣐸	fajo	0
 𣘅	fajr	0
 梪	faju	66800
-𪲳	faju	0
 本题	faka	2470000
 𣜂	faka	0
 𣕭	fakb	0
@@ -31679,10 +30578,8 @@ encoder:
 桠	faku	388000
 本周	falb	64300000
 𣑛	falb	0
-𪳓	falf	0
 木炭	falg	5040000
 杮	fali	128000
-𪲴	fall	0
 𣐈	falm	0
 柄	falo	42200000
 欐	falt	1210000
@@ -31712,7 +30609,6 @@ encoder:
 栵	fark	407000
 𣚐	faru	0
 本色	fary	13400000
-𪲰	fary	0
 本部	fasj	19200000
 本市	fasl	15500000
 本文	faso	390000000
@@ -31741,7 +30637,6 @@ encoder:
 𣓉	faxi	0
 本届	faxk	8550000
 橊	faxk	66100
-𪳫	faxw	0
 棲	faxz	2520000
 本子	faya	7680000
 杆子	faya	891000
@@ -31794,7 +30689,6 @@ encoder:
 𣝔	fbgf	0
 票面	fbgj	1450000
 𩒺	fbgo	0
-𫏄	fbgq	0
 𤞷	fbgs	0
 票友	fbgx	944000
 桂东	fbhk	486000
@@ -31814,7 +30708,6 @@ encoder:
 杜鹃	fbjq	3830000
 喸	fbjr	20200
 榬	fbjr	24600
-𪴐	fbju	0
 甄别	fbjy	3430000
 标量	fbka	264000
 标题	fbka	654000000
@@ -31829,7 +30722,6 @@ encoder:
 盙	fblk	21100
 櫝	fbll	63500
 槓	fblo	1980000
-𪳬	fbly	0
 票箱	fbmf	217000
 㲡	fbmh	4680
 标签	fbmo	133000000
@@ -31843,7 +30735,6 @@ encoder:
 甫自	fbnl	86500
 标价	fbno	5970000
 票价	fbno	8200000
-𪲲	fbno	0
 𣔭	fbob	0
 枎	fbod	434000
 𣗂	fbof	0
@@ -31871,11 +30762,9 @@ encoder:
 标语	fbsb	5610000
 标识	fbsj	27500000
 敷	fbsm	21500000
-𪵲	fbsq	0
 旉	fbsy	47200
 标记	fbsy	79400000
 标准	fbtn	328000000
-𪲿	fbub	0
 樹	fbud	51000000
 橲	fbuj	45200
 𣙀	fbuq	0
@@ -31904,7 +30793,6 @@ encoder:
 梧	fbxj	4840000
 隸	fbxk	942000
 𣟌	fbxk	0
-𪴽	fbxk	0
 𣛒	fbxl	0
 𥊨	fbxl	0
 标尺	fbxs	1350000
@@ -31917,10 +30805,7 @@ encoder:
 标引	fbyi	243000
 㯧	fbyj	3880
 桂阳	fbyk	768000
-𪳿	fbym	0
 𦑵	fbyy	0
-𪳂	fbyy	0
-𪳖	fbzj	0
 榼	fbzl	81800
 枑	fbzm	655000
 杜绝	fbzr	12800000
@@ -31966,7 +30851,6 @@ encoder:
 𣜚	fcwz	0
 棷	fcxs	99000
 櫘	fcxw	216000
-𪳭	fcxx	0
 棒子	fcya	2090000
 椰子	fcya	5680000
 楔	fcyg	2050000
@@ -31994,7 +30878,6 @@ encoder:
 䣪	fdal	3420
 𨡺	fdal	0
 𨣈	fdal	0
-𫒸	fdal	0
 𨢲	fdan	0
 𨣡	fdan	0
 𨠟	fdau	0
@@ -32017,7 +30900,6 @@ encoder:
 𨠻	fdbr	0
 醳	fdbu	36300
 醺	fdbu	884000
-𫒵	fdbv	0
 酵	fdby	2440000
 酝	fdbz	660000
 𨠂	fdbz	0
@@ -32052,13 +30934,11 @@ encoder:
 醥	fdfb	27700
 𨣤	fdfb	0
 𨣽	fdfb	0
-𫒺	fdfd	0
 醂	fdff	54900
 醹	fdfg	21200
 𨣆	fdfg	0
 𨠴	fdfj	0
 𨡋	fdfj	0
-𫒻	fdfj	0
 釄	fdfk	21800
 𨣴	fdfm	0
 𨣙	fdfr	0
@@ -32106,17 +30986,13 @@ encoder:
 𨢺	fdiq	0
 𨠐	fdir	0
 𨠃	fdix	0
-𫒲	fdiy	0
-𫒼	fdjb	0
 酲	fdjc	188000
 醻	fdjd	26000
-𫒳	fdjd	0
 𨣛	fdje	0
 醧	fdjj	29800
 醽	fdjj	41600
 𨡞	fdjj	0
 𨤀	fdjj	0
-𫒹	fdjj	0
 䣼	fdjk	3530
 䤄	fdjk	5090
 醕	fdjk	49800
@@ -32133,7 +31009,6 @@ encoder:
 醴	fdju	1110000
 𤐿	fdju	0
 𨢉	fdju	0
-𫒴	fdju	0
 𨣝	fdjw	0
 𣓊	fdjx	0
 醇	fdjy	21900000
@@ -32216,7 +31091,6 @@ encoder:
 醯	fdnl	1110000
 𨣓	fdnl	0
 醮	fdnu	1360000
-𫒽	fdnu	0
 醙	fdnx	49500
 酫	fdoc	33800
 醛	fdoc	9780000
@@ -32240,7 +31114,6 @@ encoder:
 𨠦	fdoo	0
 𨠿	fdoo	0
 𨤍	fdoo	0
-𫒷	fdoo	0
 醦	fdop	30600
 醪	fdop	1120000
 酸	fdor	89500000
@@ -32266,9 +31139,7 @@ encoder:
 酔	fdqe	4210000
 䤅	fdqk	4200
 𥂹	fdql	0
-𫒱	fdqs	0
 酘	fdqx	101000
-𫒱	fdqy	0
 𨡦	fdqz	0
 𨠏	fdra	0
 𨟴	fdrb	0
@@ -32319,7 +31190,6 @@ encoder:
 𨣭	fdsw	0
 酿	fdsx	13500000
 𨟹	fdsx	0
-𫒶	fdsx	0
 村庄	fdtb	9050000
 酙	fdte	29300
 𨣫	fdte	0
@@ -32461,7 +31331,6 @@ encoder:
 醋栗	feff	261000
 𣟒	feff	0
 𣞦	fefk	0
-𪴠	fefk	0
 欗	fefl	45500
 植株	fefm	2470000
 模板	fefp	35900000
@@ -32499,10 +31368,8 @@ encoder:
 楜	fejq	67900
 𣒖	fejr	0
 橭	fejs	25200
-𪴬	feju	0
 㰇	feka	4280
 㯵	fekb	4020
-𪴒	fekf	0
 模	fekg	91300000
 槽	fekk	26300000
 𣞦	fekk	0
@@ -32691,7 +31558,6 @@ encoder:
 𠢵	ffby	0
 樗	ffbz	268000
 橒	ffbz	42500
-𪳁	ffbz	0
 𩤆	ffcu	0
 樷	ffcx	240000
 禁毒	ffcz	2170000
@@ -32708,17 +31574,14 @@ encoder:
 𣛧	ffff	0
 𣡕	ffff	0
 𣡽	ffff	0
-𪴸	ffff	0
 𣙑	fffg	0
 𩕌	fffg	0
 𠾤	fffj	0
 𣝬	fffj	0
 梦想	fffl	135000000
-𪴾	fffl	0
 𣚵	fffu	0
 栖霞	fffx	2390000
 𡘽	ffgd	0
-𪴟	ffgf	0
 梦魇	ffgg	2820000
 辳	ffgh	26100
 檽	ffgl	169000
@@ -32745,10 +31608,8 @@ encoder:
 𣠄	ffjj	0
 楋	ffjk	475000
 𣠌	ffjl	0
-𫝺	ffjl	0
 𣙙	ffjm	0
 樕	ffjr	39000
-𪴀	ffjr	0
 𧯴	ffju	0
 𧰔	ffju	0
 楂	ffka	1730000
@@ -32772,7 +31633,6 @@ encoder:
 彬县	fflz	241000
 林县	fflz	729000
 郴县	fflz	37700
-𪶀	ffmh	0
 𢽳	ffmo	0
 𣛲	ffmu	0
 栖身	ffnc	1370000
@@ -32794,7 +31654,6 @@ encoder:
 棼	ffoy	154000
 彬	ffpd	15100000
 禁锢	ffpj	2370000
-𪬶	ffpw	0
 梵	ffqd	9760000
 𣑽	ffqd	0
 檒	ffqi	97300
@@ -32813,7 +31672,6 @@ encoder:
 梦	ffrs	222000000
 𣚐	ffru	0
 栗色	ffry	1190000
-𪵁	ffry	0
 𣘲	ffse	0
 𣞒	ffsm	0
 𧛀	ffsr	0
@@ -32833,7 +31691,6 @@ encoder:
 焚	ffuo	9830000
 𣗇	ffuo	0
 𤍕	ffuo	0
-𪳾	ffuo	0
 𣞖	ffuu	0
 林海	ffvm	2960000
 郴州	ffvn	5650000
@@ -32843,7 +31700,6 @@ encoder:
 𣏟	ffvv	0
 禁演	ffvw	165000
 禁运	ffwb	847000
-𪴑	ffwb	0
 㰈	ffwf	4400
 禁军	ffwh	508000
 𣕾	ffwm	0
@@ -32852,7 +31708,6 @@ encoder:
 梦寐	ffwz	408000
 橞	ffwz	36400
 𢛓	ffwz	0
-𪳩	ffwz	0
 㯬	ffxb	4350
 樰	ffxb	140000
 𣝪	ffxd	0
@@ -32877,15 +31732,12 @@ encoder:
 婪	ffzm	478000
 楆	ffzm	74400
 梦幻	ffzz	46800000
-𪳕	ffzz	0
 𣔏	fgae	0
 𣖍	fgai	0
 椅	fgaj	61000000
-𪴳	fgan	0
 楏	fgbb	38700
 𣔦	fgbb	0
 柘城	fgbh	504000
-𪲙	fgbi	0
 㮈	fgbk	4470
 楕	fgbq	369000
 桍	fgbz	44100
@@ -32903,12 +31755,10 @@ encoder:
 𣑊	fgib	0
 𣒽	fgir	0
 栫	fgiy	1120000
-𪳔	fgjf	0
 檶	fgjj	49500
 㮌	fgjk	4160
 槗	fgjl	279000
 𣖻	fgjl	0
-𪳒	fgjy	0
 𣕨	fgki	0
 橑	fgkk	30400
 𣞀	fgkl	0
@@ -32929,9 +31779,7 @@ encoder:
 樉	fgoo	102000
 𣔸	fgoo	0
 杯盘	fgpl	412000
-𪳪	fgqf	0
 㮋	fgqy	3990
-𪲥	fgrb	0
 㮷	fgrk	3840
 震颤	fgsj	1630000
 𣖁	fgsl	0
@@ -32939,7 +31787,6 @@ encoder:
 𣖂	fguc	0
 橱	fgud	5740000
 櫉	fgud	56100
-𪲣	fguo	0
 震惊	fgus	18400000
 𣓣	fguz	0
 柘	fgvv	2050000
@@ -32964,7 +31811,6 @@ encoder:
 栻	fhbi	118000
 桱	fhbi	50600
 樲	fhbl	50300
-𪲢	fhcd	0
 㰉	fhcm	5290
 𣝽	fhcm	0
 框框	fhfh	2100000
@@ -32993,7 +31839,6 @@ encoder:
 椻	fhkz	511000
 𣕩	fhkz	0
 𣐝	fhli	0
-𪵄	fhli	0
 欖	fhll	1370000
 𣖿	fhlo	0
 桟	fhma	495000
@@ -33051,7 +31896,6 @@ encoder:
 樝	filc	29300
 𣙏	filf	0
 𣝱	filh	0
-𪴄	filj	0
 𣟷	film	0
 桢	filo	1720000
 楨	filo	1300000
@@ -33067,7 +31911,6 @@ encoder:
 𣚀	firl	0
 𣚁	firl	0
 𣜁	firn	0
-𪴁	firn	0
 𣐑	firr	0
 橴	firz	176000
 榩	fiso	22800
@@ -33121,7 +31964,6 @@ encoder:
 䚈	fjbl	3870
 西贡	fjbl	639000
 𧢄	fjbl	0
-𫍧	fjbl	0
 𢿖	fjbm	0
 彯	fjbp	61800
 瓢	fjbp	7380000
@@ -33160,11 +32002,9 @@ encoder:
 𩙀	fjeq	0
 西苑	fjer	1870000
 鷣	fjer	24500
-𫝉	fjer	0
 𤍰	fjeu	0
 㩽	fjex	4130
 𨝸	fjey	0
-𫒪	fjey	0
 西药	fjez	11900000
 𧟾	fjez	0
 檲	fjfd	50400
@@ -33176,7 +32016,6 @@ encoder:
 𧢀	fjfl	0
 整机	fjfq	28700000
 鷅	fjfr	30400
-𫝃	fjfr	0
 𢣬	fjfw	0
 𨜼	fjfy	0
 整套	fjgc	9040000
@@ -33198,7 +32037,6 @@ encoder:
 𢎋	fjhs	0
 𣙬	fjhx	0
 整顿	fjhz	18000000
-𫃺	fjhz	0
 整点	fjij	1040000
 西餐	fjir	7300000
 槵	fjiw	79900
@@ -33211,16 +32049,13 @@ encoder:
 橾	fjjf	144000
 𥽹	fjjf	0
 梙	fjji	20800
-𪴓	fjji	0
 楍	fjjj	62600
 榀	fjjj	275000
 𣖎	fjjj	0
-𪴭	fjjj	0
 𠠅	fjjk	0
 西路	fjjr	22800000
 𠒹	fjjr	0
 𧠃	fjjr	0
-𪳯	fjjs	0
 𢣱	fjjw	0
 𧠅	fjjy	0
 整日	fjka	3680000
@@ -33259,10 +32094,8 @@ encoder:
 𪆲	fjlr	0
 𪈎	fjlr	0
 𪈐	fjlr	0
-𫍙	fjlr	0
 露骨	fjlw	3100000
 𢤿	fjlw	0
-𪭆	fjlw	0
 𨞝	fjly	0
 酃县	fjlz	38500
 𡏴	fjmb	0
@@ -33272,7 +32105,6 @@ encoder:
 𧟨	fjme	0
 䅇	fjmf	5390
 棞	fjmf	95700
-𫍕	fjmf	0
 𣑟	fjmg	0
 𣭵	fjmh	0
 䊲	fjmm	4760
@@ -33304,7 +32136,6 @@ encoder:
 𣐳	fjos	0
 整个	fjov	135000000
 𧟺	fjow	0
-𪳅	fjow	0
 𧟬	fjpd	0
 西岳	fjpl	423000
 𥢝	fjpr	0
@@ -33317,7 +32148,6 @@ encoder:
 𪇃	fjqr	0
 西服	fjqy	6280000
 𠣩	fjra	0
-𫍖	fjrc	0
 柷	fjrd	158000
 𣡫	fjrd	0
 㯝	fjrj	4270
@@ -33352,19 +32182,16 @@ encoder:
 㔄	fjuk	5480
 𣯼	fjum	0
 䙳	fjuo	4090
-𪲷	fjuo	0
 𤑶	fjuu	0
 𣙢	fjuy	0
 整数	fjuz	6530000
 整洁	fjvb	7930000
 西江	fjvb	2610000
 西湖	fjve	31800000
-𪴣	fjvr	0
 整流	fjvs	1830000
 西洋	fjvu	26300000
 杏	fjvv	27600000
 束	fjvv	22900000
-𪲑	fjvv	0
 西汉	fjvx	2760000
 整治	fjvz	38600000
 西宁	fjwa	9260000
@@ -33382,7 +32209,6 @@ encoder:
 𣗧	fjxl	0
 𠭄	fjxs	0
 𣐏	fjxs	0
-𪠪	fjxs	0
 𡥟	fjya	0
 𣒪	fjya	0
 枴	fjyd	82600
@@ -33399,7 +32225,6 @@ encoder:
 㼼	fjys	6310
 甄	fjys	9470000
 𤭾	fjys	0
-𪬟	fjyw	0
 𧟱	fjyx	0
 𧟵	fjyx	0
 翲	fjyy	69700
@@ -33479,8 +32304,6 @@ encoder:
 転	fkbz	6350000
 𨋆	fkbz	0
 𨍘	fkbz	0
-𪴺	fkbz	0
-𫐭	fkbz	0
 𨏴	fkcc	0
 𨌀	fkce	0
 𨎵	fkch	0
@@ -33512,7 +32335,6 @@ encoder:
 𨍷	fkec	0
 𣑬	fked	0
 𨍝	fkee	0
-𫐺	fkef	0
 輾	fkeh	796000
 軲	fkej	21700
 輴	fkel	37500
@@ -33552,7 +32374,6 @@ encoder:
 𨌿	fkfk	0
 𨎿	fkfk	0
 𨐄	fkfk	0
-𫐾	fkfk	0
 𨋵	fkfl	0
 𨏭	fkfl	0
 𨏼	fkfl	0
@@ -33587,10 +32408,8 @@ encoder:
 𣔑	fkgs	0
 𣚕	fkgs	0
 𨋩	fkgs	0
-𫐵	fkgx	0
 軛	fkgy	190000
 𨋛	fkgy	0
-𫐳	fkgy	0
 䡌	fkgz	4080
 𨌆	fkgz	0
 𨍥	fkgz	0
@@ -33607,7 +32426,6 @@ encoder:
 查到	fkhk	8150000
 𨍀	fkhk	0
 𨍌	fkhk	0
-𫐮	fkhm	0
 𨏺	fkhp	0
 𨌡	fkhx	0
 䡸	fkhz	3770
@@ -33615,7 +32433,6 @@ encoder:
 柚	fkia	10900000
 𤰔	fkia	0
 柙	fkib	216000
-𫐲	fkib	0
 柛	fkic	2550000
 𨊣	fkid	0
 𣠢	fkig	0
@@ -33628,7 +32445,6 @@ encoder:
 𨍅	fkil	0
 𨌳	fkiq	0
 𨍐	fkiq	0
-𪴂	fkir	0
 𢡴	fkiw	0
 軙	fkix	20800
 𨋤	fkix	0
@@ -33677,7 +32493,6 @@ encoder:
 𨏙	fkjr	0
 䡶	fkjs	4000
 𨎤	fkju	0
-𪴢	fkju	0
 轗	fkjw	58300
 𨍖	fkjy	0
 𨝩	fkjy	0
@@ -33691,7 +32506,6 @@ encoder:
 𣠠	fkkb	0
 輫	fkkc	37800
 𠜒	fkkd	0
-𪲦	fkkd	0
 䡲	fkke	8900
 雷暴	fkke	720000
 𨌬	fkke	0
@@ -33763,7 +32577,6 @@ encoder:
 𨌣	fklo	0
 𨍄	fklo	0
 𧡍	fklr	0
-𪴤	fkls	0
 𨏽	fklt	0
 𨍾	fklw	0
 𨎢	fklw	0
@@ -33773,7 +32586,6 @@ encoder:
 槾	fklx	104000
 𣕃	fklz	0
 軠	fkmb	57500
-𫐴	fkmb	0
 𡭏	fkmd	0
 𨌦	fkme	0
 輮	fkmf	50500
@@ -33794,8 +32606,6 @@ encoder:
 轞	fkml	38600
 𣗨	fkml	0
 𨌽	fkmm	0
-𪳆	fkmm	0
-𫐴	fkmm	0
 軼	fkmo	1320000
 𢽬	fkmo	0
 𨊴	fkmo	0
@@ -33808,7 +32618,6 @@ encoder:
 𨊰	fkmy	0
 𨋖	fkmy	0
 𨋱	fkmy	0
-𪳚	fkmy	0
 𣒹	fkmz	0
 𨋶	fknc	0
 𨌈	fknc	0
@@ -33823,7 +32632,6 @@ encoder:
 𨿢	fkni	0
 䰤	fknj	4280
 𨍹	fknj	0
-𫐯	fknk	0
 𨏳	fknl	0
 𨌓	fkno	0
 䡚	fknr	4190
@@ -33858,7 +32666,6 @@ encoder:
 𨊽	fkoo	0
 𨌻	fkoo	0
 𨏤	fkoo	0
-𫐱	fkoo	0
 軫	fkop	168000
 轇	fkop	46500
 𨎗	fkop	0
@@ -33918,7 +32725,6 @@ encoder:
 轚	fkqf	56300
 𨎼	fkqf	0
 𨣗	fkqf	0
-𫐼	fkqf	0
 礊	fkqg	322000
 𥖳	fkqg	0
 蟿	fkqi	34200
@@ -33955,7 +32761,6 @@ encoder:
 𨎟	fkrj	0
 𨎣	fkrj	0
 𨎲	fkrj	0
-𫐹	fkrj	0
 䡘	fkrk	3890
 𨋎	fkrk	0
 𨋮	fkrk	0
@@ -34033,7 +32838,6 @@ encoder:
 軿	fkue	57200
 𨍍	fkue	0
 輶	fkuf	73200
-𪳱	fkuf	0
 䡵	fkug	3580
 𣝢	fkug	0
 𣡲	fkug	0
@@ -34053,7 +32857,6 @@ encoder:
 𨎦	fkve	0
 杳渺	fkvl	36400
 𨋫	fkvr	0
-𪳲	fkvr	0
 東	fkvv	137000000
 杳	fkvv	4470000
 𣏬	fkvv	0
@@ -34095,7 +32898,6 @@ encoder:
 䡭	fkxe	4050
 𨋀	fkxe	0
 䡦	fkxf	4230
-𫐻	fkxf	0
 䡹	fkxi	4590
 𤴝	fkxi	0
 𨋋	fkxi	0
@@ -34226,7 +33028,6 @@ encoder:
 㯰	flel	3780
 樱花	flen	12800000
 椣	fleo	82100
-𪳘	flfj	0
 棗	flfl	3280000
 棘	flfl	7550000
 𣝯	flfl	0
@@ -34251,7 +33052,6 @@ encoder:
 𣞲	fljr	0
 榿	flju	92200
 㭗	flka	3820
-𪴃	flka	0
 檌	flkc	151000
 𦖝	flkc	0
 刺	flkd	50300000
@@ -34259,7 +33059,6 @@ encoder:
 𣍃	flki	0
 𧌐	flki	0
 𣗶	flkv	0
-𪶿	flkv	0
 相思	flkw	24900000
 相当	flkx	148000000
 相同	flld	81600000
@@ -34277,7 +33076,6 @@ encoder:
 𧠵	fllr	0
 𧡮	fllr	0
 𧡴	fllr	0
-𫍦	fllr	0
 𤏡	fllu	0
 刺骨	fllw	2670000
 𣡠	fllx	0
@@ -34314,7 +33112,6 @@ encoder:
 𣖱	flor	0
 想念	flos	36500000
 相邻	flow	5140000
-𪲵	flow	0
 梤	floy	73300
 𢒞	flpd	0
 相貌	flpn	9050000
@@ -34336,7 +33133,6 @@ encoder:
 𣞻	flrr	0
 椤	flrs	3730000
 𩰦	flrx	0
-𪳄	flry	0
 鶫	flrz	62000
 𪀜	flrz	0
 𪂼	flrz	0
@@ -34391,7 +33187,6 @@ encoder:
 𪔇	flzn	0
 相约	flzr	17700000
 相继	flzz	16600000
-𪳛	fmac	0
 酷刑	fmae	6080000
 𣔼	fmae	0
 㯚	fmaj	3510
@@ -34416,7 +33211,6 @@ encoder:
 霉素	fmcz	3930000
 酷热	fmdq	2600000
 棰	fmeb	1180000
-𪲹	fmeb	0
 檱	fmec	56000
 𣗍	fmec	0
 杵	fmed	2650000
@@ -34425,7 +33219,6 @@ encoder:
 橅	fmeu	53300
 𣠓	fmfb	0
 𣟔	fmfd	0
-𪵉	fmfl	0
 枖	fmgd	119000
 𣕊	fmgk	0
 桥	fmgn	132000000
@@ -34437,16 +33230,13 @@ encoder:
 𣟢	fmhk	0
 𣙖	fmhl	0
 𣘷	fmhm	0
-𪲸	fmhm	0
 𣜀	fmhz	0
 柞	fmid	1350000
 楀	fmil	1620000
 柹	fmim	28700
-𪴵	fmin	0
 𣖯	fmiw	0
 梴	fmiy	32800
 𣞳	fmjk	0
-𪴔	fmjk	0
 㰏	fmjl	5040
 橋	fmjl	31900000
 𩏴	fmjm	0
@@ -34456,7 +33246,6 @@ encoder:
 酷暑	fmkb	3500000
 梸	fmkd	24000
 𣙔	fmkf	0
-𪵃	fmkk	0
 𣘺	fmkl	0
 𣜤	fmkm	0
 株	fmko	94100000
@@ -34498,7 +33287,6 @@ encoder:
 橁	fmrk	69600
 𣠱	fmrk	0
 欑	fmrl	1180000
-𪴻	fmrl	0
 鬱	fmrp	9760000
 𣖰	fmrr	0
 𣘵	fmrr	0
@@ -34510,7 +33298,6 @@ encoder:
 桥头	fmtg	6230000
 𣓽	fmtr	0
 𣔪	fmtr	0
-𪳶	fmtr	0
 㭔	fmua	4160
 楸	fmuo	1420000
 𣡅	fmuq	0
@@ -34528,21 +33315,17 @@ encoder:
 𣞂	fmwl	0
 𣠗	fmwl	0
 櫷	fmwx	28700
-𪴮	fmwy	0
 棅	fmxb	121000
-𪴧	fmxb	0
 𣡡	fmxd	0
 𣒀	fmxi	0
 𣙨	fmxi	0
 𣠰	fmxk	0
 櫛	fmxy	1410000
-𪲞	fmya	0
 杚	fmyd	31900
 柂	fmyi	54000
 𣙭	fmyj	0
 𣒴	fmym	0
 𣛏	fmys	0
-𪴼	fmyu	0
 槌	fmyw	5530000
 𣒤	fmyy	0
 𣞫	fmzf	0
@@ -34567,10 +33350,8 @@ encoder:
 桦南	fnel	215000
 棉花	fnen	18500000
 柏木	fnfa	2080000
-𪳵	fnfa	0
 柏林	fnff	11600000
 𨑋	fnfg	0
-𪴥	fnfg	0
 柏树	fnfx	914000
 槐树	fnfx	1350000
 𣞚	fngb	0
@@ -34612,7 +33393,6 @@ encoder:
 𣔬	fnoe	0
 𣝼	fnol	0
 𣟨	fnol	0
-𪵆	fnol	0
 欅	fnom	475000
 𣙺	fnor	0
 𣞛	fnor	0
@@ -34632,7 +33412,6 @@ encoder:
 梎	fnrr	21400
 𣓛	fnrr	0
 𣔢	fnrr	0
-𪴕	fnrr	0
 𣚔	fnru	0
 樬	fnrw	25700
 檄	fnsm	1530000
@@ -34673,7 +33452,6 @@ encoder:
 松下	foai	38200000
 零下	foai	4090000
 𣔥	foai	0
-𪵜	foai	0
 㭘	foaj	4230
 𠎙	foaj	0
 棆	foal	87100
@@ -34748,7 +33526,6 @@ encoder:
 𪎀	fogb	0
 䫶	fogg	3430
 礬	fogg	149000
-𫗽	fogg	0
 蠜	fogi	26500
 𣒅	fogj	0
 桸	fogl	127000
@@ -34877,7 +33654,6 @@ encoder:
 棥	foof	51800
 顂	foog	28600
 樅	fooi	261000
-𪳇	fooi	0
 㭲	fooj	5310
 𣠬	fook	0
 𤲝	fook	0
@@ -34930,7 +33706,6 @@ encoder:
 𪋿	fori	0
 𪌛	fori	0
 𪍹	fori	0
-𫝖	fori	0
 𪌣	forj	0
 𪌾	fork	0
 𪍞	fork	0
@@ -34981,7 +33756,6 @@ encoder:
 䴺	fosj	6420
 𣛉	fosl	0
 𪍮	fosm	0
-𫈇	fosn	0
 樧	fosq	29600
 䙪	fosr	3600
 𩻜	fosr	0
@@ -34990,7 +33764,6 @@ encoder:
 𢠗	fosw	0
 枔	fosx	426000
 零讯	fosy	6920
-𪲖	fotd	0
 𪌉	fote	0
 𪍎	fote	0
 零头	fotg	1240000
@@ -35088,7 +33861,6 @@ encoder:
 𪎆	fozn	0
 𩸝	fozr	0
 𪁿	fozr	0
-𪝙	fozr	0
 松	fozs	90400000
 枩	fozs	149000
 棇	fozw	29300
@@ -35097,8 +33869,6 @@ encoder:
 检出	fozz	3480000
 𤕩	fozz	0
 𪌥	fozz	0
-𪲨	fpaj	0
-𪳞	fpaj	0
 𣖩	fpak	0
 𣨗	fpar	0
 栀	fpay	4610000
@@ -35107,7 +33877,6 @@ encoder:
 𣑂	fpaz	0
 𣔔	fpbn	0
 板块	fpbx	41800000
-𪲟	fpda	0
 㭩	fpds	4500
 板报	fpdy	1880000
 𣏸	fped	0
@@ -35119,7 +33888,6 @@ encoder:
 杉树	fpfx	536000
 𣛪	fpgo	0
 楥	fpgx	92200
-𪳸	fpgx	0
 板式	fphb	2690000
 板车	fphe	1980000
 榹	fpih	23100
@@ -35155,7 +33923,6 @@ encoder:
 板子	fpya	3100000
 桴	fpya	1340000
 𣐧	fpys	0
-𪴗	fpyu	0
 𣑿	fpyy	0
 榽	fpzg	25000
 桵	fpzm	102000
@@ -35167,7 +33934,6 @@ encoder:
 机井	fqbn	416000
 机场	fqby	38300000
 机动	fqbz	22600000
-𪴖	fqbz	0
 机耕	fqcb	504000
 杋	fqda	35800
 枠	fqed	21600000
@@ -35202,9 +33968,7 @@ encoder:
 𩛳	fqox	0
 机舱	fqpo	1290000
 栅	fqqa	9520000
-𪲩	fqqd	0
 机务	fqry	785000
-𪣜	fqsb	0
 𣐠	fqss	0
 机床	fqtf	14200000
 㮳	fqug	3780
@@ -35238,11 +34002,9 @@ encoder:
 𣖼	fraz	0
 𣟓	frbg	0
 柳城	frbh	520000
-𪲪	frbi	0
 𣘤	frbk	0
 桻	frci	34200
 槰	frcw	58900
-𪴈	frcy	0
 𣑣	frds	0
 𣖑	frei	0
 桅杆	frfa	1070000
@@ -35270,14 +34032,10 @@ encoder:
 𣕍	frkg	0
 㭵	frki	5410
 𣓂	frki	0
-𪴿	frkk	0
 栎	frko	683000
-𪲝	frko	0
 构思	frkw	7840000
 𣖆	frky	0
-𪴆	frkz	0
 桷	frld	405000
-𪳐	frlg	0
 槝	frll	46800
 㭥	frlo	7640
 槇	frlo	721000
@@ -35300,7 +34058,6 @@ encoder:
 𣓌	froj	0
 𣓗	frok	0
 檐	fros	5840000
-𪳈	frow	0
 格律	frox	669000
 𣑤	froz	0
 𣞗	frpk	0
@@ -35363,7 +34120,6 @@ encoder:
 𣚪	fsbi	0
 槠	fsbm	160000
 櫧	fsbm	188000
-𪳍	fsbr	0
 校场	fsby	395000
 校长	fsch	26900000
 梳理	fsck	5740000
@@ -35379,7 +34135,6 @@ encoder:
 𣠥	fsfn	0
 校样	fsfu	97600
 榜样	fsfu	17900000
-𪺪	fsfu	0
 核桃	fsfv	7750000
 樟树	fsfx	1240000
 核酸	fsfz	4630000
@@ -35417,7 +34172,6 @@ encoder:
 柿	fsli	9480000
 𣚌	fslj	0
 𣟎	fslr	0
-𪴊	fslr	0
 樆	fslz	85300
 𣘄	fsmh	0
 核算	fsml	21100000
@@ -35426,14 +34180,12 @@ encoder:
 𣖺	fsmr	0
 椸	fsmy	36900
 𣙮	fsnb	0
-𪲮	fsnd	0
 𣚳	fsni	0
 橀	fsnl	1650000
 核价	fsno	218000
 棭	fsnr	122000
 醇化	fsnr	158000
 椊	fsoe	40700
-𪳑	fsog	0
 𣖞	fsoj	0
 校舍	fsom	2590000
 校	fsoo	206000000
@@ -35445,7 +34197,6 @@ encoder:
 校风	fsqo	1190000
 㮵	fsqs	3850
 樟脑	fsqs	442000
-𪲫	fsqs	0
 𩰩	fsrd	0
 𣐿	fsrh	0
 校外	fsri	8370000
@@ -35482,7 +34233,6 @@ encoder:
 楴	fswl	50900
 㯠	fswm	21900
 酿造	fswm	5020000
-𪳤	fswq	0
 鶐	fswr	19700
 榜	fsws	119000000
 核实	fswt	24600000
@@ -35490,7 +34240,6 @@ encoder:
 怷	fswz	70000
 怸	fswz	23700
 核心	fswz	90600000
-𪵈	fsxd	0
 㯀	fsxi	4250
 校验	fsxo	6480000
 桹	fsxo	34900
@@ -35525,10 +34274,8 @@ encoder:
 𣙦	ftbd	0
 榳	ftby	43700
 枓	fted	179000
-𪴹	fteo	0
 樜	fteu	55300
 𣙃	fteu	0
-𪳡	ftex	0
 𣙪	ftff	0
 𣟖	ftfg	0
 𣘍	ftfk	0
@@ -35544,7 +34291,6 @@ encoder:
 㯅	ftne	3430
 𣚲	ftno	0
 𣖵	ftob	0
-𪴋	ftoo	0
 㮞	ftrj	3910
 栨	ftro	1060000
 橷	ftrq	52400
@@ -35564,8 +34310,6 @@ encoder:
 櫠	ftyq	606000
 𣝠	ftyz	0
 𣠯	ftzr	0
-𪴩	ftzu	0
-𪳎	ftzx	0
 梯形	fuae	1750000
 楼下	fuai	15800000
 𣞼	fuax	0
@@ -35573,7 +34317,6 @@ encoder:
 栏	fubd	211000000
 槎	fubi	1780000
 𣕲	fubk	0
-𪜆	fubn	0
 𣘰	fubp	0
 㮓	fubr	3790
 𣕗	fubr	0
@@ -35591,7 +34334,6 @@ encoder:
 楼梯	fufu	14400000
 𣜃	fufu	0
 𡑻	fugb	0
-𪴚	fugb	0
 栚	fugd	54100
 𣖙	fugd	0
 𣔾	fugq	0
@@ -35610,12 +34352,10 @@ encoder:
 様	fukv	161000000
 栏目	fula	199000000
 𣕂	fuli	0
-𪲬	fuli	0
 橧	fulk	35300
 𣙥	fulk	0
 檥	fumh	40500
 𣜧	fums	0
-𪳢	funl	0
 杰作	funm	6060000
 檤	funw	481000
 榏	fuol	22600
@@ -35623,7 +34363,6 @@ encoder:
 𣞼	fuox	0
 楼盘	fupl	37200000
 椾	fuqk	375000
-𪲾	furd	0
 橉	furm	23800
 𩽑	furr	0
 𣘎	furz	0
@@ -35664,7 +34403,6 @@ encoder:
 㮶	fuzq	4260
 𣖬	fuzr	0
 𣜑	fuzu	0
-𪴨	fuzw	0
 杰出	fuzz	15200000
 𣕜	fuzz	0
 𣘎	fuzz	0
@@ -35707,7 +34445,6 @@ encoder:
 𩅯	fvbr	0
 𩇇	fvbr	0
 䨹	fvbu	3960
-𫖶	fvbu	0
 要地	fvbv	1600000
 霆	fvby	4560000
 䨺	fvbz	4120
@@ -35721,7 +34458,6 @@ encoder:
 𩇔	fvbz	0
 𩃳	fvcb	0
 𩄴	fvcb	0
-𫖱	fvcb	0
 𩇋	fvcc	0
 𩂽	fvce	0
 𩄺	fvce	0
@@ -35736,7 +34472,6 @@ encoder:
 要素	fvcz	38700000
 𩂻	fvcz	0
 要挟	fvdb	2210000
-𫖬	fvdg	0
 要事	fvdj	1780000
 𩃂	fvdm	0
 𩃑	fvdn	0
@@ -35756,11 +34491,8 @@ encoder:
 𩅰	fvep	0
 霸	fveq	92000000
 𩆶	fver	0
-𫖴	fver	0
 酬劳	fvew	1390000
 𩂏	fvex	0
-𫖭	fvey	0
-𫖯	fvey	0
 䨢	fvez	7000
 霮	fvez	28400
 𦉣	fvez	0
@@ -35805,7 +34537,6 @@ encoder:
 需	fvgl	329000000
 𩃄	fvgm	0
 䰰	fvgn	5280
-𫖩	fvgp	0
 䨖	fvgq	3800
 𩂚	fvgq	0
 𩂢	fvgq	0
@@ -35824,7 +34555,6 @@ encoder:
 𩆫	fvhx	0
 霕	fvhz	22600
 𩂄	fvhz	0
-𫖪	fvib	0
 𧓑	fvii	0
 要点	fvij	44100000
 霑	fvij	929000
@@ -35832,7 +34562,6 @@ encoder:
 𩄷	fvij	0
 䨞	fvil	3330
 雺	fvim	56100
-𪬪	fviw	0
 㪮	fvix	4150
 䨷	fvix	3700
 𣀀	fvix	0
@@ -35854,13 +34583,11 @@ encoder:
 霣	fvjl	36700
 𧢥	fvjl	0
 𩆚	fvjl	0
-𫖦	fvjl	0
 𩆐	fvjm	0
 𩆻	fvjm	0
 𩇆	fvjm	0
 𩵀	fvjn	0
 𩵂	fvjn	0
-𫖸	fvjn	0
 𩂝	fvjo	0
 𩂲	fvjo	0
 𩆒	fvjo	0
@@ -35894,7 +34621,6 @@ encoder:
 䨵	fvke	3970
 𩅈	fvke	0
 𩅦	fvke	0
-𫖮	fvke	0
 䨔	fvkg	3810
 𩃙	fvkg	0
 𩄻	fvkg	0
@@ -35928,7 +34654,6 @@ encoder:
 𩅆	fvkr	0
 𩅳	fvkr	0
 𪆼	fvkr	0
-𫖵	fvkr	0
 𩃯	fvku	0
 𩄪	fvku	0
 𩄰	fvku	0
@@ -35938,7 +34663,6 @@ encoder:
 靆	fvkw	38700
 要紧	fvkx	7010000
 𨟘	fvky	0
-𫒨	fvky	0
 䨡	fvkz	3910
 電	fvkz	140000000
 𩃗	fvkz	0
@@ -35976,7 +34700,6 @@ encoder:
 霪	fvmb	242000
 𨗒	fvmb	0
 𩂐	fvmb	0
-𫖥	fvmb	0
 𠧍	fvme	0
 䨋	fvmh	3750
 雮	fvmh	121000
@@ -36012,7 +34735,6 @@ encoder:
 𩂛	fvnd	0
 檪	fvnf	78600
 𩂯	fvnf	0
-𫖲	fvnf	0
 𩂠	fvnh	0
 𩃷	fvnh	0
 霍	fvni	17800000
@@ -36085,7 +34807,6 @@ encoder:
 雰	fvoy	808000
 𨟯	fvoy	0
 𩃼	fvoy	0
-𫖨	fvoy	0
 𩃍	fvoz	0
 𩃭	fvoz	0
 酬金	fvpa	1360000
@@ -36101,7 +34822,6 @@ encoder:
 𩁸	fvqd	0
 𩃵	fvqf	0
 𩄏	fvqi	0
-𫖳	fvqk	0
 霰	fvqm	1340000
 霺	fvqm	75900
 𩂑	fvqo	0
@@ -36119,11 +34839,9 @@ encoder:
 𩂣	fvrj	0
 𩅗	fvrj	0
 𩅬	fvrj	0
-𪳥	fvrj	0
 𩂶	fvrk	0
 𩄉	fvrk	0
 𩅨	fvrk	0
-𫖫	fvrk	0
 霿	fvrl	35300
 𣛯	fvrl	0
 𩆂	fvrl	0
@@ -36156,7 +34874,6 @@ encoder:
 𪂕	fvrz	0
 𣕝	fvsb	0
 𩆔	fvsb	0
-𫖷	fvsb	0
 霔	fvsc	31000
 𩄊	fvse	0
 𩅁	fvse	0
@@ -36183,7 +34900,6 @@ encoder:
 霎	fvsz	1460000
 要闻	fvtc	49100000
 䨏	fvtr	4060
-𫖢	fvtr	0
 𩅄	fvtx	0
 𩄝	fvub	0
 䨴	fvud	4400
@@ -36212,7 +34928,6 @@ encoder:
 雿	fvvr	583000
 𩃎	fvvs	0
 𩃜	fvvs	0
-𫖧	fvvs	0
 𩅃	fvwb	0
 要害	fvwc	5680000
 𩅴	fvwf	0
@@ -36268,15 +34983,12 @@ encoder:
 䨸	fvxw	4170
 霞	fvxx	31600000
 𩇈	fvxx	0
-𪸤	fvxx	0
 𩂵	fvxy	0
 霋	fvxz	27200
-𪴌	fvxz	0
 桃子	fvya	6970000
 𩅱	fvyb	0
 𩁶	fvyd	0
 𩄛	fvyf	0
-𫖡	fvyi	0
 要强	fvyj	4250000
 霤	fvyk	101000
 𩆎	fvyk	0
@@ -36296,7 +35008,6 @@ encoder:
 𩆛	fvys	0
 𩆣	fvys	0
 𩄩	fvyt	0
-𫖰	fvyu	0
 𩃁	fvyx	0
 䨒	fvyy	3990
 霛	fvyy	107000
@@ -36332,11 +35043,9 @@ encoder:
 要好	fvzy	16600000
 鄠	fvzy	85900
 𨝽	fvzy	0
-𫖣	fvzy	0
 𩂗	fvzz	0
 𩃚	fvzz	0
 𩅏	fvzz	0
-𪳹	fwag	0
 柠	fwai	14300000
 槣	fwaj	55200
 𣟧	fwal	0
@@ -36363,12 +35072,9 @@ encoder:
 楎	fwfk	26500
 槤	fwfk	584000
 𣚢	fwfk	0
-𪳻	fwfk	0
 榕树	fwfx	4800000
-𪴲	fwfx	0
 𣚢	fwfz	0
 惠存	fwgi	53200
-𪵂	fwgl	0
 㯌	fwgq	3710
 榢	fwgq	30900
 𣔛	fwgr	0
@@ -36380,20 +35086,17 @@ encoder:
 梿	fwhe	161000
 惠东	fwhk	832000
 𣔝	fwhz	0
-𪵅	fwjg	0
 𣘌	fwjr	0
 𣟳	fwjr	0
 𣟴	fwjr	0
 𣡬	fwjr	0
 𣠲	fwju	0
 槴	fwjy	71500
-𪳉	fwka	0
 𣘔	fwkg	0
 榊	fwki	2290000
 𣔴	fwki	0
 㯾	fwkk	3910
 𣟆	fwkk	0
-𪴶	fwkk	0
 檳	fwkl	872000
 惠临	fwkm	54800
 𣘹	fwko	0
@@ -36422,10 +35125,8 @@ encoder:
 㭦	fwmh	4530
 榨	fwmi	4050000
 櫁	fwmi	70300
-𪴅	fwmj	0
 榓	fwml	30000
 樒	fwml	76300
-𪳣	fwmq	0
 槌	fwmy	5530000
 榷	fwni	925000
 𣙜	fwni	0
@@ -36436,7 +35137,6 @@ encoder:
 棎	fwof	358000
 榕	fwoj	12800000
 𣟯	fwoj	0
-𪴘	fwot	0
 𣔱	fwox	0
 𣔅	fwpd	0
 㰂	fwpk	5970
@@ -36450,7 +35150,6 @@ encoder:
 枕	fwrd	28200000
 𣏝	fwrd	0
 楁	fwrj	1300000
-𪳷	fwrm	0
 𣛱	fwrn	0
 柁	fwrr	173000
 𣞐	fwru	0
@@ -36461,7 +35160,6 @@ encoder:
 𣞮	fwsl	0
 榠	fwso	72500
 𣙣	fwso	0
-𪳣	fwsq	0
 𣟋	fwsr	0
 椖	fwsy	23000
 枕头	fwtg	8580000
@@ -36487,14 +35185,10 @@ encoder:
 𣑑	fwya	0
 𣐖	fwyd	0
 𣑒	fwyd	0
-𪳧	fwyj	0
 惠阳	fwyk	1220000
 惠及	fwym	2230000
 㮼	fwyy	4330
-𪳂	fwyy	0
 𣗈	fwzf	0
-𪴰	fwzl	0
-𪵇	fwzl	0
 桉	fwzm	1450000
 惠允	fwzr	14200
 树干	fxae	2860000
@@ -36503,14 +35197,12 @@ encoder:
 𣛣	fxae	0
 楑	fxag	47200
 树下	fxai	14400000
-𪳽	fxau	0
 𣜓	fxax	0
 𣐓	fxbd	0
 𣑵	fxbd	0
 𣕑	fxbf	0
 𣕪	fxbf	0
 𣐕	fxbi	0
-𪳼	fxbk	0
 𣡃	fxbr	0
 楗	fxby	699000
 雪球	fxcd	1420000
@@ -36542,8 +35234,6 @@ encoder:
 𡐨	fxfb	0
 树枝	fxfe	5700000
 树林	fxff	10600000
-𪴝	fxff	0
-𪴪	fxff	0
 霹雳	fxfg	7470000
 雪柜	fxfh	218000
 树梢	fxfk	1650000
@@ -36556,7 +35246,6 @@ encoder:
 权术	fxfs	547000
 树桩	fxft	575000
 概要	fxfv	140000000
-𪴎	fxfv	0
 懋	fxfw	3920000
 树根	fxfx	1650000
 㭈	fxgd	3840
@@ -36586,7 +35275,6 @@ encoder:
 㮭	fxju	4030
 橙	fxju	40000000
 𣜘	fxju	0
-𪸋	fxju	0
 櫭	fxka	61500
 𣑕	fxka	0
 𣛛	fxka	0
@@ -36602,14 +35290,11 @@ encoder:
 㮀	fxkz	4700
 桶	fxld	45700000
 𡭌	fxld	0
-𪳏	fxld	0
-𪴷	fxlk	0
 雪山	fxll	11900000
 雪崩	fxlq	2290000
 雪峰	fxlr	1930000
 樋	fxlw	763000
 𣖽	fxlx	0
-𪳦	fxly	0
 𣜔	fxlz	0
 楙	fxmf	146000
 楺	fxmf	34400
@@ -36634,7 +35319,6 @@ encoder:
 权衡	fxor	6840000
 概念	fxos	89900000
 𣡞	fxos	0
-𪲘	fxos	0
 𣚉	fxou	0
 概貌	fxpn	1040000
 雪豹	fxpr	652000
@@ -36740,7 +35424,6 @@ encoder:
 𣚦	fyji	0
 椭圆	fyjj	5370000
 配器	fyjj	12900000
-𪴜	fyjl	0
 𤋐	fyju	0
 𣑌	fyjz	0
 𣙶	fyka	0
@@ -36750,7 +35433,6 @@ encoder:
 配置	fyle	116000000
 𣓶	fylk	0
 极具	fylo	13700000
-𪴱	fylx	0
 杞县	fylz	282000
 梃	fymb	474000
 𣗕	fymb	0
@@ -36793,7 +35475,6 @@ encoder:
 配方	fysy	31200000
 极度	fytv	18100000
 极差	fyub	5450000
-𪴛	fyug	0
 配料	fyut	5360000
 极为	fyuv	30600000
 杨浦	fyvf	3720000
@@ -36836,7 +35517,6 @@ encoder:
 桳	fzge	49800
 𣔊	fzgj	0
 㮥	fzgk	7600
-𫗢	fzgo	0
 椮	fzgp	28900
 椽	fzgq	1860000
 𣗭	fzhi	0
@@ -36860,7 +35540,6 @@ encoder:
 酸化	fznr	5870000
 槮	fzop	550000
 梭	fzor	19800000
-𪴫	fzor	0
 𣚈	fzou	0
 㯿	fzoz	5920
 㭇	fzrd	4010
@@ -36869,11 +35548,9 @@ encoder:
 𣖊	fzrk	0
 桚	fzrs	20000
 𩿤	fzrz	0
-𫜦	fzrz	0
 札记	fzsy	6220000
 酸度	fztv	1350000
 酸痛	fztx	3800000
-𪲻	fzuf	0
 酸类	fzug	918000
 酸性	fzum	5580000
 酸洗	fzvm	1250000
@@ -36895,7 +35572,6 @@ encoder:
 𣝵	fzzk	0
 𣠭	fzzl	0
 𣚓	fzzq	0
-𪲯	fzzr	0
 㭃	fzzs	6780
 柪	fzzy	49900
 酸奶	fzzy	4880000
@@ -37014,7 +35690,6 @@ encoder:
 左贡	gbbl	170000
 左联	gbcu	176000
 压抑	gbdr	5050000
-𫀈	gbds	0
 𥔫	gbek	0
 压榨	gbfw	2330000
 左权	gbfx	765000
@@ -37052,7 +35727,6 @@ encoder:
 𥓪	gbob	0
 砆	gbod	190000
 𥗇	gbof	0
-𫀤	gboh	0
 硅谷	gboo	13100000
 碐	gbor	27300
 压铸	gbpc	1850000
@@ -37063,8 +35737,6 @@ encoder:
 硅胶	gbqs	3360000
 夸脱	gbqu	92000
 压服	gbqy	137000
-𪿿	gbrd	0
-𫀂	gbrd	0
 压条	gbrf	380000
 左角	gbrl	232000
 硓	gbrr	56900
@@ -37108,7 +35780,6 @@ encoder:
 压缩	gbzw	55900000
 䂶	gbzy	5030
 耷拉	gcds	1860000
-𫀌	gcds	0
 套鞋	gceb	195000
 套餐	gcir	33200000
 聋哑	gcja	2630000
@@ -37123,7 +35794,6 @@ encoder:
 套件	gcnm	8250000
 礟	gcoo	53700
 礮	gcoo	42000
-𫀔	gcrh	0
 𥗗	gcsr	0
 套装	gctb	35400000
 套间	gctk	1220000
@@ -37132,10 +35802,8 @@ encoder:
 套牢	gcwm	3000000
 套衫	gcwp	316000
 套房	gcws	17000000
-𫀫	gcxg	0
 碶	gcyg	337000
 磝	gcym	57300
-𫀥	gcyz	0
 碡	gczy	106000
 丆	gdaa	82800
 	gdaa	0
@@ -37163,7 +35831,6 @@ encoder:
 𩠣	gdan	0
 𡘂	gdao	0
 𪍢	gdaq	0
-𪥑	gdau	0
 㦽	gdaz	3900
 㚝	gdbb	4080
 大款	gdbb	3670000
@@ -37171,13 +35838,11 @@ encoder:
 𡙔	gdbb	0
 夳	gdbd	53700
 左	gdbi	186000000
-𪩵	gdbi	0
 大鼓	gdbj	984000
 奝	gdbj	40900
 奈	gdbk	24100000
 𠝥	gdbk	0
 𡘍	gdbk	0
-𪥔	gdbk	0
 𡘟	gdbl	0
 奢	gdbm	3300000
 𢴷	gdbm	0
@@ -37283,7 +35948,6 @@ encoder:
 𩕑	gdgg	0
 耐碱	gdgh	602000
 大面	gdgj	1040000
-𪟅	gdgk	0
 𧡅	gdgl	0
 大雁	gdgn	4150000
 𢒊	gdgp	0
@@ -37296,7 +35960,6 @@ encoder:
 𡚓	gdhb	0
 大车	gdhe	2080000
 大致	gdhm	22900000
-𪥎	gdhm	0
 奁	gdho	574000
 大成	gdhv	9490000
 奆	gdhx	25100
@@ -37308,7 +35971,6 @@ encoder:
 大叔	gdia	5950000
 在	gdib	2700000000
 𡗱	gdii	0
-𫌍	gdii	0
 大战	gdij	33300000
 大步	gdik	9070000
 𡘧	gdik	0
@@ -37340,7 +36002,6 @@ encoder:
 𡙗	gdjj	0
 𣎥	gdjj	0
 𪌦	gdjj	0
-𪡔	gdjj	0
 剞	gdjk	313000
 奤	gdjk	39800
 𡙲	gdjk	0
@@ -37349,7 +36010,6 @@ encoder:
 大员	gdjl	991000
 𠳮	gdjl	0
 𥁓	gdjl	0
-𪥥	gdjl	0
 大跌	gdjm	6120000
 𢽽	gdjm	0
 𤯱	gdjm	0
@@ -37361,7 +36021,6 @@ encoder:
 大路	gdjr	7490000
 欹	gdjr	939000
 鵸	gdjr	22800
-𪥣	gdjr	0
 𡘰	gdju	0
 大中	gdjv	15300000
 𪓡	gdjw	0
@@ -37401,14 +36060,12 @@ encoder:
 𤊽	gdku	0
 𤋯	gdku	0
 大水	gdkv	4490000
-𪶍	gdkv	0
 大堂	gdkw	5960000
 遼	gdkw	2850000
 𡘨	gdkx	0
 𨝷	gdky	0
 奄	gdkz	4640000
 𡘤	gdkz	0
-𪥖	gdkz	0
 大幅	gdla	67100000
 夺目	gdla	5380000
 㚗	gdlc	3890
@@ -37443,7 +36100,6 @@ encoder:
 𤯗	gdmc	0
 𡗧	gdme	0
 𠬗	gdmh	0
-𪲁	gdmh	0
 大竹	gdmi	3130000
 𡗸	gdmi	0
 𧌝	gdmi	0
@@ -37456,7 +36112,6 @@ encoder:
 大管	gdmw	420000
 大气	gdmy	27500000
 奅	gdmy	44000
-𪥚	gdmy	0
 綔	gdmz	1130000
 大使	gdna	18900000
 𡘪	gdnc	0
@@ -37495,7 +36150,6 @@ encoder:
 大街	gdob	55600000
 𡘫	gdob	0
 𪌴	gdob	0
-𪥜	gdob	0
 大全	gdoc	142000000
 大人	gdod	95800000
 𠦵	gdoe	0
@@ -37524,7 +36178,6 @@ encoder:
 鵊	gdor	32000
 鷞	gdor	39800
 㤲	gdow	8730
-𪥏	gdox	0
 郟	gdoy	385000
 𠷔	gdoz	0
 大丘	gdpd	174000
@@ -37535,7 +36188,6 @@ encoder:
 大兵	gdpo	4020000
 𡗷	gdps	0
 大凡	gdqd	1670000
-𫝸	gdqg	0
 大胆	gdqk	37500000
 䀁	gdql	9600
 𧠶	gdql	0
@@ -37592,14 +36244,11 @@ encoder:
 大意	gdsk	10100000
 𡘐	gdsk	0
 𡘒	gdsk	0
-𪟃	gdsk	0
 盇	gdsl	50900
 盋	gdsl	28500
 大话	gdsm	28900000
-𪻟	gdsm	0
 大齐	gdsn	519000
 𨾩	gdsn	0
-𪥘	gdso	0
 𨫦	gdsp	0
 飆	gdsq	6300000
 䳊	gdsr	3540
@@ -37635,7 +36284,6 @@ encoder:
 㚔	gdub	4010
 大半	gdub	18500000
 𥘾	gdub	0
-𪲎	gdub	0
 羍	gduc	53500
 𩢙	gduc	0
 𢌾	gdue	0
@@ -37704,7 +36352,6 @@ encoder:
 耐心	gdwz	35600000
 大尉	gdxb	1260000
 𡚛	gdxb	0
-𫇊	gdxb	0
 𨷎	gdxc	0
 大殿	gdxe	5440000
 大戏	gdxh	3530000
@@ -37722,7 +36369,6 @@ encoder:
 𡙕	gdyb	0
 𡙺	gdyb	0
 𡯁	gdyd	0
-𪥋	gdyd	0
 大巴	gdyi	5380000
 夿	gdyi	106000
 𡗵	gdyi	0
@@ -37731,18 +36377,15 @@ encoder:
 夯	gdym	5070000
 耐力	gdym	8670000
 𤙼	gdym	0
-𪥚	gdym	0
 㚕	gdyn	4060
 𩁭	gdyn	0
 大办	gdyo	602000
 大队	gdyo	15700000
 大阪	gdyp	130000000
-𪽢	gdyp	0
 鴺	gdyr	27300
 㼪	gdys	4390
 㼽	gdys	5120
 𤭨	gdys	0
-𫘏	gdyt	0
 大院	gdyw	8590000
 𡙈	gdyx	0
 翃	gdyy	124000
@@ -37766,7 +36409,6 @@ encoder:
 𠞒	gdzk	0
 𡙂	gdzk	0
 𡭡	gdzk	0
-𪟋	gdzk	0
 大姐	gdzl	11800000
 大纲	gdzl	13500000
 𢽱	gdzm	0
@@ -37778,7 +36420,6 @@ encoder:
 瓠	gdzp	1080000
 𤬄	gdzp	0
 䫺	gdzq	3600
-𪵪	gdzq	0
 㰭	gdzr	4480
 匏	gdzr	414000
 大约	gdzr	44100000
@@ -37788,7 +36429,6 @@ encoder:
 𠣻	gdzr	0
 𣣚	gdzr	0
 𩿅	gdzr	0
-𫜬	gdzr	0
 厷	gdzs	666000
 厺	gdzs	108000
 大娘	gdzs	1930000
@@ -37804,7 +36444,6 @@ encoder:
 𡗰	gdzz	0
 𡘘	gdzz	0
 𡘛	gdzz	0
-𪥞	gdzz	0
 礞	geag	118000
 𥔽	geaj	0
 奔赴	gebi	2920000
@@ -37850,7 +36489,6 @@ encoder:
 𥕪	geoy	0
 𥒴	geoz	0
 𥕶	gepd	0
-𫀮	gepk	0
 䃟	geqm	5490
 奔腾	gequ	12700000
 磺胺	geqw	952000
@@ -37896,7 +36534,6 @@ encoder:
 碴	gfka	2580000
 磹	gfke	1490000
 礌	gfki	433000
-𫀓	gfmo	0
 礭	gfni	33300
 䂾	gfoo	4820
 𥓜	gfoo	0
@@ -37914,7 +36551,6 @@ encoder:
 㕌	ggad	4130
 㕃	ggae	5810
 厈	ggae	28800
-𪮱	ggae	0
 厅	ggai	162000000
 㕉	ggaj	4120
 碕	ggaj	506000
@@ -37931,7 +36567,6 @@ encoder:
 砺	ggay	1910000
 𠩳	ggay	0
 硕士	ggba	37100000
-𪠓	ggba	0
 厓	ggbb	343000
 𠪤	ggbb	0
 𠪆	ggbd	0
@@ -37939,7 +36574,6 @@ encoder:
 𠨭	ggbi	0
 𥑰	ggbi	0
 𥐘	ggbj	0
-𪠈	ggbj	0
 𧡋	ggbl	0
 𠨶	ggbo	0
 𠪑	ggbq	0
@@ -37952,20 +36586,16 @@ encoder:
 𠪩	ggbu	0
 𠪯	ggbu	0
 𠩍	ggbx	0
-𪠩	ggbx	0
 䣑	ggby	3510
 𠨼	ggby	0
 𨞋	ggby	0
 𨞬	ggby	0
-𫒬	ggby	0
 𠩂	ggbz	0
 𥑹	ggbz	0
 𠫑	ggcc	0
 厂长	ggch	5650000
-𪠐	ggch	0
 𠨵	ggci	0
 𠪚	ggcm	0
-𪠞	ggcm	0
 𠩻	ggcq	0
 㻹	ggcs	8760
 𠪏	ggcx	0
@@ -37977,14 +36607,12 @@ encoder:
 厝	ggek	3820000
 𠪄	ggek	0
 𥕉	ggek	0
-𪠎	ggel	0
 𠩷	ggeo	0
 𠪙	ggeo	0
 厮	ggep	4480000
 𠪜	ggep	0
 𠫌	ggeq	0
 𩿫	gger	0
-𪵌	gger	0
 厌世	ggev	525000
 磊落	ggev	738000
 厒	ggez	160000
@@ -37993,7 +36621,6 @@ encoder:
 㕊	ggfb	4290
 𠪖	ggfb	0
 𠩚	ggfd	0
-𪠔	ggfd	0
 𠩵	ggff	0
 𠪝	ggfg	0
 歴	ggfi	14700000
@@ -38007,7 +36634,6 @@ encoder:
 厯	ggfw	42000
 𢟍	ggfw	0
 𨟥	ggfy	0
-𪤲	gggb	0
 碝	gggd	59900
 𥗉	gggg	0
 𥗐	gggg	0
@@ -38059,7 +36685,6 @@ encoder:
 𠪶	ggju	0
 𠪔	ggjx	0
 𠩭	ggjy	0
-𪠋	ggjz	0
 厂里	ggkb	2350000
 厘	ggkb	40100000
 𠪵	ggkb	0
@@ -38070,8 +36695,6 @@ encoder:
 𠪧	ggkf	0
 願	ggkg	26300000
 𩖒	ggkg	0
-𪠍	ggkg	0
-𫗻	ggkg	0
 㕅	ggki	4630
 𠪿	ggki	0
 𧏐	ggki	0
@@ -38079,12 +36702,10 @@ encoder:
 𠪥	ggkk	0
 𥕴	ggkk	0
 𠫂	ggkl	0
-𪠖	ggko	0
 𠩼	ggkr	0
 𣢭	ggkr	0
 𣤔	ggkr	0
 𪄁	ggkr	0
-𪠙	ggku	0
 𣱷	ggkv	0
 愿	ggkw	193000000
 𠪰	ggkw	0
@@ -38094,8 +36715,6 @@ encoder:
 硽	ggkz	21600
 𠪎	ggkz	0
 𥕠	ggkz	0
-𪠇	ggkz	0
-𫀛	ggkz	0
 𥑢	ggli	0
 厕	gglk	7790000
 厠	gglk	485000
@@ -38129,7 +36748,6 @@ encoder:
 𪙪	ggmi	0
 曆	ggmk	50300000
 𠩯	ggmk	0
-𪠝	ggmk	0
 𧗖	ggml	0
 厤	ggmm	328000
 𩴣	ggmn	0
@@ -38156,7 +36774,6 @@ encoder:
 𠩡	ggnn	0
 𨿳	ggnn	0
 厂价	ggno	3580000
-𪠊	ggno	0
 𦢖	ggnq	0
 厦	ggnr	13500000
 鴈	ggnr	267000
@@ -38200,22 +36817,17 @@ encoder:
 𩔟	ggpg	0
 𠪢	ggpr	0
 𠨹	ggpx	0
-𪠜	ggqg	0
 𠪣	ggqm	0
 𠩇	ggqp	0
 𠪘	ggqq	0
-𫛵	ggqr	0
 𠪑	ggqs	0
 𠨻	ggqx	0
 橜	ggrf	26500
 𥕳	ggrg	0
-𪠏	ggrg	0
 𠨸	ggrh	0
 𠨿	ggrh	0
 𤑂	ggrh	0
 蟨	ggri	27800
-𪠌	ggri	0
-𫀧	ggri	0
 蹷	ggrj	28300
 𥔇	ggrj	0
 劂	ggrk	173000
@@ -38227,7 +36839,6 @@ encoder:
 𩀾	ggrn	0
 𨬐	ggrp	0
 𦠒	ggrq	0
-𪠗	ggrq	0
 䃎	ggrr	4730
 鷢	ggrr	25400
 𠨬	ggrr	0
@@ -38241,7 +36852,6 @@ encoder:
 𠡲	ggry	0
 𠢤	ggry	0
 𠢭	ggry	0
-𫀒	ggry	0
 鳫	ggrz	67800
 𡡕	ggrz	0
 壓	ggsb	26200000
@@ -38278,29 +36888,24 @@ encoder:
 懕	ggsw	93500
 㕂	ggsx	4550
 𥀬	ggsx	0
-𪠒	ggsx	0
 厂方	ggsy	1650000
 厌弃	ggsz	128000
 嬮	ggsz	984000
 㕏	ggte	4230
 𣂀	ggte	0
-𪰈	ggte	0
 𣃞	ggts	0
 𠩽	ggua	0
 㕓	ggub	3950
 𠪉	ggub	0
 㕑	ggud	6820
 厨	ggud	32000000
-𪠉	ggue	0
 𠩕	gguf	0
 厌烦	ggug	3870000
 㓹	gguk	4020
 𤉓	gguk	0
 𠫈	ggum	0
 𣯅	ggum	0
-𪠘	ggun	0
 𥔕	gguo	0
-𫀇	gguo	0
 𠩔	ggur	0
 𠩦	ggur	0
 𠪛	gguu	0
@@ -38308,7 +36913,6 @@ encoder:
 𠪊	ggux	0
 𠪼	ggux	0
 𠩋	gguz	0
-𪠕	gguz	0
 𠩓	ggvr	0
 𠩗	ggvr	0
 砳	ggvv	39600
@@ -38319,7 +36923,6 @@ encoder:
 𠪂	ggwl	0
 厂房	ggws	21200000
 𠩞	ggwy	0
-𪠆	ggxa	0
 𠪡	ggxb	0
 𡊃	ggxb	0
 𩒣	ggxg	0
@@ -38350,8 +36953,6 @@ encoder:
 𧠏	ggyl	0
 历	ggym	40400000
 厫	ggym	118000
-𪠛	ggym	0
-𫁣	ggym	0
 𪃱	ggyr	0
 㽁	ggys	4700
 𠨳	ggys	0
@@ -38386,7 +36987,6 @@ encoder:
 𠩐	ggzt	0
 𠪱	ggzt	0
 𨑄	ggzt	0
-𪠑	ggzw	0
 勵	ggzy	2310000
 𠨷	ggzy	0
 𥗠	ggzy	0
@@ -38419,7 +37019,6 @@ encoder:
 𥕇	ghjo	0
 𥗄	ghjr	0
 䃭	ghjw	4370
-𫒣	ghjy	0
 𥓫	ghkd	0
 𥔌	ghkz	0
 砸	ghli	64100000
@@ -38428,7 +37027,6 @@ encoder:
 𣭽	ghmh	0
 礛	ghml	151000
 敐	ghmo	486000
-𫀪	ghms	0
 砸毁	ghnb	271000
 砸伤	ghnm	668000
 碱化	ghnr	347000
@@ -38444,14 +37042,12 @@ encoder:
 碱性	ghum	4280000
 砸烂	ghuu	798000
 碱熔	ghuw	12400
-𪢓	ghvy	0
 𪓧	ghwx	0
 𢛚	ghwz	0
 䃘	ghxb	4540
 𥓼	ghxf	0
 礥	ghxl	27000
 砌	ghyd	16800000
-𪡮	ghyj	0
 砘	ghzi	158000
 𡝌	ghzm	0
 𣎴	giaa	0
@@ -38461,7 +37057,6 @@ encoder:
 不正	giai	21500000
 歪	giai	46700000
 不可	giaj	322000000
-𪜅	giaj	0
 不严	giak	2770000
 不再	gial	118000000
 𣬾	giam	0
@@ -38471,7 +37066,6 @@ encoder:
 不一	giav	18000000
 邳	giay	949000
 𥒿	giay	0
-𫀀	giaz	0
 不巧	giba	2520000
 存款	gibb	65300000
 不堪	gibe	35900000
@@ -38542,7 +37136,6 @@ encoder:
 𤰺	giki	0
 不少	gikm	123000000
 𠀰	gikm	0
-𪵟	gikm	0
 不小	giko	20600000
 𥒼	giko	0
 不明	gikq	104000000
@@ -38565,7 +37158,6 @@ encoder:
 覔	gilr	26600
 不用	gilv	152000000
 存贮	gilw	1780000
-𫀨	gilz	0
 不等	gimb	21100000
 𤘮	gimb	0
 𤯚	gimc	0
@@ -38632,7 +37224,6 @@ encoder:
 不久	girs	106000000
 存包	giry	265000
 鴀	girz	50700
-𫜢	girz	0
 不计	gise	9200000
 存亡	gish	3820000
 不高	gisj	26300000
@@ -38648,7 +37239,6 @@ encoder:
 不问	gitj	8650000
 不准	gitn	25600000
 不应	gitv	17700000
-𪨊	giud	0
 不惜	giue	16900000
 不慎	giue	2510000
 不懂	giue	66400000
@@ -38674,7 +37264,6 @@ encoder:
 不清	givc	46100000
 不满	give	30100000
 不测	givl	3120000
-𫀉	givv	0
 不觉	givw	25100000
 不宁	giwa	1980000
 不定	giwd	58800000
@@ -38700,7 +37289,6 @@ encoder:
 不予	gixx	14100000
 不屈	gixz	5150000
 不加	giyj	13700000
-𪵝	giyj	0
 不力	giym	9040000
 不及	giym	20300000
 不改	giym	8720000
@@ -38720,11 +37308,9 @@ encoder:
 不好	gizy	117000000
 孬	gizy	1550000
 𩈅	gjae	0
-𫗁	gjaf	0
 右下	gjai	3860000
 𩈔	gjaj	0
 靧	gjal	31600
-𫗄	gjal	0
 𩈖	gjax	0
 𩈎	gjaz	0
 𩈮	gjbj	0
@@ -38775,7 +37361,6 @@ encoder:
 𩈊	gjkg	0
 𩔁	gjkg	0
 𩈤	gjkj	0
-𫐏	gjkj	0
 䩍	gjkk	3950
 䩄	gjkl	3890
 靦	gjkl	1060000
@@ -38857,7 +37442,6 @@ encoder:
 面料	gjut	16700000
 面洽	gjvo	238000
 右派	gjvp	2290000
-𫗂	gjvr	0
 否定	gjwd	50800000
 𩈬	gjwi	0
 𩈭	gjwl	0
@@ -39062,10 +37646,8 @@ encoder:
 𦓕	glzm	0
 𥗴	glzn	0
 𥗿	glzn	0
-𫀙	gmac	0
 䶮	gmag	31100
 	gmag	0
-𫀭	gmal	0
 𥗁	gmbm	0
 龙井	gmbn	2710000
 聋	gmce	7740000
@@ -39112,8 +37694,6 @@ encoder:
 𥗎	gmrk	0
 礸	gmrl	52900
 𪁪	gmrz	0
-𫜥	gmrz	0
-𫀩	gmse	0
 袭	gmsr	51300000
 龙头	gmtg	28400000
 龙门	gmtl	7720000
@@ -39156,13 +37736,11 @@ encoder:
 原图	gnjr	13900000
 原野	gnkb	4380000
 原由	gnki	1960000
-𫀕	gnko	0
 原是	gnkv	6890000
 𥗰	gnlg	0
 䃇	gnli	4600
 原则	gnlk	121000000
 原罪	gnlk	3280000
-𫀟	gnlo	0
 原籍	gnmc	1720000
 原告	gnmj	5840000
 原先	gnmr	18900000
@@ -39225,7 +37803,6 @@ encoder:
 𩖏	gogg	0
 页面	gogj	416000000
 𩔊	gogo	0
-𫗪	gojk	0
 䃸	goka	4980
 𥑒	goko	0
 𥖩	golk	0
@@ -39237,7 +37814,6 @@ encoder:
 𩒈	gook	0
 礆	gooo	93500
 䪾	goop	3290
-𫗯	goop	0
 𥓻	goor	0
 䂚	goos	4920
 䂦	gopd	5120
@@ -39267,7 +37843,6 @@ encoder:
 𩑍	gozz	0
 𥕬	gpai	0
 𥒖	gpaj	0
-𫀯	gpcm	0
 䂡	gpda	5240
 𥕬	gpei	0
 碷	gpel	23600
@@ -39278,7 +37853,6 @@ encoder:
 𥕫	gpil	0
 𥗦	gpkb	0
 磻	gpki	952000
-𫀠	gplk	0
 𥓕	gpmb	0
 𥕬	gpmi	0
 𥔿	gpnb	0
@@ -39365,7 +37939,6 @@ encoder:
 𧰯	gqgz	0
 豘	gqhz	23300
 𧲋	gqig	0
-𫗫	gqig	0
 蟸	gqii	29800
 𧲒	gqii	0
 𧲟	gqii	0
@@ -39418,7 +37991,6 @@ encoder:
 𧲐	gqok	0
 有余	gqom	8450000
 𧱼	gqoo	0
-𫏁	gqoo	0
 𧱕	gqoq	0
 𧱭	gqor	0
 砜	gqos	989000
@@ -39427,7 +37999,6 @@ encoder:
 𧱢	gqow	0
 䝓	gqoz	4480
 有错	gqpe	5070000
-𫏃	gqpg	0
 有钱	gqph	34200000
 𧱻	gqpl	0
 有所	gqpv	1970000
@@ -39532,7 +38103,6 @@ encoder:
 㞆	graj	4050
 𡯽	graj	0
 尵	gral	150000
-𪨕	gral	0
 𥒛	graz	0
 𥐩	grbd	0
 𥖷	grbj	0
@@ -39560,7 +38130,6 @@ encoder:
 𡯰	grhe	0
 𢍽	grhs	0
 确切	grhy	12200000
-𪨖	grji	0
 𡰏	grjk	0
 𡰑	grjl	0
 𡰝	grjn	0
@@ -39585,7 +38154,6 @@ encoder:
 𡯪	grlc	0
 确	grld	56000000
 砾岩	grlg	161000
-𪾸	grlk	0
 确山	grll	340000
 𡰋	grln	0
 𡯞	grlo	0
@@ -39645,7 +38213,6 @@ encoder:
 𡯏	grte	0
 㞉	grub	3710
 𡯾	gruf	0
-𪨗	grun	0
 䂹	gruo	5400
 𡰠	gruq	0
 尤为	gruv	19000000
@@ -39690,7 +38257,6 @@ encoder:
 磅礴	gsge	2290000
 太不	gsgi	9780000
 太厚	gsgk	1200000
-𫀣	gsgm	0
 太原	gsgn	33900000
 太太	gsgs	20800000
 飙车	gshe	1390000
@@ -39754,7 +38320,6 @@ encoder:
 硋	gszo	62300
 䃷	gszq	4310
 磙	gszr	202000
-𫀄	gszz	0
 𥑈	gtai	0
 𥖂	gtar	0
 矿工	gtbi	4960000
@@ -39766,7 +38331,6 @@ encoder:
 矿藏	gteh	993000
 𥕒	gtek	0
 𥔷	gtel	0
-𫀢	gtff	0
 礳	gtfg	29200
 䃺	gtfk	5010
 𥗂	gtfm	0
@@ -39835,7 +38399,6 @@ encoder:
 磁针	gupe	127000
 磁盘	gupl	24300000
 磁铁	gupm	2390000
-𫀗	guqd	0
 磷肥	guqy	1350000
 𥓌	gurd	0
 磷	gurm	17700000
@@ -39905,7 +38468,6 @@ encoder:
 磲	gvxf	321000
 在即	gvxy	10100000
 在线	gvzh	1100000000
-𫀏	gwae	0
 𥕯	gwan	0
 𥕈	gwar	0
 硿	gwbi	102000
@@ -39915,12 +38477,9 @@ encoder:
 磍	gwcj	25100
 牵挂	gwdb	16200000
 牵扯	gwdi	3740000
-𫀡	gwez	0
 碗柜	gwfh	343000
 䃛	gwfk	4420
 碗碟	gwge	714000
-𫀜	gwgq	0
-𫀞	gwgq	0
 䃐	gwgs	5140
 𥓎	gwgs	0
 硡	gwgz	39400
@@ -39938,7 +38497,6 @@ encoder:
 牵制	gwml	5310000
 磓	gwmy	34800
 確	gwni	7520000
-𫀝	gwoj	0
 𥔉	gwox	0
 𥓸	gwpd	0
 𥐱	gwqd	0
@@ -39957,9 +38515,7 @@ encoder:
 牵涉	gwvi	6180000
 牵连	gwwh	3400000
 𥖶	gwxl	0
-𫀦	gwxl	0
 砨	gwyd	27200
-𫀊	gwyd	0
 牵引	gwyi	6840000
 𥔱	gwyy	0
 𥓰	gwyz	0
@@ -39980,7 +38536,6 @@ encoder:
 破损	gxdj	4440000
 𥖖	gxdy	0
 碾	gxeh	5230000
-𫀘	gxej	0
 𥔤	gxeo	0
 破获	gxeq	3700000
 破落	gxev	667000
@@ -40017,11 +38572,9 @@ encoder:
 䃤	gxnd	4760
 码位	gxns	78000
 友人	gxod	47300000
-𫀚	gxoo	0
 友邻	gxow	1130000
 友爱	gxpw	7000000
 破解	gxrl	101000000
-𫀅	gxrr	0
 䂘	gxsa	4940
 𥗲	gxsg	0
 破产	gxsm	11500000
@@ -40041,14 +38594,12 @@ encoder:
 𠬷	gxxs	0
 𥑊	gxxs	0
 碬	gxxx	31000
-𪜙	gxyd	0
 破费	gxyn	644000
 破除	gxyo	3320000
 𥗮	gxzr	0
 破绽	gxzw	4000000
 友好	gxzy	34400000
 历来	gybk	7140000
-𫀑	gyby	0
 乭	gyda	60700
 𥔊	gyhb	0
 䂥	gyhd	5220
@@ -40189,13 +38740,11 @@ encoder:
 转增	hbbu	2270000
 转动	hbbz	10400000
 臻	hbcm	7930000
-𫈆	hbcm	0
 贰拾	hbdo	257000
 转折	hbdp	5590000
 转播	hbdp	5860000
 转换	hbdr	116000000
 𦥃	hbeo	0
-𫈃	hbfj	0
 转机	hbfq	4410000
 式样	hbfu	3630000
 转存	hbgi	993000
@@ -40247,7 +38796,6 @@ encoder:
 转会	hbob	4020000
 转入	hbod	9100000
 𠤱	hbod	0
-𫈄	hboo	0
 至今	hbos	65700000
 转盘	hbpl	2650000
 转船	hbpq	56200
@@ -40274,7 +38822,6 @@ encoder:
 转运	hbwb	2390000
 转速	hbwf	7020000
 转达	hbwg	1740000
-𫈅	hbxa	0
 转录	hbxk	2440000
 𦥌	hbxk	0
 𦤽	hbxr	0
@@ -40287,16 +38834,13 @@ encoder:
 转给	hbzo	1980000
 转发	hbzv	26000000
 转嫁	hbzw	2270000
-𪥗	hcgd	0
 𩒑	hcgo	0
 賾	hclo	90200
 赜	hclo	345000
 𦣱	hclo	0
 𢼳	hcmo	0
-𪰏	hcsy	0
 匡	hcvv	6460000
 劻	hcym	83700
-𪠟	hdal	0
 七百	hdan	4010000
 七列	hdar	37800
 七万	hday	1850000
@@ -40317,11 +38861,9 @@ encoder:
 七成	hdhv	6370000
 七点	hdij	4840000
 𢻴	hdix	0
-𪜄	hdjx	0
 东	hdko	291000000
 鸫	hdkr	249000
 𧴦	hdlo	0
-𫏞	hdlq	0
 𥄽	hdls	0
 𡿱	hdmb	0
 七千	hdme	3610000
@@ -40329,7 +38871,6 @@ encoder:
 七倍	hdns	384000
 七分	hdoy	7960000
 𡴣	hdpx	0
-𪟈	hdqk	0
 七月	hdqv	34900000
 𥂉	hdrl	0
 𩾔	hdrz	0
@@ -40347,7 +38888,6 @@ encoder:
 顿	hdzg	80500000
 屯	hdzi	30300000
 旾	hdzk	28200
-𪟁	hdzk	0
 𡵭	hdzl	0
 巰	hdzn	30200
 㼊	hdzp	4730
@@ -40362,16 +38902,12 @@ encoder:
 𨐆	heae	0
 辏	heag	229000
 轲	heaj	1030000
-𫑉	heaj	0
 戒严	heak	803000
 车工	hebi	1290000
-𫐐	hebj	0
-𫑊	hebj	0
 车夫	hebo	1610000
 车长	hech	980000
 辖	hecj	8560000
 𨐉	hecx	0
-𫑐	hecx	0
 戒毒	hecz	2730000
 辄	hecz	1530000
 戒指	hedr	18800000
@@ -40387,9 +38923,7 @@ encoder:
 匿	hegj	5940000
 𨐇	hegm	0
 轿	hegn	9510000
-𫐿	hegr	0
 轭	hegy	538000
-𫑁	hegy	0
 车臣	heha	1370000
 车辆	heha	103000000
 轼	hehb	3420000
@@ -40404,49 +38938,36 @@ encoder:
 𧏾	heji	0
 辌	hejk	30900
 辐	hejk	1580000
-𫏜	hejl	0
 轵	hejo	368000
 𠥟	hejp	0
 辕	hejr	12300000
 慝	hejw	216000
-𫑓	hejw	0
 𡠷	hejz	0
 𨐈	hekg	0
 轴	heki	24000000
-𫑔	hekk	0
 辒	hekl	47000
-𫑒	heku	0
 辋	held	244000
-𫑀	hell	0
 𦣶	helo	0
-𫑂	helo	0
 𨐊	helw	0
 车手	hemd	4540000
-𫑎	hemf	0
 车程	hemj	6540000
 轶	hemo	7210000
 轷	hemu	51400
 䢀	hemy	5430
 车身	henc	9610000
-𫑈	henc	0
 匶	henn	42100
 车牌	henn	6470000
 𠥬	henn	0
-𫑋	henr	0
 车位	hens	4150000
 辁	heoc	57500
 较	heoo	241000000
 辆	heoo	57700000
 轸	heop	406000
-𫑑	heop	0
 轮	heor	98800000
-𫑄	heow	0
 堑	hepb	1510000
 斩	hepd	18700000
 椠	hepf	106000
-𫐋	hepj	0
 暂	hepk	298000000
-𪮚	hepm	0
 车铃	hepo	174000
 錾	hepp	408000
 辀	hepy	42100
@@ -40462,7 +38983,6 @@ encoder:
 辚	herm	212000
 软	hero	97500000
 辊	herr	3780000
-𫑍	hers	0
 车站	hesi	16400000
 车市	hesl	14500000
 䢂	hesu	4190
@@ -40474,19 +38994,16 @@ encoder:
 车资	hetr	201000
 辘	hetx	285000
 车灯	heua	2300000
-𫑇	heue	0
 戒烟	heuj	4700000
 车前	heuq	3380000
 车流	hevs	1740000
 车速	hewf	4330000
 车祸	hewj	12200000
 𠥖	hewl	0
-𫑌	hewy	0
 戒心	hewz	2800000
 车马	hexa	2050000
 轻	hexb	170000000
 车展	hexe	11400000
-𫑃	hexs	0
 轰	hexx	17700000
 辍	hexx	1200000
 车子	heya	23400000
@@ -40496,7 +39013,6 @@ encoder:
 车队	heyo	9510000
 轫	heys	146000
 辎	hezk	121000
-𫑏	hezl	0
 转	hezs	985000000
 辅路	hfjr	369000
 辅助	hfly	42000000
@@ -40514,11 +39030,9 @@ encoder:
 㰼	hgor	6330
 㥦	hgow	4700
 翘首	hgun	1860000
-𪟯	hhia	0
 匦	hhqy	578000
 𦣦	hhvv	0
 𦣩	hhvv	0
-𫇻	hhvv	0
 𠤲	hhzi	0
 𤘌	hiaj	0
 𠃢	hian	0
@@ -40561,7 +39075,6 @@ encoder:
 雅	hini	142000000
 𠥬	hinn	0
 𠥞	hioc	0
-𪻐	hioe	0
 𣻊	hiok	0
 𣀗	hioo	0
 䭆	hiox	3800
@@ -40583,7 +39096,6 @@ encoder:
 𢗬	hiwz	0
 𢛶	hiwz	0
 𡏃	hixb	0
-𪻏	hixg	0
 𤘎	hixi	0
 牙刷	hixl	4310000
 㸧	hixo	7010
@@ -40621,9 +39133,7 @@ encoder:
 歐	hjjr	34800000
 鷗	hjjr	1740000
 𠥹	hjjr	0
-𪠲	hjjx	0
 𠢔	hjjy	0
-𫒥	hjjy	0
 匰	hjke	114000
 或是	hjkv	74700000
 𠿦	hjmb	0
@@ -40697,7 +39207,6 @@ encoder:
 东部	hksj	17100000
 东郊	hkso	1700000
 东方	hksy	126000000
-𪰆	hkte	0
 东北	hktr	74400000
 到底	hktr	154000000
 东兰	hkub	377000
@@ -40784,16 +39293,13 @@ encoder:
 威	hmaz	114000000
 医士	hmba	207000
 𨢒	hmbf	0
-𫀴	hmbk	0
 𢎐	hmbl	0
 𥊇	hmbl	0
 𧵸	hmbl	0
 𢦶	hmbo	0
-𪱻	hmbq	0
 𣤮	hmbr	0
 黳	hmbu	32100
 𡦋	hmby	0
-𪭦	hmbz	0
 𢧔	hmco	0
 轶事	hmdj	5280000
 医护	hmdw	8810000
@@ -40821,10 +39327,8 @@ encoder:
 盞	hmhl	3080000
 𧶤	hmhl	0
 戔	hmhm	533000
-𫇼	hmhm	0
 𣂧	hmhp	0
 𢧓	hmhy	0
-𫒞	hmhy	0
 𡒥	hmia	0
 𢨜	hmii	0
 𧕹	hmii	0
@@ -40867,7 +39371,6 @@ encoder:
 划	hmkd	178000000
 刬	hmkd	76300
 顣	hmkg	530000
-𫗼	hmkg	0
 𢦦	hmki	0
 𤰭	hmki	0
 𧐶	hmki	0
@@ -40893,10 +39396,8 @@ encoder:
 𤀩	hmlk	0
 𥁘	hmlk	0
 𥁫	hmlk	0
-𪭣	hmlk	0
 覽	hmll	42300000
 𥃆	hmll	0
-𪭨	hmll	0
 㲯	hmlm	3970
 擥	hmlm	59700
 𣱄	hmlm	0
@@ -40907,10 +39408,8 @@ encoder:
 譼	hmls	9710
 𥽏	hmlu	0
 𨞐	hmly	0
-𪧍	hmly	0
 医生	hmmc	59800000
 𢦩	hmme	0
-𪭥	hmmk	0
 𥃉	hmml	0
 𢦕	hmmq	0
 致辞	hmms	11500000
@@ -40918,7 +39417,6 @@ encoder:
 致使	hmna	18500000
 𨾓	hmni	0
 𢧩	hmnj	0
-𪭥	hmnk	0
 致命	hmoa	23300000
 医德	hmoe	1210000
 𣠿	hmof	0
@@ -40930,7 +39428,6 @@ encoder:
 𢦲	hmpd	0
 𣫫	hmpp	0
 𢦞	hmpv	0
-𪭧	hmpy	0
 㙠	hmqb	4730
 瑿	hmqc	39900
 𩥯	hmqc	0
@@ -41003,9 +39500,7 @@ encoder:
 𠤷	hmyi	0
 𢦽	hmyj	0
 盛	hmyl	90500000
-𪩀	hmyl	0
 致力	hmym	33400000
-𪭡	hmym	0
 𪁋	hmyr	0
 㼩	hmys	4380
 㽉	hmys	4060
@@ -41029,7 +39524,6 @@ encoder:
 𣤭	hmzr	0
 𩿰	hmzr	0
 𨜠	hmzy	0
-𫒙	hmzy	0
 𢦙	hmzz	0
 𢦻	hmzz	0
 𠥉	hned	0
@@ -41041,7 +39535,6 @@ encoder:
 𠥥	hnni	0
 㔱	hnod	10600
 𠥑	hnrf	0
-𪟲	hnrj	0
 雅座	hnto	714000
 𦣳	hnuo	0
 雅兴	hnva	877000
@@ -41063,7 +39556,6 @@ encoder:
 区码	hogx	722000
 轮辐	hoha	127000
 轮式	hohb	1230000
-𫇾	hohi	0
 轮轴	hohk	428000
 𧇬	hoih	0
 区别	hojy	55500000
@@ -41117,7 +39609,6 @@ encoder:
 轮子	hoya	2500000
 𦣡	hoyd	0
 欧阳	hoyk	10400000
-𪟰	hoyo	0
 瓯	hoys	5380000
 𠤰	hozs	0
 欧姆	hozz	3030000
@@ -41139,11 +39630,9 @@ encoder:
 斩首	hpun	1670000
 暂定	hpwd	2510000
 𠥃	hpyl	0
-𪦜	hpzm	0
 暂缓	hpzp	2670000
 䝂	hqju	4610
 𧷙	hqlo	0
-𪟮	hqvv	0
 轨迹	hqws	21700000
 轨道	hqwu	30700000
 𣄰	hraj	0
@@ -41165,7 +39654,6 @@ encoder:
 䫬	hrkg	3420
 㔆	hrkk	5090
 𣄷	hrkk	0
-𪯱	hrkm	0
 𩀿	hrkn	0
 𪅽	hrkr	0
 䣟	hrky	3270
@@ -41180,7 +39668,6 @@ encoder:
 鸦片	hrnx	3020000
 匢	hrod	63000
 𣄭	hrod	0
-𫇺	hrod	0
 匫	hrok	29100
 软盘	hrpl	10900000
 软肋	hrqy	2410000
@@ -41211,7 +39698,6 @@ encoder:
 貳	hsbl	2860000
 贰	hsbl	3950000
 𥁦	hsbl	0
-𪟴	hsbl	0
 𪀦	hsbr	0
 𪉅	hsbr	0
 𠤶	hsbz	0
@@ -41235,7 +39721,6 @@ encoder:
 隿	hsni	24000
 𨾍	hsni	0
 较低	hsnr	20500000
-𫇽	hsoe	0
 𢎂	hsoo	0
 𢎏	hsoo	0
 䬥	hsox	4210
@@ -41271,7 +39756,6 @@ encoder:
 𧏆	htei	0
 𦨃	huac	0
 𠥙	hufd	0
-𪟳	hufj	0
 𢽇	hugm	0
 𠥛	huho	0
 𧡼	hulr	0
@@ -41355,7 +39839,6 @@ encoder:
 𢀭	hxeq	0
 轻薄	hxev	7250000
 轻飘	hxfb	751000
-𪩺	hxff	0
 轻松	hxfo	141000000
 巨大	hxgd	98700000
 辗转	hxhb	6130000
@@ -41393,22 +39876,18 @@ encoder:
 轻信	hxns	5210000
 轻佻	hxnv	1450000
 巨人	hxod	19500000
-𪩽	hxog	0
 䵖	hxok	4200
 轻微	hxol	11700000
 𦜜	hxoo	0
-𪩾	hxor	0
 𩜬	hxox	0
 轻钢	hxpl	828000
 轻铁	hxpm	69300
 轰然	hxrg	3240000
-𪩸	hxrk	0
 𢀲	hxrl	0
 𢀱	hxrm	0
 𩿝	hxrz	0
 轻言	hxsa	1910000
 㻨	hxsc	4580
-𪩹	hxsj	0
 竪	hxsu	495000
 轻率	hxsv	1520000
 巨变	hxsx	5160000
@@ -41416,7 +39895,6 @@ encoder:
 巨头	hxtg	17200000
 巨资	hxtr	6610000
 巨鹿	hxtx	681000
-𪩽	hxug	0
 轰炸	hxum	5480000
 㷂	hxuo	5960
 轻快	hxux	3860000
@@ -41521,7 +39999,6 @@ encoder:
 𧌀	iagj	0
 𩙤	iagq	0
 𩺁	iagr	0
-𪜉	iahd	0
 卡车	iahe	7060000
 𢅓	iahl	0
 𥋚	iahl	0
@@ -41552,11 +40029,9 @@ encoder:
 𠟗	iajk	0
 螎	iajl	22000
 𧁌	iajo	0
-𫋮	iajo	0
 𧄼	iaju	0
 𨞯	iajy	0
 凸显	iakk	6900000
-𫌑	iakk	0
 𧋑	iako	0
 𣤬	iakr	0
 𧏲	iaku	0
@@ -41630,7 +40105,6 @@ encoder:
 𣤾	iaxr	0
 𪇡	iaxr	0
 卡尺	iaxs	431000
-𫋽	iaxz	0
 凸	iaya	27000000
 虫子	iaya	10600000
 𥌱	iayh	0
@@ -41650,20 +40124,16 @@ encoder:
 𧊌	ibaz	0
 蟯	ibbg	412000
 𧑱	ibbj	0
-𫌡	ibcx	0
-𫋰	ibds	0
 𡐪	ibeb	0
 𧓜	ibgf	0
 㒫	ibgr	4310
 𧑰	ibhl	0
 𧑅	ibhz	0
 虹口	ibja	7170000
-𫌟	ibjd	0
 𧒗	ibjj	0
 虹吸	ibjy	514000
 𧉿	ibko	0
 𧔖	ibll	0
-𫌋	iblo	0
 𥎨	ibma	0
 𧐻	ibni	0
 𧋒	ibno	0
@@ -41683,7 +40153,6 @@ encoder:
 蟛	ibup	209000
 蟽	ibuw	28700
 蛙泳	ibvs	519000
-𫋠	ibvv	0
 𧋺	ibwz	0
 𧑕	ibwz	0
 𧋋	ibxj	0
@@ -41708,7 +40177,6 @@ encoder:
 螓	icmf	922000
 𧐍	icnb	0
 𧑜	icrr	0
-𫌌	icuc	0
 蚟	icvv	52300
 𩰋	icvv	0
 𧒓	icwm	0
@@ -41737,7 +40205,6 @@ encoder:
 忐	idaw	4520000
 𢤰	idaw	0
 𠧕	idax	0
-𪥭	idaz	0
 𧎋	idbd	0
 𢧍	idbh	0
 𢧡	idbh	0
@@ -41755,7 +40222,6 @@ encoder:
 𪉼	idcx	0
 𪉴	idef	0
 㦸	ideh	4580
-𪠂	idei	0
 𣧮	idej	0
 𨿧	iden	0
 𢒛	idep	0
@@ -41833,7 +40299,6 @@ encoder:
 𪀄	idjr	0
 点	idju	1190000000
 𪉣	idju	0
-𫝍	idju	0
 㤐	idjw	4820
 迠	idjw	49900
 𪊄	idjw	0
@@ -41843,7 +40308,6 @@ encoder:
 𧮸	idjx	0
 𠛤	idjy	0
 𨟩	idjy	0
-𪟄	idjy	0
 乩	idjz	887000
 䪥	idka	3810
 韰	idka	53000
@@ -41859,7 +40323,6 @@ encoder:
 𪉨	idkk	0
 𢂦	idkl	0
 𧠪	idkl	0
-𫝐	idkl	0
 𢒦	idkp	0
 𢒭	idkp	0
 䴛	idkq	3710
@@ -41871,7 +40334,6 @@ encoder:
 𣩻	idkr	0
 𪀖	idkr	0
 𪊉	idkr	0
-𫜭	idkr	0
 𢙤	idkw	0
 𢤕	idkw	0
 叔	idkx	16900000
@@ -41885,7 +40347,6 @@ encoder:
 𣦵	idld	0
 𥹟	idld	0
 𠨇	idlf	0
-𫗦	idlg	0
 卨	idlj	61700
 盀	idlk	34900
 𠛯	idlk	0
@@ -41928,7 +40389,6 @@ encoder:
 𠦲	idme	0
 𣗴	idmf	0
 𣧕	idmg	0
-𫋯	idmh	0
 𥌟	idml	0
 𪊀	idml	0
 𪊇	idml	0
@@ -41938,7 +40398,6 @@ encoder:
 𧌕	idmy	0
 𠚝	idmz	0
 𪉥	idmz	0
-𫁵	idmz	0
 𠧇	idne	0
 𨾇	idni	0
 𡌓	idob	0
@@ -42015,7 +40474,6 @@ encoder:
 𣩕	idrr	0
 歺	idrs	172000
 𠣳	idrs	0
-𪤿	idrs	0
 𠧽	idru	0
 𤈭	idru	0
 𦍲	idru	0
@@ -42051,7 +40509,6 @@ encoder:
 𥹄	idwp	0
 肻	idwq	32100
 𪉛	idwq	0
-𫇫	idwq	0
 壑	idxb	2830000
 壡	idxb	25200
 𡋹	idxb	0
@@ -42080,7 +40537,6 @@ encoder:
 𥉆	idxl	0
 𥌄	idxl	0
 𧷧	idxl	0
-𪾽	idxl	0
 卢	idxm	32200000
 餐	idxo	84500000
 𩜨	idxo	0
@@ -42133,12 +40589,10 @@ encoder:
 𧋪	iead	0
 蠓	ieag	253000
 𧋞	ieag	0
-𫌎	ieaj	0
 𧔠	ieaz	0
 𧓥	iebz	0
 𧑑	iecb	0
 𧎣	iece	0
-𫌖	iecq	0
 𧑍	ieeb	0
 蠎	ieee	150000
 蟦	ieel	31700
@@ -42196,7 +40650,6 @@ encoder:
 螮	iewl	35700
 𧋢	iewy	0
 𧎳	iewz	0
-𪠃	iexb	0
 蠨	iexn	19300
 蚑	iexs	47700
 𧋫	ieya	0
@@ -42249,7 +40702,6 @@ encoder:
 蟟	igkk	27500
 𧌄	igkz	0
 𧉩	igli	0
-𫌆	iglk	0
 蠣	iglz	263000
 𧔝	igmi	0
 螈	ignk	319000
@@ -42300,7 +40752,6 @@ encoder:
 𧇊	ihbz	0
 𧇏	ihbz	0
 𧈃	ihbz	0
-𫋛	ihci	0
 𧷤	ihcl	0
 𧇶	ihco	0
 𩤌	ihcu	0
@@ -42424,7 +40875,6 @@ encoder:
 㔧	ihly	4600
 䣜	ihly	3560
 𧆮	ihlz	0
-𫋚	ihmb	0
 𧆠	ihmd	0
 𧇮	ihmj	0
 𧓦	ihml	0
@@ -42441,7 +40891,6 @@ encoder:
 𢨘	ihnh	0
 雐	ihni	17600
 𧆽	ihnk	0
-𫋜	ihnl	0
 𧇚	ihnn	0
 𧈄	ihnr	0
 𪇦	ihnr	0
@@ -42496,7 +40945,6 @@ encoder:
 齾	ihsi	26500
 𪚊	ihsi	0
 㓺	ihsk	4180
-𫋝	ihsn	0
 虔	ihso	1940000
 𧇻	ihso	0
 𧇠	ihsq	0
@@ -42526,13 +40974,10 @@ encoder:
 䖛	ihwz	3450
 虑	ihwz	9960000
 𧆹	ihwz	0
-𫋙	ihxb	0
 𧆿	ihxl	0
-𫌚	ihxl	0
 𧇹	ihxm	0
 𧆛	ihxs	0
 𧆰	ihya	0
-𫋢	ihyd	0
 𢧝	ihyh	0
 虏	ihym	3810000
 甗	ihys	66300
@@ -42573,7 +41018,6 @@ encoder:
 歭	iibd	78900
 𣦙	iibi	0
 𥘣	iibk	0
-𪵘	iibk	0
 𧢏	iibl	0
 𣦈	iibm	0
 𣥞	iibn	0
@@ -42598,8 +41042,6 @@ encoder:
 㱗	iigs	4060
 𧖃	iigs	0
 𧭹	iigs	0
-𫎋	iigs	0
-𪵞	iihh	0
 歫	iihx	24900
 𣥌	iiia	0
 蝆	iiib	23100
@@ -42656,7 +41098,6 @@ encoder:
 𦡖	iikq	0
 𣤠	iikr	0
 𣦇	iikr	0
-𫜊	iikr	0
 𤉭	iiku	0
 𤎵	iiku	0
 𧓻	iikw	0
@@ -42752,7 +41193,6 @@ encoder:
 𣥅	iirr	0
 𣥻	iirr	0
 𪉈	iirr	0
-𫛜	iirr	0
 㱑	iirs	4200
 訾	iirs	802000
 𤇬	iiru	0
@@ -42774,16 +41214,13 @@ encoder:
 𢧼	iiwb	0
 𣦅	iiwb	0
 㱕	iiwl	3590
-𪵚	iiwm	0
 𡎙	iixb	0
 𣦠	iixb	0
 𣥣	iixi	0
 𪘚	iixj	0
 𣥸	iixl	0
 𧓩	iixl	0
-𪵙	iixl	0
 𤚜	iixm	0
-𫋩	iixm	0
 𣥦	iixo	0
 𣦲	iixs	0
 𣦳	iixs	0
@@ -42878,7 +41315,6 @@ encoder:
 战况	ijtj	2010000
 点将	ijtr	2050000
 点灯	ijua	4810000
-𫌕	ijud	0
 战火	ijuo	12700000
 点火	ijuo	6280000
 战前	ijuq	3240000
@@ -42892,7 +41328,6 @@ encoder:
 点子	ijya	9630000
 点阵	ijyh	1720000
 𧋾	ijyi	0
-𫋸	ijyk	0
 𧊅	ijym	0
 战绩	ijzc	7150000
 占线	ijzh	853000
@@ -42917,7 +41352,6 @@ encoder:
 虚夸	ikgb	164000
 桌面	ikgj	63900000
 卓有	ikgq	380000
-𫋱	ikgr	0
 旧历	ikgy	403000
 旧式	ikhb	1690000
 旧车	ikhe	2790000
@@ -42933,7 +41367,6 @@ encoder:
 蟷	ikjk	145000
 𧑊	ikjk	0
 蟐	ikjl	31600
-𫌛	ikju	0
 𧕫	ikkb	0
 蛐	ikkd	270000
 𧓅	ikkg	0
@@ -42960,7 +41393,6 @@ encoder:
 频段	iknc	3990000
 𣇑	iknc	0
 步伐	iknh	27900000
-𫌒	ikni	0
 虚像	iknr	756000
 虚伪	iknu	8990000
 虚假	iknx	26800000
@@ -43027,7 +41459,6 @@ encoder:
 贞操	ildj	2440000
 𧌎	ileo	0
 贞节	iley	715000
-𫋧	ilgd	0
 𧔇	ilgg	0
 𧍒	ilgl	0
 𧏱	ilgl	0
@@ -43055,7 +41486,6 @@ encoder:
 蜆	ilra	1240000
 𧏢	ilrc	0
 蠋	ilri	115000
-𫌤	ilru	0
 𧑵	ilrz	0
 䘃	ilub	4940
 𧊁	ilvv	0
@@ -43068,7 +41498,6 @@ encoder:
 𧌯	imeb	0
 蟱	imeu	22100
 𧊦	imez	0
-𫋳	imgn	0
 虴	imhd	124000
 蛾	imhm	9020000
 䘊	imhs	4230
@@ -43099,7 +41528,6 @@ encoder:
 𧐹	imrr	0
 𣱱	imtd	0
 蝌	imte	238000
-𫋪	imua	0
 𧎐	imuo	0
 𧒸	imuw	0
 𧎯	imxg	0
@@ -43122,7 +41550,6 @@ encoder:
 𧐃	ingd	0
 螑	ings	20100
 蟘	inhl	24600
-𫌇	inhl	0
 蚮	inhs	27900
 蝗虫	inia	1090000
 𧓈	iniy	0
@@ -43163,7 +41590,6 @@ encoder:
 𪘁	ioaj	0
 𪘇	ioaj	0
 蜦	ioal	35100
-𫝫	ioaq	0
 𪗹	iobb	0
 𪘬	iobb	0
 𪗺	iobd	0
@@ -43171,9 +41597,7 @@ encoder:
 𪗾	iobj	0
 𪗞	iobn	0
 齶	iobz	59600
-𫋴	iobz	0
 𪙏	iocj	0
-𫝵	iocj	0
 䶦	iocl	4100
 䶫	iocm	3660
 齱	iocx	32400
@@ -43184,15 +41608,12 @@ encoder:
 𪗕	ioed	0
 𪙕	ioeh	0
 齰	ioek	37700
-𫝲	ioek	0
 𪙳	ioel	0
 䶪	ioen	3980
 𪘾	ioen	0
 齛	ioez	54600
 𪘠	iofa	0
 齽	iofb	29200
-𫝬	iofb	0
-𫝱	iofb	0
 𧒆	iofd	0
 𪙍	iofd	0
 𪚂	iofd	0
@@ -43264,7 +41685,6 @@ encoder:
 𪘹	iokr	0
 𪙰	iokr	0
 𪙅	iokx	0
-𫝭	iola	0
 齟	iolc	183000
 龃	iolc	460000
 𪘍	iold	0
@@ -43284,7 +41704,6 @@ encoder:
 齵	iolz	45600
 𪙥	iolz	0
 𪙺	iolz	0
-𫝏	iolz	0
 蜍	iomf	113000
 𪗮	iomf	0
 𪘐	iomh	0
@@ -43297,7 +41716,6 @@ encoder:
 𪘾	iomn	0
 𪗫	iomo	0
 齴	iomp	30700
-𫝴	iomp	0
 齕	iomy	48500
 龁	iomy	63100
 𪗟	iomy	0
@@ -43321,7 +41739,6 @@ encoder:
 䶨	iooo	4260
 齩	iooo	23300
 𪘨	iooo	0
-𫝰	iooo	0
 䗄	ioop	3400
 𪙆	iooq	0
 蝬	ioor	600000
@@ -43403,7 +41820,6 @@ encoder:
 齦	ioxo	110000
 龈	ioxo	1290000
 齭	ioxp	27200
-𫝳	ioxp	0
 𪙩	ioxq	0
 蚡	ioyd	108000
 䶔	ioyi	3730
@@ -43411,8 +41827,6 @@ encoder:
 齠	ioyj	67000
 龆	ioyj	231000
 螉	ioyy	26400
-𫌙	ioyy	0
-𫋺	ioze	0
 齝	iozj	35900
 齥	iozm	25100
 𪗯	iozr	0
@@ -43435,14 +41849,12 @@ encoder:
 蚯蚓	ipiy	3770000
 𧕥	ipkg	0
 蟠	ipki	3510000
-𫌗	ipld	0
 𧐎	iplr	0
 𧕉	ipoj	0
 𧓳	ippl	0
 𧓙	ipqf	0
 𧏘	ipqx	0
 䖰	iprh	3680
-𫌁	ipvv	0
 𧓁	ipwr	0
 𧌅	ipwx	0
 蟋	ipwz	445000
@@ -43483,7 +41895,6 @@ encoder:
 雌雄	irgz	2210000
 餐车	irhe	399000
 此致	irhm	1530000
-𫋫	irid	0
 餐桌	irik	10900000
 𧓾	irix	0
 蟓	irjg	114000
@@ -43550,9 +41961,7 @@ encoder:
 蠩	isbm	27900
 蚁王	isca	77100
 𧏃	iscg	0
-𫋼	ised	0
 蠰	iser	39000
-𫌣	isfl	0
 𧌬	isjk	0
 𧎸	isjl	0
 𧐛	isjr	0
@@ -43604,7 +42013,6 @@ encoder:
 𧕳	isyu	0
 蚊媒	isze	20600
 蟀	isze	1480000
-𫌏	isze	0
 𧏷	iszk	0
 𧊷	iszm	0
 𧌃	iszm	0
@@ -43621,7 +42029,6 @@ encoder:
 𧓼	iteu	0
 䗫	itff	3550
 𧍈	itij	0
-𫌢	itko	0
 螏	itma	22200
 𧕄	itnw	0
 𧒐	itob	0
@@ -43656,7 +42063,6 @@ encoder:
 𧑹	iukk	0
 䗒	iuku	3390
 蟻	iumh	4780000
-𫌉	iunl	0
 蜕化	iunr	403000
 螠	iuol	34600
 𧓲	iuox	0
@@ -43670,7 +42076,6 @@ encoder:
 䗊	iuuo	3530
 𧕊	iuux	0
 蠑	iuwf	145000
-𫌠	iuwq	0
 𧓌	iuwu	0
 蟧	iuwy	28900
 𧏮	iuwz	0
@@ -43786,7 +42191,6 @@ encoder:
 𧎊	iwfk	0
 𧐖	iwfk	0
 𧏿	iwgq	0
-𫌐	iwgq	0
 蜧	iwgs	20300
 𧎛	iwgs	0
 螲	iwhb	27700
@@ -43817,18 +42221,15 @@ encoder:
 𧏴	iwnx	0
 𧔚	iwny	0
 𧑚	iwot	0
-𫌀	iwpd	0
 𧏖	iwpo	0
 䗦	iwrc	3650
 𧉡	iwrd	0
-𫌈	iwrj	0
 蛇	iwrr	39500000
 𧊼	iwrt	0
 𧓺	iwru	0
 蜿	iwry	5230000
 𧒫	iwsl	0
 螟	iwso	1730000
-𫌃	iwsy	0
 𧒠	iwul	0
 𧒴	iwun	0
 䗏	iwux	3090
@@ -43837,7 +42238,6 @@ encoder:
 𧐺	iwxl	0
 𧓍	iwxl	0
 螁	iwxo	43100
-𫌝	iwxu	0
 𧉵	iwyd	0
 𧎥	iwyy	0
 𧍜	ixag	0
@@ -43845,7 +42245,6 @@ encoder:
 𧐇	ixbd	0
 𠁲	ixbn	0
 𧖆	ixbu	0
-𫋶	ixds	0
 䖡	ixed	3670
 蜛	ixej	27400
 𧕗	ixfl	0
@@ -43921,7 +42320,6 @@ encoder:
 𧊱	iymf	0
 蜒	iymi	8920000
 𧌡	iymi	0
-𫋤	iyms	0
 𧎤	iymz	0
 𧉸	iynd	0
 𧑈	iynl	0
@@ -43939,7 +42337,6 @@ encoder:
 蛡	iyyt	19200
 蛠	iyyy	23600
 𢍭	iyze	0
-𫌔	iyzi	0
 𧏬	izai	0
 𧏂	izbg	0
 𧉳	izbi	0
@@ -43948,7 +42345,6 @@ encoder:
 蟣	izho	31900
 𧕂	izka	0
 𧑀	izkf	0
-𫌓	izki	0
 𧑳	izku	0
 𧌍	izkv	0
 𧖖	izll	0
@@ -43965,7 +42361,6 @@ encoder:
 𧎒	izrs	0
 虬	izvv	1390000
 𧈞	izvv	0
-𫋵	izvv	0
 𧑾	izyy	0
 䘎	izyz	3930
 𧔉	izzf	0
@@ -43989,7 +42384,6 @@ encoder:
 𡂍	jagl	0
 𠽒	jago	0
 呒	jagr	437000
-𫜄	jagr	0
 㖭	jagu	6100
 号码	jagx	194000000
 𠳒	jaia	0
@@ -44021,7 +42415,6 @@ encoder:
 叮嘱	jajx	4370000
 𠸅	jajx	0
 𠿓	jaka	0
-𪢝	jaka	0
 𨤥	jakb	0
 𠵗	jakg	0
 哽	jako	1750000
@@ -44029,7 +42422,6 @@ encoder:
 𠺅	jaku	0
 口水	jakv	26600000
 叮当	jakx	5730000
-𫒡	jaky	0
 𠵾	jakz	0
 𠱻	jalb	0
 𣚧	jalf	0
@@ -44090,7 +42482,6 @@ encoder:
 號	jazi	217000000
 𢿙	jazm	0
 𣭖	jazm	0
-𪠾	jazn	0
 飸	jazo	41000
 𣪆	jazq	0
 鴞	jazr	131000
@@ -44133,10 +42524,8 @@ encoder:
 𡀁	jbjj	0
 唖	jbjk	321000
 哮喘	jbjl	9480000
-𪢝	jbjl	0
 𠹣	jbjm	0
 𠵪	jbjo	0
-𪡯	jbjr	0
 噎	jbju	3760000
 𠷸	jbju	0
 𡃨	jbjw	0
@@ -44144,7 +42533,6 @@ encoder:
 咺	jbka	80000
 𠹺	jbkb	0
 𡁲	jbki	0
-𪡾	jbkl	0
 味	jbko	156000000
 𡁻	jbkq	0
 𠳃	jbkv	0
@@ -44164,7 +42552,6 @@ encoder:
 𠚎	jbnz	0
 𠵕	jbob	0
 呋	jbod	538000
-𪠹	jbod	0
 𠾱	jbok	0
 𡂐	jbol	0
 𠻲	jbom	0
@@ -44174,7 +42561,6 @@ encoder:
 𡄇	jbqg	0
 𠽃	jbqs	0
 𠺱	jbqw	0
-𪵫	jbqx	0
 𠵕	jbrb	0
 味儿	jbrd	2920000
 𠰂	jbrd	0
@@ -44183,7 +42569,6 @@ encoder:
 𠲊	jbrs	0
 吐痰	jbtu	1490000
 啈	jbub	66000
-𪡖	jbub	0
 味精	jbuc	3850000
 𠾢	jbud	0
 嘻	jbuj	41900000
@@ -44226,7 +42611,6 @@ encoder:
 𠸫	jcag	0
 国歌	jcaj	3520000
 国画	jcak	13700000
-𪢫	jcaw	0
 𠻠	jcax	0
 国土	jcba	40600000
 唪	jcbi	88000
@@ -44256,7 +42640,6 @@ encoder:
 𡁉	jcji	0
 𡁢	jcjl	0
 𡆌	jcjl	0
-𪢒	jcjm	0
 𡂣	jcjn	0
 国别	jcjy	4640000
 国界	jcko	3360000
@@ -44270,10 +42653,8 @@ encoder:
 国籍	jcmc	16100000
 嗪	jcmf	1860000
 国策	jcmf	8430000
-𪡵	jcmh	0
 𠺾	jcmk	0
 嚽	jcml	38800
-𪢙	jcml	0
 国税	jcmu	12600000
 㗦	jcmy	4070
 𠽅	jcnb	0
@@ -44351,9 +42732,7 @@ encoder:
 爴	jdap	29200
 𣂽	jdap	0
 𡇕	jdar	0
-𫜖	jdar	0
 𢠝	jdaw	0
-𪡉	jdax	0
 𡆭	jday	0
 𡆽	jdaz	0
 𡇭	jdaz	0
@@ -44382,7 +42761,6 @@ encoder:
 国	jdcs	526000000
 𡈊	jdcu	0
 团聚	jdcx	4690000
-𪢞	jdcx	0
 因素	jdcz	96300000
 𡇦	jdcz	0
 团	jddm	220000000
@@ -44392,7 +42770,6 @@ encoder:
 固	jdej	73700000
 𡇣	jdej	0
 𡈌	jdel	0
-𪢳	jdel	0
 𠴜	jdex	0
 𡇐	jdfa	0
 圃	jdfb	4900000
@@ -44404,9 +42781,7 @@ encoder:
 𩒱	jdfg	0
 𡇯	jdfj	0
 𠜠	jdfk	0
-𪢯	jdfk	0
 团校	jdfs	713000
-𪢭	jdga	0
 𡒀	jdgb	0
 𡈔	jdgg	0
 𠺲	jdgh	0
@@ -44424,7 +42799,6 @@ encoder:
 慁	jdgw	36700
 因式	jdhb	445000
 𡇓	jdhb	0
-𪢉	jdhb	0
 𡈑	jdhh	0
 囤	jdhz	3900000
 𡆥	jdid	0
@@ -44445,7 +42819,6 @@ encoder:
 圗	jdjk	71300
 圙	jdjk	39500
 𡇿	jdjk	0
-𪟖	jdjk	0
 团员	jdjl	8060000
 圆	jdjl	90600000
 圓	jdjl	24000000
@@ -44502,7 +42875,6 @@ encoder:
 𡈝	jdlp	0
 𡈪	jdlp	0
 朙	jdlq	410000
-𪢴	jdlq	0
 圐	jdls	48600
 𢚊	jdlw	0
 𡈟	jdlx	0
@@ -44574,20 +42946,17 @@ encoder:
 𡇙	jdqf	0
 𥂗	jdql	0
 𪆌	jdqr	0
-𪠽	jdqs	0
 𢜹	jdqw	0
 𢝕	jdqw	0
 𠲴	jdqx	0
 𡇀	jdqx	0
 𠴋	jdqy	0
-𪠽	jdqy	0
 𠁤	jdrd	0
 𡆿	jdrh	0
 𡇾	jdrj	0
 囫	jdro	174000
 欭	jdro	30300
 𡇘	jdrr	0
-𪢰	jdrr	0
 𡇹	jdrs	0
 图	jdrt	941000000
 𡈡	jdrt	0
@@ -44598,12 +42967,10 @@ encoder:
 𡀴	jdrz	0
 𡈎	jdrz	0
 𡈙	jdrz	0
-𪢲	jdsf	0
 𡆲	jdsh	0
 团部	jdsj	311000
 𠟑	jdsk	0
 团旗	jdsm	491000
-𪢬	jdso	0
 囥	jdsq	690000
 𡈂	jdsr	0
 𡈃	jdsr	0
@@ -44611,17 +42978,14 @@ encoder:
 啦	jdsu	516000000
 𡇅	jdsy	0
 𡇁	jdsz	0
-𪡼	jdsz	0
 唞	jdte	36100
 𡈳	jdtm	0
 図	jdto	41100000
 𡇸	jdtr	0
 𡈷	jdtz	0
-𪢮	jduc	0
 𡇒	jduf	0
 𡇬	jdui	0
 𡈚	jduk	0
-𪢱	jduk	0
 𡈕	jdul	0
 図	jduo	41100000
 𡇂	jduo	0
@@ -44690,7 +43054,6 @@ encoder:
 𡇟	jdzz	0
 𡈫	jdzz	0
 𠿨	jeae	0
-𪡊	jeae	0
 𡁏	jeag	0
 𡄷	jeai	0
 嗒	jeaj	2420000
@@ -44721,7 +43084,6 @@ encoder:
 鄙薄	jeev	263000
 𠽢	jefd	0
 囒	jefl	65700
-𪢤	jefl	0
 喷雾	jefr	6310000
 𠶙	jegi	0
 叶面	jegj	1220000
@@ -44813,11 +43175,9 @@ encoder:
 𠶋	jeon	0
 𡅧	jeon	0
 𡂕	jeop	0
-𫜝	jeor	0
 哎	jeos	40000000
 𠹅	jeou	0
 𠸖	jeow	0
-𪡡	jeoy	0
 嘶	jepd	9790000
 固镇	jepe	789000
 𠼼	jepy	0
@@ -44915,7 +43275,6 @@ encoder:
 𡆀	jfff	0
 𡃎	jffg	0
 呆板	jffp	2420000
-𪢋	jffw	0
 𠼖	jffz	0
 嚅	jfgl	1630000
 困惑	jfhj	22200000
@@ -44966,7 +43325,6 @@ encoder:
 哺乳	jfpy	7110000
 𡀑	jfpy	0
 𠺝	jfrj	0
-𪢔	jfrl	0
 𠿙	jfry	0
 𪁣	jfrz	0
 𠵉	jfsq	0
@@ -44985,7 +43343,6 @@ encoder:
 呆子	jfya	1700000
 𡂆	jfyk	0
 𡃤	jfyl	0
-𪡱	jfyy	0
 喓	jfzm	1080000
 𠻇	jfzm	0
 𠿊	jfzq	0
@@ -45048,7 +43405,6 @@ encoder:
 喐	jgqy	377000
 𡁷	jgrd	0
 𠺳	jgrk	0
-𪳳	jgsf	0
 𡅃	jgsi	0
 嘹亮	jgsj	1690000
 𡄛	jgsj	0
@@ -45088,7 +43444,6 @@ encoder:
 𠲮	jhbi	0
 𠽬	jhbl	0
 𠸴	jhbo	0
-𪠶	jhed	0
 喊醒	jhfk	238000
 𠲦	jhgd	0
 𠽋	jhgj	0
@@ -45105,7 +43460,6 @@ encoder:
 𠿑	jhjw	0
 喊叫	jhjz	3100000
 𠴼	jhkd	0
-𪡇	jhki	0
 𡄱	jhkj	0
 𡂔	jhkw	0
 𠸯	jhkz	0
@@ -45124,7 +43478,6 @@ encoder:
 𠯕	jhrd	0
 噆	jhrk	30900
 𢙸	jhrw	0
-𪠾	jhsn	0
 距离	jhso	83000000
 𠱸	jhvv	0
 𠲬	jhvv	0
@@ -45141,7 +43494,6 @@ encoder:
 啭	jhzs	489000
 	jiaa	0
 𧾷	jiaa	0
-𫐡	jiab	0
 𨃅	jiac	0
 忠于	jiad	4580000
 趶	jiad	29100
@@ -45188,15 +43540,12 @@ encoder:
 𥅌	jial	0
 𨆨	jial	0
 𨇙	jial	0
-𫐤	jial	0
 蹜	jian	36500
 𧿄	jian	0
 𠁵	jiao	0
 𨂳	jiao	0
 𧿊	jiaq	0
 𨇋	jiaq	0
-𫐉	jiar	0
-𪜊	jiau	0
 𨁊	jiax	0
 𨆖	jiax	0
 𠯡	jiay	0
@@ -45224,7 +43573,6 @@ encoder:
 𨅡	jibj	0
 𨅧	jibj	0
 跊	jibk	20300
-𫐇	jibk	0
 𨇛	jibl	0
 踷	jibm	18600
 䟚	jibn	3330
@@ -45239,12 +43587,10 @@ encoder:
 𨀿	jibr	0
 𨁚	jibr	0
 𨂟	jibr	0
-𫐎	jibr	0
 躂	jibu	353000
 𨂧	jibu	0
 𨅟	jibu	0
 𨆅	jibu	0
-𫏼	jibu	0
 嘘声	jibx	890000
 踍	jiby	20900
 踺	jiby	102000
@@ -45260,13 +43606,11 @@ encoder:
 𨃖	jibz	0
 𨅫	jibz	0
 𨇞	jibz	0
-𫐠	jibz	0
 躡	jicc	132000
 足球	jicd	118000000
 踌	jicd	331000
 𨁦	jice	0
 䠆	jich	5310
-𫏾	jich	0
 𧿣	jici	0
 𨀤	jick	0
 蹟	jicl	1260000
@@ -45274,8 +43618,6 @@ encoder:
 蹖	jicn	42000
 踳	jico	48400
 𨆱	jicq	0
-𫐊	jicq	0
-𫐒	jicq	0
 𧿷	jics	0
 踙	jicx	24500
 𨀱	jicx	0
@@ -45287,7 +43629,6 @@ encoder:
 𨃁	jidm	0
 䟷	jidp	3410
 𨄸	jidp	0
-𫏻	jids	0
 𨁩	jidy	0
 𧿰	jiea	0
 𧿱	jiea	0
@@ -45296,7 +43637,6 @@ encoder:
 𨁠	jieb	0
 𨄎	jieb	0
 𨅯	jieb	0
-𫏿	jieb	0
 䠜	jiec	4060
 踑	jiec	40300
 𧾽	jied	0
@@ -45321,14 +43661,12 @@ encoder:
 𨂾	jiel	0
 𨆛	jiel	0
 𨇿	jiel	0
-𫐖	jiel	0
 𨂵	jien	0
 𨇧	jien	0
 䠄	jieo	5280
 䠣	jieo	4260
 𨂚	jieo	0
 𨅜	jieo	0
-𫐂	jieo	0
 𨀭	jieq	0
 𨅤	jieq	0
 𨅹	jieq	0
@@ -45354,7 +43692,6 @@ encoder:
 𨃙	jiff	0
 𨅾	jiff	0
 𨇢	jifg	0
-𫐢	jifg	0
 跴	jifj	37500
 踈	jifj	108000
 𠾋	jifj	0
@@ -45392,7 +43729,6 @@ encoder:
 𨀁	jigm	0
 𨀗	jigm	0
 𨄉	jigm	0
-𫐆	jign	0
 𨂠	jigo	0
 𨂪	jigp	0
 噱	jigq	313000
@@ -45411,7 +43747,6 @@ encoder:
 𨂨	jigu	0
 跶	jigw	204000
 䟦	jigx	4100
-𫐑	jigx	0
 跠	jigy	22000
 跪	jigy	23600000
 踯	jigy	541000
@@ -45419,7 +43754,6 @@ encoder:
 躑	jigy	152000
 躚	jigy	26300
 𨇴	jigy	0
-𫐚	jigy	0
 跮	jihb	22600
 踁	jihb	34300
 𨀕	jihc	0
@@ -45466,16 +43800,13 @@ encoder:
 𧿓	jiis	0
 𨄲	jiiw	0
 𨀛	jiiy	0
-𫐗	jija	0
 蹚	jijb	187000
 贵国	jijc	694000
 𨁎	jijc	0
-𫙜	jijc	0
 躊	jijd	129000
 躁	jijf	6040000
 𨁉	jijf	0
 𨅨	jijf	0
-𫐜	jijg	0
 𨅝	jijh	0
 踀	jiji	43500
 蹿	jiji	2540000
@@ -45544,7 +43875,6 @@ encoder:
 嚬	jikg	403000
 蹴	jikg	3870000
 𨆞	jikg	0
-𫐃	jikg	0
 𡃰	jikh	0
 𨃄	jikh	0
 䟧	jiki	3770
@@ -45556,12 +43886,10 @@ encoder:
 𨄩	jikk	0
 𨇉	jikk	0
 𨇡	jikk	0
-𫐞	jikk	0
 䠀	jikl	16900
 嚧	jikl	138000
 𨂅	jikl	0
 𨇖	jikl	0
-𫐓	jikl	0
 䟞	jikm	3200
 贵省	jikm	98700
 𨁭	jikm	0
@@ -45600,8 +43928,6 @@ encoder:
 𨀜	jild	0
 䫭	jilg	3350
 踹	jilg	5630000
-𫐀	jilg	0
-𫐝	jilg	0
 贵贱	jilh	1340000
 踻	jilj	19700
 𨀩	jilj	0
@@ -45631,7 +43957,6 @@ encoder:
 𠿖	jilr	0
 𨁍	jilr	0
 𨁞	jilr	0
-𫐌	jilr	0
 躧	jilt	36500
 遗	jilw	16600000
 遺	jilw	6310000
@@ -45647,7 +43972,6 @@ encoder:
 𨁎	jimb	0
 𨁗	jimb	0
 𨂘	jimb	0
-𫐅	jimb	0
 𧿐	jime	0
 𧿘	jime	0
 跥	jimf	32900
@@ -45678,12 +44002,10 @@ encoder:
 蹫	jiml	25700
 𨆦	jiml	0
 𨇣	jiml	0
-𫐛	jiml	0
 𨄕	jimm	0
 𨂵	jimn	0
 𨇧	jimn	0
 跌	jimo	68700000
-𫏽	jimo	0
 𧿦	jimq	0
 跣	jimr	380000
 趿	jims	291000
@@ -45788,7 +44110,6 @@ encoder:
 𧿚	jioy	0
 𨃈	jioy	0
 𨇫	jioy	0
-𫐍	jioy	0
 躐	jioz	110000
 𧿖	jioz	0
 䟬	jipd	3670
@@ -45849,7 +44170,6 @@ encoder:
 𨂥	jirj	0
 𨃶	jirj	0
 𨆿	jirj	0
-𫐄	jirj	0
 䟢	jirk	3670
 跞	jirk	133000
 𨀴	jirk	0
@@ -45894,7 +44214,6 @@ encoder:
 𨂂	jiru	0
 𨇟	jiru	0
 𨇤	jiru	0
-𫐣	jiru	0
 𪛅	jirw	0
 踭	jirx	84600
 跑	jiry	159000000
@@ -45906,7 +44225,6 @@ encoder:
 𨄐	jirz	0
 𨄙	jirz	0
 𩿀	jirz	0
-𫐔	jirz	0
 忠言	jisa	823000
 跓	jisc	28200
 𨁅	jise	0
@@ -45917,7 +44235,6 @@ encoder:
 贵部	jisj	66200
 踣	jisj	122000
 𨁮	jisj	0
-𫐕	jisj	0
 𨅩	jisk	0
 𨃋	jisl	0
 贵族	jism	21700000
@@ -45927,7 +44244,6 @@ encoder:
 跻	jisn	515000
 𨂋	jisn	0
 㗔	jiso	3770
-𪯺	jiso	0
 䟘	jisq	3360
 𨀫	jisq	0
 蹨	jisu	62500
@@ -45983,7 +44299,6 @@ encoder:
 𨄇	jiuk	0
 蹢	jiul	34200
 𨇇	jiul	0
-𫐘	jiul	0
 𨃪	jium	0
 𤆪	jiuo	0
 𧿮	jiuo	0
@@ -46101,7 +44416,6 @@ encoder:
 㕜	jixs	4330
 䟕	jixs	3430
 跋	jixs	4770000
-𫐁	jixs	0
 踗	jixw	21300
 蹆	jixw	77900
 𨆲	jixw	0
@@ -46137,7 +44451,6 @@ encoder:
 蹾	jiym	87200
 𧾼	jiym	0
 𨄨	jiym	0
-𫐈	jiym	0
 躍	jiyn	3820000
 𧿳	jiyn	0
 𨄌	jiyn	0
@@ -46194,7 +44507,6 @@ encoder:
 𨇰	jizp	0
 𨀮	jizq	0
 𨂔	jizq	0
-𫐟	jizq	0
 䟲	jizr	3600
 蹶	jizr	858000
 𨀨	jizr	0
@@ -46221,7 +44533,6 @@ encoder:
 𡆔	jjaj	0
 嘳	jjal	34900
 𢃋	jjal	0
-𪡢	jjal	0
 𠱐	jjas	0
 𤊌	jjau	0
 鼉	jjaw	47200
@@ -46310,7 +44621,6 @@ encoder:
 回车	jjhe	10200000
 回到	jjhk	169000000
 𢦸	jjhm	0
-𪺔	jjhu	0
 𧕛	jjii	0
 𧕦	jjii	0
 圆桌	jjik	3290000
@@ -46368,7 +44678,6 @@ encoder:
 𩱴	jjjl	0
 𠻖	jjjm	0
 𣀬	jjjm	0
-𪯸	jjjm	0
 咽喉	jjjn	9810000
 回响	jjjn	4280000
 𩀏	jjjn	0
@@ -46400,7 +44709,6 @@ encoder:
 𡀋	jjkz	0
 𡁥	jjkz	0
 圆周	jjlb	956000
-𪢀	jjlg	0
 𠲢	jjli	0
 器皿	jjlk	4020000
 𠞫	jjlk	0
@@ -46412,7 +44720,6 @@ encoder:
 回见	jjlr	715000
 𠺐	jjlr	0
 回用	jjlv	988000
-𪟥	jjly	0
 𠾧	jjlz	0
 𡀈	jjmb	0
 𡅚	jjmb	0
@@ -46500,20 +44807,17 @@ encoder:
 串通	jjwx	1880000
 回避	jjwx	24800000
 圆通	jjwx	1250000
-𫝣	jjwx	0
 器官	jjwy	16800000
 串案	jjwz	157000
 嗯	jjwz	44700000
 圆心	jjwz	953000
 患	jjwz	96700000
-𪬇	jjwz	0
 回函	jjxk	2000000
 㖐	jjxm	4080
 患难	jjxn	2030000
 𡁳	jjxs	0
 𪛄	jjxx	0
 𡄞	jjxy	0
-𪡴	jjxy	0
 圆子	jjya	729000
 嚣张	jjyc	7890000
 回民	jjyh	1410000
@@ -46598,7 +44902,6 @@ encoder:
 唱段	jknc	477000
 㘍	jknh	4580
 𠻘	jkni	0
-𪢁	jkob	0
 嚗	jkok	739000
 𠷟	jkon	0
 𡄗	jkos	0
@@ -46613,7 +44916,6 @@ encoder:
 啺	jkro	93900
 𠴭	jkro	0
 𠿒	jkrr	0
-𪡗	jkrr	0
 喝	jkry	226000000
 𠵫	jkry	0
 𡅩	jkry	0
@@ -46634,7 +44936,6 @@ encoder:
 踏实	jkwt	9060000
 𠹵	jkwz	0
 𠾦	jkwz	0
-𪡀	jkxb	0
 唱戏	jkxh	1340000
 嘢	jkxi	1780000
 吵架	jkyj	13600000
@@ -46647,7 +44948,6 @@ encoder:
 𡂡	jkzm	0
 𡀾	jkzu	0
 喂奶	jkzy	1410000
-𫒟	jkzy	0
 𠵄	jlad	0
 𠵚	jlae	0
 𠽭	jlai	0
@@ -46669,8 +44969,6 @@ encoder:
 𠼌	jlcm	0
 𡆑	jlcm	0
 𡂼	jlcu	0
-𪡲	jlds	0
-𪡘	jlea	0
 𠳣	jled	0
 唺	jleo	61500
 𠾨	jler	0
@@ -46682,9 +44980,7 @@ encoder:
 喘	jlgl	19400000
 𠹃	jlgl	0
 䫟	jlgo	3230
-𫗵	jlgo	0
 𠾪	jlgq	0
-𪡭	jlgu	0
 嚺	jlgw	23700
 𠸵	jlhd	0
 𠯧	jlia	0
@@ -46736,14 +45032,12 @@ encoder:
 呐	jlod	22900000
 呙	jlod	194000
 剐	jlok	2760000
-𪠿	jloo	0
 𡂅	jlor	0
 𠵙	jlow	0
 𠼹	jlpd	0
 吊销	jlpk	4530000
 吊舱	jlpo	201000
 吊钩	jlpr	358000
-𪢟	jlpx	0
 嘣	jlqq	969000
 员外	jlri	901000
 噣	jlri	521000
@@ -46753,7 +45047,6 @@ encoder:
 啰	jlrs	3080000
 𦫮	jlry	0
 鶰	jlrz	18600
-𫜱	jlrz	0
 𠺯	jlsh	0
 𧷯	jlsj	0
 勋章	jlsk	58700000
@@ -46761,7 +45054,6 @@ encoder:
 㖗	jlsx	3760
 㗄	jlsy	3730
 吊装	jltb	1910000
-𪡳	jltl	0
 吊灯	jlua	1530000
 嚜	jlub	1340000
 𡀕	jluu	0
@@ -46771,9 +45063,7 @@ encoder:
 郧阳	jlyk	654000
 勋	jlym	5130000
 勛	jlym	1880000
-𪽧	jlys	0
 𤏩	jlyu	0
-𪭀	jlyw	0
 翤	jlyy	20800
 囉	jlzn	46600000
 𪔅	jlzn	0
@@ -46805,8 +45095,6 @@ encoder:
 呼机	jmfq	921000
 㕭	jmgd	4250
 𠰙	jmgk	0
-𪡃	jmgn	0
-𪢎	jmgq	0
 𠺑	jmgs	0
 跌破	jmgx	7820000
 吒	jmhd	2090000
@@ -46822,7 +45110,6 @@ encoder:
 呼喊	jmjh	6310000
 吃喝	jmjk	22300000
 嘺	jmjl	36200
-𪢨	jmjl	0
 呼呼	jmjm	8090000
 呼唤	jmjr	14600000
 𠾔	jmjr	0
@@ -46842,17 +45129,14 @@ encoder:
 吃水	jmkv	1710000
 吃紧	jmkx	1870000
 跌幅	jmla	11300000
-𪢍	jmld	0
 𠲣	jmlk	0
 𠶜	jmlk	0
 𡀹	jmlo	0
 哖	jmmb	1420000
 𠵮	jmmb	0
 𣽿	jmmb	0
-𪢂	jmmc	0
 跃升	jmme	1390000
 㗛	jmmg	3860
-𪡂	jmmi	0
 吃香	jmmk	1550000
 𠽶	jmmm	0
 𠾆	jmmm	0
@@ -46898,13 +45182,11 @@ encoder:
 𠽩	jmxb	0
 跃居	jmxe	2240000
 𠺋	jmxg	0
-𪢕	jmxj	0
 𡅉	jmxk	0
 𡅣	jmxn	0
 𡅌	jmxq	0
 𡀝	jmxw	0
 𡅯	jmxw	0
-𪢚	jmxw	0
 㘉	jmxy	4590
 吃	jmyd	516000000
 𠰹	jmyi	0
@@ -46940,7 +45222,6 @@ encoder:
 𤳧	jneo	0
 𡀯	jnfd	0
 𡃽	jnfg	0
-𪢏	jnfl	0
 响板	jnfp	123000
 𠹎	jnfu	0
 嗥	jnge	890000
@@ -46962,7 +45243,6 @@ encoder:
 𠷊	jnko	0
 𡂈	jnku	0
 响水	jnkv	992000
-𪡤	jnkv	0
 𡀭	jnky	0
 𠼸	jnkz	0
 𡂗	jnld	0
@@ -46982,14 +45262,12 @@ encoder:
 𪅺	jnmr	0
 喺	jnmz	1040000
 𡁫	jnnb	0
-𪡌	jnnk	0
 咱们	jnnt	26900000
 𠸘	jnoj	0
 𡃪	jnol	0
 𠴺	jnor	0
 𠻦	jnor	0
 𠿬	jnor	0
-𪡣	jnor	0
 𠱖	jnos	0
 𠴒	jnow	0
 𡄆	jnoy	0
@@ -47001,10 +45279,7 @@ encoder:
 哗	jnre	7060000
 𠺧	jnrf	0
 哗然	jnrg	4110000
-𪡍	jnri	0
-𪡋	jnrk	0
 𡄊	jnrl	0
-𪢄	jnrm	0
 吪	jnrr	68300
 𠹇	jnrr	0
 𠿬	jnrr	0
@@ -47051,7 +45326,6 @@ encoder:
 𠾑	joai	0
 哈	joaj	190000000
 㖮	joal	4130
-𪢡	joaw	0
 𠯋	joaz	0
 𠸤	jobd	0
 𡆁	jobg	0
@@ -47059,7 +45333,6 @@ encoder:
 𠻀	jobo	0
 𠹐	jobr	0
 史地	jobv	3030000
-𪡏	jobv	0
 哙	jobz	330000
 叺	joda	151000
 𠾑	joei	0
@@ -47082,7 +45355,6 @@ encoder:
 㖉	joii	3840
 嘥	joii	87300
 只占	joij	4940000
-𪡚	jojd	0
 啽	joje	40000
 𠹞	joje	0
 𠼟	jojk	0
@@ -47135,7 +45407,6 @@ encoder:
 哈欠	joro	1790000
 𠿮	joro	0
 嗲	jorr	4040000
-𪠸	jorr	0
 𩿦	jorz	0
 𪀎	jorz	0
 只读	jose	5600000
@@ -47183,7 +45454,6 @@ encoder:
 嗂	jpez	25900
 啋	jpfa	643000
 𡀖	jpfa	0
-𪢠	jpfb	0
 𡄮	jpfl	0
 𠾫	jpgo	0
 喛	jpgx	125000
@@ -47207,14 +45477,12 @@ encoder:
 听从	jpoo	4990000
 听众	jpoo	6990000
 𡂒	jppl	0
-𪡎	jpqa	0
 𡂑	jpql	0
 哌	jprh	1330000
 𠲐	jprh	0
 𠾠	jprj	0
 𠾬	jpro	0
 𡃶	jpro	0
-𪡛	jpro	0
 𠹕	jprs	0
 听讲	jpsb	1750000
 听课	jpsk	8960000
@@ -47244,7 +45512,6 @@ encoder:
 𠹻	jqag	0
 㕨	jqda	4220
 𠯥	jqed	0
-𪢃	jqhb	0
 叽叽	jqjq	763000
 剈	jqkd	22600
 𡄯	jqkw	0
@@ -47324,7 +45591,6 @@ encoder:
 跑题	jrka	1500000
 𠳉	jrka	0
 路由	jrki	25700000
-𪠻	jrko	0
 图景	jrks	1250000
 𣵯	jrkv	0
 𠼓	jrkz	0
@@ -47332,7 +45598,6 @@ encoder:
 唃	jrld	37500
 唤	jrlg	12700000
 喚	jrlg	2820000
-𪾻	jrlk	0
 𠼠	jrlo	0
 跪拜	jrma	1210000
 吹牛	jrmb	5700000
@@ -47357,7 +45622,6 @@ encoder:
 𠱎	jroa	0
 吻	jrod	101000000
 路人	jrod	14300000
-𪥛	jrog	0
 𠳪	jroj	0
 𠴰	jroj	0
 𥁴	jrol	0
@@ -47365,7 +45629,6 @@ encoder:
 𠸀	jroo	0
 噡	jros	34200
 𠰯	jros	0
-𪠷	jros	0
 唿	jrow	255000
 路径	jrox	18300000
 哛	jroy	18900
@@ -47379,7 +45642,6 @@ encoder:
 图象	jrrj	13400000
 图解	jrrl	15700000
 喈	jrrn	330000
-𪡙	jrro	0
 吡	jrrr	3100000
 哆	jrrs	10100000
 嚵	jrrs	34500
@@ -47448,7 +45710,6 @@ encoder:
 𠾍	jsef	0
 𨅇	jsej	0
 嚷	jser	7350000
-𪢜	jsfj	0
 嚫	jsfl	65600
 囃	jsfn	212000
 噺	jsfp	1770000
@@ -47492,7 +45753,6 @@ encoder:
 𡄶	jslg	0
 𠽜	jslj	0
 𠽆	jslo	0
-𪢣	jslu	0
 𠻗	jslz	0
 𠻾	jsmb	0
 𠼯	jsme	0
@@ -47514,13 +45774,11 @@ encoder:
 𠸠	jsoj	0
 咬	jsoo	40100000
 𠺡	jsor	0
-𪢇	jsor	0
 唹	jsot	183000
 𠲲	jspd	0
 㘖	jspg	4220
 吭	jsqd	4400000
 𠾀	jsqm	0
-𪡄	jsrd	0
 𠵒	jsre	0
 𠲖	jsrh	0
 𧘗	jsrh	0
@@ -47532,7 +45790,6 @@ encoder:
 𡆙	jsrs	0
 𡁈	jsse	0
 𡅼	jsss	0
-𪰇	jste	0
 㕸	jsua	4640
 𠱪	jsua	0
 嘀	jsul	9040000
@@ -47544,7 +45801,6 @@ encoder:
 𠷥	jswa	0
 嚎	jswg	6580000
 啼	jswl	8170000
-𪢅	jswm	0
 喨	jswq	461000
 嗙	jsws	1330000
 𠻫	jswz	0
@@ -47553,12 +45809,10 @@ encoder:
 哴	jsxo	66800
 𠻴	jsxq	0
 啷	jsxy	1450000
-𪡝	jsxy	0
 𠾓	jsyj	0
 噋	jsym	20600
 𡁹	jsym	0
 㗥	jsyy	3720
-𪡸	jsyy	0
 𠻜	jsze	0
 𠴬	jszf	0
 㗜	jszk	3680
@@ -47570,7 +45824,6 @@ encoder:
 唷	jszq	31600000
 𠵷	jszr	0
 呟	jszz	207000
-𪡟	jtaj	0
 㘎	jtcm	15700
 	jtcm	0
 呌	jted	33600
@@ -47581,12 +45834,10 @@ encoder:
 嘛	jtff	122000000
 嚰	jtfg	39200
 𠺟	jtfk	0
-𪢐	jtfl	0
 嚤	jtfm	364000
 𠶧	jtij	0
 㖢	jtir	4130
 𠹂	jtir	0
-𪡪	jtiy	0
 𡄁	jtjm	0
 𡀧	jtkh	0
 𠶦	jtki	0
@@ -47602,7 +45853,6 @@ encoder:
 𠹔	jtxj	0
 𠻞	jtxk	0
 嘃	jtxl	21700
-𪢘	jtzu	0
 嚒	jtzz	444000
 𡂺	juax	0
 嗟	jubi	1880000
@@ -47612,7 +45862,6 @@ encoder:
 𠵐	jubz	0
 𡁔	jucq	0
 噂	jufd	19100000
-𪡫	jufd	0
 圈套	jugc	5070000
 咲	jugd	10100000
 𠸍	jugd	0
@@ -47633,7 +45882,6 @@ encoder:
 𡅬	jukr	0
 𠵔	juku	0
 𠿏	juku	0
-𪢆	jula	0
 噌	julk	1300000
 圈内	julo	4630000
 𠶞	jumc	0
@@ -47656,7 +45904,6 @@ encoder:
 圈养	juun	799000
 㗝	juuo	5020
 啖	juuo	3250000
-𫐙	juup	0
 㗵	juur	4050
 𤑽	juuu	0
 𡄕	juux	0
@@ -47682,7 +45929,6 @@ encoder:
 𠶑	juzi	0
 喽	juzm	25300000
 𠷩	juzm	0
-𪢖	juzm	0
 𠾌	juzn	0
 嗍	juzq	72300
 㘂	juzw	5410
@@ -47711,7 +45957,6 @@ encoder:
 中的	jvdv	501000000
 中南	jvel	22500000
 中英	jvel	9040000
-𪡩	jveo	0
 中期	jveq	23100000
 中药	jvez	24200000
 𠾻	jvez	0
@@ -47742,7 +45987,6 @@ encoder:
 中国	jvjc	2130000000
 中叶	jvje	2120000
 跳跃	jvjm	9430000
-𪡹	jvjq	0
 中路	jvjr	24100000
 𡁺	jvjr	0
 跳跳	jvjv	4140000
@@ -47762,7 +46006,6 @@ encoder:
 𠿭	jvlw	0
 中等	jvmb	41500000
 𠽍	jvmb	0
-𪡞	jvmc	0
 中午	jvme	65000000
 跳舞	jvme	22800000
 𠴎	jvmg	0
@@ -47851,7 +46094,6 @@ encoder:
 咛	jwai	760000
 𠳽	jwai	0
 𠽰	jwai	0
-𪡧	jwak	0
 𠴴	jwal	0
 𠸐	jwax	0
 𠰇	jwaz	0
@@ -47861,7 +46103,6 @@ encoder:
 𠷪	jwbj	0
 喧	jwbk	4330000
 𠵻	jwbk	0
-𪢊	jwbm	0
 唍	jwbr	264000
 噠	jwbu	519000
 嗐	jwcj	721000
@@ -47886,7 +46127,6 @@ encoder:
 𠴈	jwgz	0
 㗌	jwhb	3940
 㗧	jwhb	3930
-𪡓	jwhe	0
 𠴨	jwix	0
 𡁁	jwix	0
 𠾯	jwjf	0
@@ -47918,7 +46158,6 @@ encoder:
 哰	jwmb	36800
 咤	jwmh	591000
 𠻉	jwmi	0
-𪢛	jwmi	0
 𠻛	jwmj	0
 嘧	jwml	1950000
 𠷖	jwmw	0
@@ -47950,7 +46189,6 @@ encoder:
 𠾰	jwrh	0
 喀	jwrj	9260000
 咜	jwrr	177000
-𪡺	jwrs	0
 啘	jwry	202000
 𠶐	jwry	0
 𠹼	jwse	0
@@ -47969,7 +46207,6 @@ encoder:
 𠸺	jwuz	0
 𠻩	jwvr	0
 𠯣	jwvv	0
-𪢩	jwws	0
 嗵	jwxl	513000
 𠺙	jwxo	0
 𠸽	jwxr	0
@@ -48030,7 +46267,6 @@ encoder:
 𡂛	jxju	0
 跟踪	jxjw	38800000
 𠹴	jxjy	0
-𪡴	jxjy	0
 㗲	jxka	5320
 𠱺	jxka	0
 𡃢	jxka	0
@@ -48074,8 +46310,6 @@ encoder:
 𠿷	jxsl	0
 𠲙	jxsq	0
 跟头	jxtg	1830000
-𪡆	jxtg	0
-𪡬	jxuf	0
 嚍	jxul	75300
 跟着	jxul	42700000
 𠴌	jxuo	0
@@ -48187,14 +46421,12 @@ encoder:
 吸入	jyod	10900000
 噿	jyoe	32600
 另行	jyoi	11400000
-𪡻	jyom	0
 𡄉	jyoo	0
 𡄣	jyoo	0
 𤕦	jyoo	0
 嘐	jyop	83700
 𠻱	jyor	0
 哪个	jyov	61300000
-𪡒	jyow	0
 䬭	jyox	3770
 𠸳	jyoz	0
 𠔦	jypo	0
@@ -48241,7 +46473,6 @@ encoder:
 吸附	jyyn	5660000
 嚁	jyyn	29000
 嗋	jyyq	62900
-𪢈	jyys	0
 𠺁	jyyt	0
 𠱿	jyyy	0
 𠱳	jyyz	0
@@ -48258,7 +46489,6 @@ encoder:
 呉	jzao	4200000
 𡅍	jzbg	0
 𠸣	jzbi	0
-𪢑	jzbj	0
 𠵈	jzbk	0
 𡆓	jzbn	0
 𠿆	jzcr	0
@@ -48294,7 +46524,6 @@ encoder:
 𠶼	jzlz	0
 唉	jzma	54300000
 哞	jzmb	1060000
-𪡅	jzmb	0
 𠹷	jzmh	0
 𠲠	jzmo	0
 𠺻	jzms	0
@@ -48382,11 +46611,9 @@ encoder:
 师大	kagd	16800000
 昊	kagd	11200000
 𩑰	kago	0
-𪱊	kagx	0
 日历	kagy	92700000
 𨛴	kagy	0
 𣊰	kaib	0
-𪨇	kaid	0
 題	kaig	59400000
 题	kaig	93700000
 是	kaii	2210000000
@@ -48398,11 +46625,9 @@ encoder:
 𧡰	kail	0
 晸	kaim	626000
 𦧪	kaim	0
-𪱌	kaim	0
 匙	kair	9160000
 鶗	kair	61100
 𫜾	kair	0
-𫃷	kaiu	0
 遈	kaiw	528000
 㪋	kaix	3830
 𢾙	kaix	0
@@ -48441,7 +46666,6 @@ encoder:
 师生	kamc	19300000
 日程	kamj	33300000
 𣊋	kamj	0
-𪱆	kamk	0
 量筒	kaml	435000
 𣉺	kamo	0
 旱稻	kamp	87100
@@ -48472,7 +46696,6 @@ encoder:
 𣆃	karb	0
 旱象	karj	70300
 题名	karj	20300000
-𪱚	kark	0
 题解	karl	1210000
 𧤘	karl	0
 昜	karo	836000
@@ -48493,10 +46716,8 @@ encoder:
 旱冰	katk	654000
 师资	katr	12000000
 量度	katv	1050000
-𪰭	kaua	0
 旱情	kauc	1250000
 量瓶	kaue	120000
-𫗨	kaug	0
 日益	kauo	37200000
 日前	kauq	90200000
 𤓐	kauu	0
@@ -48510,7 +46731,6 @@ encoder:
 旱灾	kawu	2980000
 鼂	kawx	26000
 题字	kawy	1010000
-𪱛	kawy	0
 𢘇	kawz	0
 㫸	kaxi	3970
 日子	kaya	106000000
@@ -48530,7 +46750,6 @@ encoder:
 日出	kazz	12900000
 暑天	kbag	328000
 𨤷	kbaj	0
-𫒿	kbal	0
 尘土	kbba	4790000
 晆	kbba	24900
 𣈹	kbbb	0
@@ -48546,7 +46765,6 @@ encoder:
 野营	kbew	5050000
 𢻣	kbex	0
 里面	kbgj	102000000
-𫗥	kbgo	0
 𣌐	kbia	0
 墅	kbib	15100000
 𣆞	kbii	0
@@ -48556,9 +46774,7 @@ encoder:
 𤍓	kbiu	0
 野味	kbjb	1540000
 𣋬	kbjd	0
-𪰿	kbjk	0
 曀	kbju	86400
-𪱔	kbkb	0
 野果	kbkf	626000
 昧	kbko	1940000
 里昂	kbkr	4490000
@@ -48577,16 +46793,12 @@ encoder:
 𣊚	kboo	0
 𣇾	kbor	0
 𣊎	kbqs	0
-𫚨	kbra	0
-𪰢	kbrd	0
 里外	kbri	3830000
 野外	kbri	20600000
-𪱋	kbri	0
 𣉟	kbrk	0
 𨤧	kbrk	0
 𢄾	kbrl	0
 𣇾	kbrr	0
-𪰴	kbrr	0
 野蛮	kbsi	17600000
 𧚣	kbsr	0
 黙	kbsu	864000
@@ -48598,7 +46810,6 @@ encoder:
 𤜔	kbum	0
 野火	kbuo	1710000
 黒	kbuo	98100000
-𪺞	kbuo	0
 𣊎	kbuq	0
 野炊	kbur	1080000
 𨤮	kbuu	0
@@ -48683,7 +46894,6 @@ encoder:
 䪤	kcpk	4180
 𩈀	kcpk	0
 非凡	kcqd	17300000
-𪱱	kcri	0
 最多	kcrv	267000000
 𪂏	kcrz	0
 𪂞	kcrz	0
@@ -48706,7 +46916,6 @@ encoder:
 旺	kcvv	65500000
 非洲	kcvv	58300000
 最深	kcvw	14300000
-𪪝	kcwm	0
 最近	kcwp	553000000
 最迟	kcwx	1940000
 最初	kcwy	226000000
@@ -48719,13 +46928,10 @@ encoder:
 㬩	kcxw	7360
 𩇫	kcya	0
 㐟	kcyd	4330
-𪱎	kcyg	0
 𩇯	kcyi	0
 朂	kcym	118000
-𫆢	kcyo	0
 䨽	kcyy	3870
 翡	kcyy	1880000
-𫆢	kcyy	0
 婓	kczm	903000
 晴纶	kczo	400000
 最能	kczq	9660000
@@ -48737,7 +46943,6 @@ encoder:
 𣥠	kdbi	0
 𤯶	kdbm	0
 𠁿	kdbs	0
-𫕯	kdbt	0
 时髦	kdcm	7370000
 时事	kddj	43800000
 时报	kddy	41700000
@@ -48749,13 +46954,10 @@ encoder:
 时区	kdho	26200000
 时日	kdka	5640000
 时时	kdkd	18600000
-𪳙	kdkf	0
 时光	kdkg	39500000
 时尚	kdkl	288000000
 时常	kdkw	15200000
 帅	kdli	248000000
-𪟐	kdlk	0
-𫏉	kdlo	0
 临	kdmk	61500000
 监	kdml	70100000
 览	kdml	65800000
@@ -48765,7 +46967,6 @@ encoder:
 时段	kdnc	23600000
 时代	kdnh	203000000
 时候	kdni	454000000
-𪮻	kdom	0
 时令	kdow	1700000
 𨵣	kdox	0
 时分	kdoy	9880000
@@ -48788,7 +46989,6 @@ encoder:
 𣈓	kdxi	0
 䝨	kdxl	3490
 贤	kdxl	37900000
-𪾹	kdxl	0
 肾	kdxq	25700000
 竖	kdxs	14800000
 时局	kdxy	1260000
@@ -48814,7 +47014,6 @@ encoder:
 早报	kedy	13900000
 曄	keeb	1290000
 曅	keeb	102000
-𪰸	keeb	0
 暁	keeg	4240000
 早期	keeq	65100000
 𣊿	keeq	0
@@ -48866,7 +47065,6 @@ encoder:
 㬮	keon	5050
 𣌖	keon	0
 暪	keoo	162000
-𪱥	keoo	0
 早饭	keop	4810000
 𣋸	keor	0
 謈	keos	24700
@@ -48884,7 +47082,6 @@ encoder:
 𣉪	kesn	0
 𣇷	kesy	0
 𣇪	keuo	0
-𪹈	keuo	0
 𣊴	keve	0
 㫒	kevv	3610
 暴涨	kevy	6330000
@@ -48909,7 +47106,6 @@ encoder:
 㬍	kfds	4340
 暷	kfds	29000
 𢻔	kfex	0
-𪴡	kfex	0
 果木	kffa	431000
 𣋜	kffb	0
 果枝	kffe	195000
@@ -48941,7 +47137,6 @@ encoder:
 曤	kfni	87200
 𣌟	kfoo	0
 𣛤	kfoo	0
-𪱄	kfoo	0
 㬡	kfow	4080
 晰	kfpd	2600000
 𢒙	kfpd	0
@@ -48966,7 +47161,6 @@ encoder:
 𠕖	kfvv	0
 果农	kfwr	953000
 果实	kfwt	11200000
-𪱣	kfwz	0
 果敢	kfxc	2450000
 𣌊	kfxx	0
 果子	kfya	6350000
@@ -49004,7 +47198,6 @@ encoder:
 晨曦	kgku	6220000
 光是	kgkv	8390000
 光照	kgky	6650000
-𪱍	kgky	0
 光电	kgkz	13800000
 晻	kgkz	123000
 耀眼	kglx	11200000
@@ -49029,9 +47222,7 @@ encoder:
 尖锐	kgpu	11200000
 𩉉	kgrn	0
 鷐	kgrz	28800
-𫝆	kgrz	0
 𡒦	kgsb	0
-𪱭	kgsb	0
 光亮	kgsj	7830000
 尖端	kgsl	6760000
 光谱	kgsu	2660000
@@ -49040,7 +47231,6 @@ encoder:
 光源	kgvg	8350000
 光滑	kgvl	21700000
 光州	kgvn	598000
-𪰬	kgvv	0
 光学	kgvw	27700000
 光波	kgvx	1780000
 光泽	kgvx	9240000
@@ -49059,7 +47249,6 @@ encoder:
 光能	kgzq	1170000
 𣆜	khai	0
 𣇁	khbi	0
-𪰶	khbi	0
 暱	khgj	887000
 晓	khgr	63500000
 𣇈	khgr	0
@@ -49067,15 +47256,12 @@ encoder:
 𩳺	khjn	0
 𢤃	khjw	0
 𠕥	khkd	0
-𪰷	khkd	0
 𣈿	khkz	0
 𣋣	khml	0
 晓得	khok	18100000
 畏惧	khul	6220000
-𪥟	khxg	0
 畏难	khxn	1150000
 煚	khxu	81300
-𪱃	khxy	0
 旽	khzi	82400
 畏缩	khzw	2350000
 𤱤	kiaa	0
@@ -49093,16 +47279,12 @@ encoder:
 𤱉	kiag	0
 𤳃	kiag	0
 𤰣	kiah	0
-𪽶	kiah	0
 町	kiai	148000000
 甼	kiai	39700
 𤲂	kiai	0
 𤲣	kiai	0
 畸	kiaj	4980000
 𤳴	kiaj	0
-𪟣	kiaj	0
-𪽺	kiaj	0
-𪽻	kiaj	0
 𣷛	kiak	0
 𤳨	kiak	0
 𢄖	kial	0
@@ -49128,7 +47310,6 @@ encoder:
 𤳐	kiau	0
 迪	kiaw	138000000
 𡱋	kiax	0
-𪽼	kiax	0
 㐕	kiay	4280
 㕀	kiay	5360
 廸	kiay	229000
@@ -49166,13 +47347,11 @@ encoder:
 𠔱	kibo	0
 𤲍	kibo	0
 𤳉	kibo	0
-𪾉	kibq	0
 鴨	kibr	9980000
 鸭	kibr	25400000
 𠒛	kibr	0
 𣢗	kibr	0
 𪈦	kibr	0
-𪽷	kibr	0
 𤲜	kibu	0
 𪒕	kibu	0
 田地	kibv	3840000
@@ -49184,7 +47363,6 @@ encoder:
 𤳟	kibz	0
 𡒮	kicb	0
 𣌨	kicb	0
-𪾆	kicb	0
 畴	kicd	1240000
 𡬤	kicd	0
 𣁱	kice	0
@@ -49204,7 +47382,6 @@ encoder:
 𤳘	kicu	0
 迧	kicw	19900
 𤰷	kicy	0
-𪟠	kidm	0
 申批	kidr	84300
 𤰥	kids	0
 𤴃	kidu	0
@@ -49261,7 +47438,6 @@ encoder:
 𨎠	kijf	0
 𤲊	kiji	0
 𧐯	kiji	0
-𪾀	kiji	0
 𤴐	kijk	0
 𦉩	kijk	0
 㨼	kijm	4410
@@ -49269,7 +47445,6 @@ encoder:
 𤲈	kijr	0
 𤲡	kijr	0
 𪅅	kijr	0
-𪾒	kiju	0
 䌎	kijz	5390
 𤳏	kika	0
 壘	kikb	3580000
@@ -49303,7 +47478,6 @@ encoder:
 曥	kikl	116000
 𡾔	kikl	0
 𥃇	kikl	0
-𪾑	kikl	0
 㽮	kikm	4740
 𣀡	kikm	0
 𣰭	kikm	0
@@ -49322,7 +47496,6 @@ encoder:
 𢣲	kiky	0
 𤲶	kiky	0
 𨞽	kiky	0
-𪟩	kiky	0
 㽢	kikz	4470
 纍	kikz	1080000
 𤳍	kikz	0
@@ -49338,7 +47511,6 @@ encoder:
 𧵗	kilo	0
 䴑	kilr	3960
 申购	kilr	4180000
-𪾁	kilr	0
 𤲳	kilz	0
 㽚	kimb	4010
 𤰼	kimb	0
@@ -49361,12 +47533,10 @@ encoder:
 㽯	kinl	4500
 𤳬	kinl	0
 申奥	kinu	1660000
-𪾏	kinu	0
 𤰽	kinx	0
 田鼠	kinz	396000
 𤱝	kiob	0
 𤲲	kiob	0
-𪾅	kiob	0
 㽗	kiod	4250
 𤲠	kioe	0
 𤳑	kiok	0
@@ -49390,7 +47560,6 @@ encoder:
 𤲻	kiou	0
 𤳒	kiou	0
 申令	kiow	33900
-𪽼	kiow	0
 田径	kiox	4630000
 𤰯	kiox	0
 𤰪	kioy	0
@@ -49404,9 +47573,6 @@ encoder:
 𤳚	kiqd	0
 𤱧	kiqf	0
 𠠩	kiqk	0
-𪽴	kiqy	0
-𫒢	kiqy	0
-𪾅	kirb	0
 𠨃	kiri	0
 𧖈	kiri	0
 㽛	kirj	4340
@@ -49419,7 +47585,6 @@ encoder:
 𪉀	kirk	0
 疄	kirm	589000
 𤳩	kirm	0
-𪽾	kirm	0
 畼	kiro	134000
 𤰿	kiro	0
 𤳈	kiro	0
@@ -49441,7 +47606,6 @@ encoder:
 𤳽	kisi	0
 由衷	kisj	5190000
 盢	kisl	205000
-𪽹	kiso	0
 申诉	kisp	14600000
 㽘	kisq	4210
 甲亢	kisq	3140000
@@ -49479,7 +47643,6 @@ encoder:
 𤲏	kiwq	0
 申冤	kiwr	523000
 𪃄	kiwr	0
-𫇴	kiwu	0
 𨜐	kiwy	0
 思	kiwz	179000000
 疉	kiwz	81300
@@ -49503,9 +47666,7 @@ encoder:
 㽖	kiym	4390
 男	kiym	516000000
 𣋭	kiym	0
-𪟨	kiyn	0
 申办	kiyo	4440000
-𪽵	kiyo	0
 𤮉	kiys	0
 𤲹	kiyt	0
 𢣢	kiyy	0
@@ -49517,7 +47678,6 @@ encoder:
 𩌺	kize	0
 𤲺	kizg	0
 𩕃	kizg	0
-𪾓	kizh	0
 㚻	kizm	3690
 𤲼	kizm	0
 𤴏	kizn	0
@@ -49525,14 +47685,12 @@ encoder:
 𤰵	kizo	0
 㽙	kizr	4780
 𤲋	kizr	0
-𪽿	kizr	0
 𤰜	kizs	0
 甲级	kizy	4150000
 𤱎	kizy	0
 㽧	kizz	4650
 𤱟	kizz	0
 冔	kjad	43500
-𫁍	kjbb	0
 曮	kjcm	30800
 𣆉	kjed	0
 𢿘	kjix	0
@@ -49572,7 +47730,6 @@ encoder:
 𣉆	kkai	0
 𣰱	kkan	0
 昌平	kkau	8270000
-𪱕	kkbe	0
 𣍕	kkbg	0
 昌吉	kkbj	2830000
 显示	kkbk	519000000
@@ -49589,7 +47746,6 @@ encoder:
 𠦤	kked	0
 曲直	kkel	1430000
 𣌝	kker	0
-𪱢	kker	0
 晃荡	kkev	1280000
 晶莹	kkew	13800000
 𢻅	kkex	0
@@ -49598,7 +47754,6 @@ encoder:
 显露	kkfj	9730000
 晶析	kkfp	62700
 显要	kkfv	673000
-𪱴	kkfz	0
 𣌹	kkga	0
 農	kkgh	17400000
 𣊐	kkgh	0
@@ -49631,7 +47786,6 @@ encoder:
 𣋏	kkkg	0
 𣊫	kkkk	0
 𣊭	kkkk	0
-𪱤	kkkk	0
 曐	kkkm	95400
 𣌱	kkkm	0
 显影	kkks	775000
@@ -49673,9 +47827,7 @@ encoder:
 晹	kkro	105000
 暘	kkro	1370000
 𣣘	kkro	0
-𪵑	kkro	0
 𣈀	kkrr	0
-𪱖	kkrr	0
 暍	kkry	203000
 艶	kkry	6590000
 𪂇	kkrz	0
@@ -49696,7 +47848,6 @@ encoder:
 𤒍	kkuu	0
 豑	kkuy	25300
 鄷	kkuy	29300
-𪪅	kkuy	0
 昌江	kkvb	514000
 曲江	kkvb	1160000
 曲酒	kkvf	594000
@@ -49735,10 +47886,8 @@ encoder:
 晪	kleo	468000
 冒雨	klfv	1760000
 映	klgd	44800000
-𪰮	klgd	0
 𣉗	klgl	0
 𥝂	klgy	0
-𫁍	klib	0
 𠠡	klik	0
 㪞	klix	3840
 𢿕	klix	0
@@ -49822,13 +47971,11 @@ encoder:
 𣆠	klzx	0
 𨜖	klzy	0
 映出	klzz	1180000
-𪰰	kmaa	0
 少于	kmad	15100000
 鉴于	kmad	17600000
 𣈨	kmae	0
 昨天	kmag	112000000
 临武	kmah	335000
-𪱦	kmaj	0
 临夏	kman	2110000
 临死	kmar	3690000
 监考	kmba	1860000
@@ -49845,7 +47992,6 @@ encoder:
 星球	kmcd	29200000
 省长	kmch	10100000
 监理	kmck	14400000
-𪼥	kmcs	0
 监事	kmdj	2880000
 省事	kmdj	6820000
 劣势	kmdq	5070000
@@ -49890,7 +48036,6 @@ encoder:
 省略	kmkr	105000000
 鉴赏	kmkw	14200000
 㫼	kmlk	3950
-𪱈	kmlk	0
 省内	kmlo	14600000
 少见	kmlr	9520000
 𧡶	kmlr	0
@@ -49919,7 +48064,6 @@ encoder:
 劣质	kmpe	5430000
 𣌌	kmpg	0
 临猗	kmqg	761000
-𪱪	kmqk	0
 临朐	kmqr	1200000
 监狱	kmqs	21800000
 少儿	kmrd	30700000
@@ -49974,14 +48118,12 @@ encoder:
 临了	kmyv	357000
 劣绅	kmzk	199000
 少女	kmzm	218000000
-𪱟	kmzm	0
 临终	kmzr	3290000
 晦	kmzy	2670000
 省级	kmzy	20600000
 𣉃	knaz	0
 𣋌	knbz	0
 𣋓	knbz	0
-𪱏	kncq	0
 𣈢	kned	0
 𣊊	knfa	0
 暤	knge	95500
@@ -49995,12 +48137,10 @@ encoder:
 𣆿	knrd	0
 晔	knre	1870000
 𣈙	knrk	0
-𪱰	knrl	0
 曒	knsm	30100
 𣌻	knuf	0
 暭	knve	59300
 曍	knve	23100
-𪱲	knxg	0
 㬋	knxm	4010
 𣉲	knxs	0
 	koaa	0
@@ -50138,7 +48278,6 @@ encoder:
 𣕇	kokf	0
 𠒼	kokg	0
 𠓉	kokg	0
-𪨓	kokh	0
 虩	koki	41300
 𧈅	koki	0
 𧒾	koki	0
@@ -50151,7 +48290,6 @@ encoder:
 揱	kokm	79500
 𡭣	kokm	0
 𡮏	kokm	0
-𪞅	kokm	0
 𠓃	kokn	0
 黋	koko	16500
 㼕	kokp	3930
@@ -50172,7 +48310,6 @@ encoder:
 𠝿	kolk	0
 𣋘	kolk	0
 䚇	koll	3770
-𪨳	koll	0
 敞	kolm	5370000
 𨿰	koln	0
 𩀯	koln	0
@@ -50207,7 +48344,6 @@ encoder:
 毟	komm	152000
 氅	komm	589000
 𦦢	komn	0
-𪨒	komn	0
 䲵	komr	4110
 𣢒	komr	0
 𩵮	komr	0
@@ -50223,16 +48359,13 @@ encoder:
 雀	koni	18200000
 𨾳	koni	0
 𡮂	konk	0
-𪿩	konl	0
 小偷	kono	23000000
 㝸	konr	4170
 𪅓	konr	0
 𤍳	konu	0
 𪕗	konz	0
 小街	koob	1650000
-𪱀	koob	0
 小人	kood	16500000
-𪨐	kooe	0
 𠣇	koof	0
 暰	kooi	88300
 𣋽	kook	0
@@ -50263,7 +48396,6 @@ encoder:
 𨛍	koqy	0
 𡜽	koqz	0
 小儿	kord	22200000
-𪞂	kori	0
 嘗	kork	3150000
 𠓑	kork	0
 𡮀	korl	0
@@ -50321,7 +48453,6 @@ encoder:
 辉	kowh	43700000
 䟫	kowj	3320
 𡭵	kowk	0
-𫇎	kowq	0
 小农	kowr	2090000
 𡭠	kowr	0
 𤇑	kowu	0
@@ -50336,20 +48467,17 @@ encoder:
 𡙪	koxg	0
 𢦢	koxh	0
 晗	koxj	1960000
-𪱗	koxj	0
 㓥	koxk	3820
 𡮷	koxl	0
 𡭩	koxo	0
 𠓇	koxq	0
 小鸡	koxr	5460000
 𣅝	koxs	0
-𪞈	koxu	0
 𡮬	koxw	0
 𡮮	koxw	0
 昐	koyd	64500
 𣌥	koyd	0
 小巴	koyi	1790000
-𪨑	koyl	0
 耀	koyn	33000000
 𦒉	koyn	0
 小队	koyo	3770000
@@ -50377,7 +48505,6 @@ encoder:
 昖	kozs	47400
 𡭲	kozz	0
 𡮍	kozz	0
-𪨍	kozz	0
 暖壶	kpbw	212000
 𧂓	kpeh	0
 暚	kpez	52800
@@ -50394,7 +48521,6 @@ encoder:
 𧞈	kpsr	0
 暖流	kpvs	1900000
 曖	kpwr	907000
-𪱇	kpxb	0
 㬭	kpxd	4200
 㫹	kpxp	3980
 昄	kpxs	68800
@@ -50407,7 +48533,6 @@ encoder:
 𣆎	kqbi	0
 明示	kqbk	5930000
 𣋐	kqbm	0
-𪱞	kqbm	0
 𪒞	kqbu	0
 明理	kqck	1110000
 明珠	kqcm	15900000
@@ -50507,7 +48632,6 @@ encoder:
 𣆡	krgy	0
 易感	krha	973000
 𣉝	krhg	0
-𫜈	krhr	0
 昆虫	kria	13000000
 𧇷	krih	0
 晚点	krij	2390000
@@ -50526,18 +48650,14 @@ encoder:
 略图	krjr	6180000
 煦	krju	2230000
 𤋗	krju	0
-𪱝	krkb	0
 㓭	krkd	4170
 昆明	krkq	52200000
 晩	krkr	13900000
-𪹽	krku	0
 㬇	krlg	4340
 昆山	krll	11800000
 𢒠	krlp	0
-𪱫	krlr	0
 易县	krlz	530000
 曻	krmb	47300
-𪰺	krmb	0
 易手	krmd	1740000
 毼	krmh	57900
 𪙶	krmi	0
@@ -50615,9 +48735,7 @@ encoder:
 景泰	ksck	831000
 暗探	ksdw	199000
 暗藏	kseh	4850000
-𪫠	ksep	0
 曩	kser	1420000
-𪱮	kser	0
 𣋩	ksfj	0
 暗想	ksfl	2320000
 影碟	ksge	5550000
@@ -50654,7 +48772,6 @@ encoder:
 𣋚	kskr	0
 𪆣	kskr	0
 暗暗	ksks	19800000
-𪱩	kskw	0
 景山	ksll	1720000
 𡦩	ksly	0
 景县	kslz	431000
@@ -50723,9 +48840,7 @@ encoder:
 昡	kszz	58700
 𣆂	kszz	0
 旷工	ktbi	471000
-𪰧	kted	0
 𣊍	ktff	0
-𪱙	ktfk	0
 旷	ktga	3100000
 曠	ktga	1870000
 𣈔	ktij	0
@@ -50735,10 +48850,8 @@ encoder:
 𣌫	ktrr	0
 旷课	ktsk	837000
 𣋳	ktuo	0
-𪱘	ktxj	0
 昿	ktzs	53000
 𣋟	ktzz	0
-𫏂	kuag	0
 曦	kuaz	5840000
 㫠	kuba	3990
 暛	kubi	51200
@@ -50766,9 +48879,7 @@ encoder:
 黹	kukl	231000
 业界	kuko	109000000
 𣤞	kukr	0
-𪵊	kuku	0
 黼	kulf	378000
-𪪓	kulf	0
 㬝	kulk	4240
 黹	kulk	231000
 𣉼	kulk	0
@@ -50794,12 +48905,10 @@ encoder:
 暽	kurm	33700
 㱉	kuro	4300
 业务	kury	582000000
-𪱯	kusx	0
 丵	kuub	26300
 業	kuuc	93900000
 菐	kuuc	125000
 對	kuud	187000000
-𪱧	kuuj	0
 𢄁	kuul	0
 㲫	kuum	3920
 晱	kuuo	89500
@@ -50813,8 +48922,6 @@ encoder:
 凿	kuuz	7060000
 䝉	kuwg	5780
 𪓎	kuwl	0
-𪱂	kuwm	0
-𪱨	kuwy	0
 黻	kuxs	393000
 邺	kuya	676000
 㷖	kuyj	4020
@@ -50835,7 +48942,6 @@ encoder:
 水土	kvba	7650000
 水城	kvbh	3800000
 水域	kvbh	5400000
-𪱡	kvbm	0
 水井	kvbn	2710000
 水塘	kvbt	2430000
 水壶	kvbw	4500000
@@ -50900,8 +49006,6 @@ encoder:
 水网	kvlo	1890000
 䳤	kvlr	4340
 𪂟	kvlr	0
-𪶦	kvlr	0
-𫜴	kvlr	0
 水牛	kvmb	6010000
 𡐞	kvmb	0
 𦗥	kvmc	0
@@ -50928,7 +49032,6 @@ encoder:
 鱉	kvmr	404000
 鳖	kvmr	4820000
 鷩	kvmr	44100
-𫝇	kvmr	0
 𣁢	kvms	0
 𤎨	kvmu	0
 憋	kvmw	11500000
@@ -50959,7 +49062,6 @@ encoder:
 水饺	kvos	1290000
 是个	kvov	133000000
 水分	kvoy	20100000
-𪶑	kvpd	0
 水质	kvpe	7930000
 水银	kvpx	1570000
 𣱻	kvqd	0
@@ -50967,10 +49069,8 @@ encoder:
 水印	kvra	7970000
 晀	kvrd	28400
 晁	kvrd	2130000
-𫚸	kvrg	0
 水解	kvrl	2190000
 斃	kvrr	2740000
-𪶠	kvry	0
 𩾼	kvrz	0
 𧩁	kvsk	0
 水产	kvsm	19200000
@@ -51008,7 +49108,6 @@ encoder:
 𣍒	kvzb	0
 水线	kvzh	519000
 凼	kvzi	695000
-𪰾	kvzm	0
 是以	kvzo	62400000
 水能	kvzq	1710000
 𠒳	kvzr	0
@@ -51041,7 +49140,6 @@ encoder:
 𣉐	kwfs	0
 常有	kwgq	7960000
 常态	kwgs	2590000
-𪱁	kwgz	0
 晕	kwhe	94900000
 晖	kwhe	9930000
 党龄	kwio	362000
@@ -51059,7 +49157,6 @@ encoder:
 曢	kwkk	1290000
 𣋪	kwkl	0
 𣊇	kwko	0
-𪱠	kwko	0
 常常	kwkw	61800000
 𤲥	kwlb	0
 𣆹	kwlc	0
@@ -51145,7 +49242,6 @@ encoder:
 思维	kwzn	39900000
 鷃	kwzr	55300
 党纪	kwzy	3830000
-𫒤	kwzy	0
 思乡	kwzz	1470000
 归于	kxad	5510000
 当天	kxag	34200000
@@ -51199,7 +49295,6 @@ encoder:
 曃	kxkw	23900
 当归	kxkx	4050000
 紧紧	kxkx	31500000
-𪱐	kxky	0
 紧盯	kxla	3930000
 归置	kxle	93300
 归罪	kxlk	653000
@@ -51313,7 +49408,6 @@ encoder:
 昲	kynd	45700
 照射	kynd	9730000
 曊	kynl	31300
-𪱑	kynl	0
 邮件	kynm	689000000
 照片	kynx	197000000
 照会	kyob	12300000
@@ -51344,7 +49438,6 @@ encoder:
 昭通	kywx	2050000
 畅通	kywx	12400000
 𣇡	kywz	0
-𪱒	kyxb	0
 男双	kyxx	466000
 邮局	kyxy	50800000
 男子	kyya	128000000
@@ -51357,7 +49450,6 @@ encoder:
 男孩	kyys	49900000
 𤭼	kyys	0
 𦐇	kyyt	0
-𪰽	kyyt	0
 遢	kyyw	3960000
 翡翠	kyyy	16800000
 邮戳	kyyy	973000
@@ -51396,7 +49488,6 @@ encoder:
 电厂	kzgg	5810000
 𣌲	kzgi	0
 𧖙	kzgi	0
-𫏠	kzgl	0
 𩒳	kzgo	0
 𣈬	kzgq	0
 𣈚	kzgs	0
@@ -51427,7 +49518,6 @@ encoder:
 电位	kzns	2860000
 电信	kzns	170000000
 𣇓	kznx	0
-𪱉	kznx	0
 𣋦	kzoe	0
 晙	kzor	166000
 𣋲	kzoz	0
@@ -51439,7 +49529,6 @@ encoder:
 电脑	kzqs	407000000
 累犯	kzqy	360000
 𣅏	kzrd	0
-𪞁	kzrd	0
 电解	kzrl	5060000
 𣆄	kzro	0
 䳛	kzrz	3450
@@ -51533,7 +49622,6 @@ encoder:
 睫	laxi	2960000
 目录	laxk	197000000
 赋予	laxx	17300000
-𪿍	laza	0
 𥆆	lazn	0
 眄	lazy	313000
 𥄆	lazz	0
@@ -51573,7 +49661,6 @@ encoder:
 周围	lbjb	59500000
 𥌆	lbjd	0
 赌咒	lbjj	365000
-𪿪	lbju	0
 周日	lbka	18400000
 𩔠	lbkg	0
 𩴈	lbkn	0
@@ -51718,7 +49805,6 @@ encoder:
 𣌧	ldak	0
 𡸭	ldal	0
 𧷅	ldal	0
-𫇯	ldal	0
 㒷	ldao	4270
 𦋭	ldao	0
 𠕔	ldaq	0
@@ -51766,7 +49852,6 @@ encoder:
 𦌎	ldeb	0
 𦊖	ldej	0
 𦊟	ldej	0
-𪞐	ldej	0
 刪	ldek	7030000
 𣌧	ldek	0
 𦋘	ldel	0
@@ -51774,14 +49859,12 @@ encoder:
 典	ldeo	69400000
 𦍅	ldeo	0
 同期	ldeq	31400000
-𫇭	ldfd	0
 𦋗	ldff	0
 同样	ldfu	112000000
 𤑇	ldfu	0
 财权	ldfx	481000
 𩢥	ldgc	0
 央	ldgd	42100000
-𫋨	ldgi	0
 𦋑	ldgj	0
 盎	ldgl	2820000
 𡘦	ldgl	0
@@ -51794,7 +49877,6 @@ encoder:
 𢘲	ldgw	0
 𪓛	ldgw	0
 㿮	ldgx	6820
-𫇠	ldgx	0
 同感	ldha	14600000
 戙	ldhm	1020000
 㢥	ldhs	3980
@@ -51864,7 +49946,6 @@ encoder:
 𦌌	ldkz	0
 𦌑	ldkz	0
 𦜽	ldkz	0
-𫝹	ldkz	0
 𦊕	ldlc	0
 𦊨	ldlc	0
 𦊩	ldlc	0
@@ -51908,7 +49989,6 @@ encoder:
 㕯	ldoj	3820
 冏	ldoj	602000
 𣇺	ldok	0
-𪨌	ldok	0
 覥	ldol	29800
 觍	ldol	44600
 𡶬	ldol	0
@@ -52023,7 +50103,6 @@ encoder:
 𦡝	ldwr	0
 同道	ldwu	3330000
 财迷	ldwu	635000
-𫇢	ldwu	0
 𪓙	ldwx	0
 𢘖	ldwy	0
 𦊦	ldwy	0
@@ -52040,7 +50119,6 @@ encoder:
 同屋	ldxh	668000
 羀	ldxk	45300
 𦋔	ldxk	0
-𫇑	ldxr	0
 𠕀	ldxs	0
 𠬸	ldxs	0
 𡱸	ldxs	0
@@ -52049,7 +50127,6 @@ encoder:
 𥀙	ldxx	0
 𦉳	ldxx	0
 𦋖	ldxx	0
-𫅸	ldxz	0
 𦊞	ldyh	0
 𦙢	ldyi	0
 财力	ldym	7120000
@@ -52135,7 +50212,6 @@ encoder:
 瞄准	letn	13100000
 𥃲	levv	0
 矒	lewl	65600
-𪿧	lewl	0
 𥌋	lewr	0
 典礼	lewz	10600000
 𥄏	lexs	0
@@ -52143,7 +50219,6 @@ encoder:
 䁋	lezf	5580
 瞸	lezf	28600
 𥍐	lezf	0
-𫖿	lezk	0
 羁绊	lezu	1390000
 𥉯	lfbb	0
 瞟	lfbk	6100000
@@ -52229,7 +50304,6 @@ encoder:
 瞘	lhjj	21100
 𥈔	lhkz	0
 𥍖	lhll	0
-𪿒	lhma	0
 𥌈	lhml	0
 眍	lhos	183000
 𥇢	lhpd	0
@@ -52243,7 +50317,6 @@ encoder:
 䀙	lhyd	6130
 𥊱	lhyl	0
 盹	lhzi	1190000
-𪪎	liac	0
 帲	liae	42400
 𢁗	liae	0
 帓	liaf	104000
@@ -52256,7 +50329,6 @@ encoder:
 帢	liaj	96100
 贴画	liak	455000
 帞	lian	192000
-𪪐	lian	0
 𢄅	liau	0
 𢁮	liax	0
 㡢	liay	20900
@@ -52277,7 +50349,6 @@ encoder:
 帏	liby	607000
 㡁	libz	4600
 𢁢	libz	0
-𪪔	libz	0
 帱	licd	86200
 𢁚	licd	0
 𢃈	lice	0
@@ -52303,7 +50374,6 @@ encoder:
 㡒	liel	3910
 幩	liel	38000
 𢃜	liel	0
-𪪍	liel	0
 贴花	lien	532000
 𢂔	lieo	0
 𢂾	lies	0
@@ -52379,7 +50449,6 @@ encoder:
 幝	like	36000
 𢅀	like	0
 𥇍	like	0
-𪪌	like	0
 𢃦	likf	0
 幌	likg	2330000
 幙	likg	183000
@@ -52570,7 +50639,6 @@ encoder:
 贴边	liwy	161000
 𢃙	liwy	0
 贴心	liwz	20000000
-𪪉	lixd	0
 𢁪	lixg	0
 𢾔	lixg	0
 幄	lixh	356000
@@ -52578,11 +50646,9 @@ encoder:
 𢅟	lixi	0
 𥈤	lixi	0
 𢂽	lixj	0
-𪪈	lixj	0
 𢃼	lixl	0
 𢄟	lixl	0
 帿	lixm	89300
-𪿔	lixm	0
 帗	lixs	559000
 𠬥	lixs	0
 𥄎	lixs	238
@@ -52599,13 +50665,11 @@ encoder:
 㼙	liys	4320
 𢁡	liys	0
 𥌯	liys	0
-𪪑	liyu	0
 贴己	liyy	40200
 𢂐	liyy	0
 𢄒	liyy	0
 𢁠	liyz	0
 幉	lizf	536000
-𪪒	lizg	0
 𥍗	lizi	0
 𢄍	lizl	0
 𢅤	lizl	0
@@ -52624,10 +50688,8 @@ encoder:
 瞆	ljal	30000
 瞶	ljal	831000
 𥆰	ljan	0
-𪿓	ljaz	0
 𠹬	ljbr	0
 𥈭	ljbz	0
-𪿖	ljbz	0
 䁒	ljce	5920
 𥍓	ljcm	0
 䫚	ljgo	3360
@@ -52651,7 +50713,6 @@ encoder:
 𢢸	ljrw	0
 𥆽	ljsx	0
 𣂄	ljte	0
-𪬢	ljwz	0
 𥇂	ljyk	0
 罒	lkaa	1270000
 䵦	lkad	4870
@@ -52684,10 +50745,8 @@ encoder:
 𪒩	lkak	0
 四百	lkan	7210000
 睤	lkan	26200
-𫅺	lkao	0
 刚烈	lkar	951000
 四列	lkar	413000
-𪿄	lkar	0
 四平	lkau	5490000
 𥁔	lkaw	0
 𦊃	lkax	0
@@ -52706,7 +50765,6 @@ encoder:
 𪒖	lkbb	0
 罻	lkbd	82900
 𡭀	lkbd	0
-𫅾	lkbd	0
 罫	lkbi	377000
 黠	lkbj	867000
 𪒧	lkbj	0
@@ -52727,7 +50785,6 @@ encoder:
 𪑅	lkbz	0
 𪒝	lkbz	0
 𪓂	lkbz	0
-𫅲	lkbz	0
 𪒑	lkcl	0
 𪒆	lkcm	0
 𪒠	lkcm	0
@@ -52765,7 +50822,6 @@ encoder:
 𢻧	lkex	0
 𦌖	lkex	0
 𪔒	lkex	0
-𪯟	lkex	0
 黮	lkez	73800
 䍒	lkfa	6770
 𦊚	lkfa	0
@@ -52778,7 +50834,6 @@ encoder:
 𦊵	lkfq	0
 四楼	lkfu	5980000
 𪒜	lkfw	0
-𫅻	lkfy	0
 𦌋	lkgb	0
 四大	lkgd	48500000
 𦉼	lkgd	0
@@ -52855,7 +50910,6 @@ encoder:
 𥊼	lkjh	0
 𦌭	lkji	0
 𦍈	lkji	0
-𫅼	lkjj	0
 黥	lkjk	408000
 𥋓	lkjk	0
 𥋇	lkjm	0
@@ -52923,7 +50977,6 @@ encoder:
 𦋸	lkkz	0
 𦌁	lkkz	0
 𪒎	lkkz	0
-𫝟	lkkz	0
 四周	lklb	28200000
 罝	lklc	103000
 𦊤	lkld	0
@@ -52940,7 +50993,6 @@ encoder:
 罾	lklk	171000
 𡮨	lklk	0
 𪒟	lklk	0
-𫅽	lklk	0
 䚑	lkll	3630
 黷	lkll	97200
 𡶩	lkll	0
@@ -52973,11 +51025,8 @@ encoder:
 𪓀	lkmi	0
 𪑜	lkmj	0
 𪒦	lkml	0
-𪿊	lkml	0
-𪿟	lkml	0
 𦋋	lkmm	0
 𩙽	lkmn	0
-𫝡	lkmn	0
 𪃦	lkmr	0
 𪃧	lkmr	0
 𪑄	lkmr	0
@@ -53000,7 +51049,6 @@ encoder:
 四份	lkno	832000
 四化	lknr	1230000
 𪈰	lknr	0
-𫅳	lknr	0
 四倍	lkns	2170000
 罪魁	lknt	4170000
 邏	lknw	351000
@@ -53041,7 +51089,6 @@ encoder:
 𦊓	lkow	0
 𦌣	lkow	0
 𪐸	lkow	0
-𫝠	lkow	0
 四分	lkoy	9950000
 𪑋	lkpd	0
 𪒐	lkpl	0
@@ -53067,7 +51114,6 @@ encoder:
 四处	lkri	21700000
 四外	lkri	382000
 蜀	lkri	65200000
-𫏕	lkri	0
 罪名	lkrj	6660000
 𦊒	lkrj	0
 𦊲	lkrj	0
@@ -53121,8 +51167,6 @@ encoder:
 罸	lksd	117000
 刚毅	lksg	1760000
 𦉾	lksh	0
-𪵠	lksi	0
-𫅿	lksi	0
 罚	lksk	43000000
 罯	lksk	17600
 罰	lksk	10100000
@@ -53132,7 +51176,6 @@ encoder:
 䁿	lksl	6480
 𥊷	lksl	0
 𪑥	lksl	0
-𫅷	lksn	0
 𪒄	lkso	0
 𪐦	lksq	0
 𦌽	lkss	0
@@ -53208,7 +51251,6 @@ encoder:
 𪐩	lkuu	0
 𪑓	lkuu	0
 䵴	lkuw	4910
-𫝤	lkuw	0
 𦋰	lkux	0
 𪑉	lkux	0
 罤	lkuy	36000
@@ -53222,7 +51264,6 @@ encoder:
 䵝	lkuz	4050
 𦅔	lkuz	0
 四海	lkvm	15600000
-𫅶	lkvr	0
 𪑬	lkwa	0
 罪过	lkwd	5640000
 𪒴	lkwh	0
@@ -53280,7 +51321,6 @@ encoder:
 𡤔	lkzj	0
 𦌟	lkzk	0
 𪑔	lkzk	0
-𪾊	lkzk	0
 𦋽	lkzl	0
 瞜	lkzm	142000
 䍦	lkzn	4150
@@ -53321,8 +51361,6 @@ encoder:
 𡴵	llai	0
 𡴶	llai	0
 𡶛	llai	0
-𪨱	llai	0
-𪩔	llai	0
 㞹	llaj	4130
 㟃	llaj	4330
 㟢	llaj	4870
@@ -53358,7 +51396,6 @@ encoder:
 𡷧	llax	0
 𡷴	llax	0
 𡼘	llax	0
-𪩋	llax	0
 𡥏	llay	0
 㞻	llaz	3710
 崴	llaz	4000000
@@ -53378,7 +51415,6 @@ encoder:
 嵵	llbd	78100
 嶎	llbd	271000
 𡻄	llbd	0
-𪩪	llbd	0
 嶢	llbg	90400
 嶤	llbg	34500
 𡼔	llbg	0
@@ -53414,7 +51450,6 @@ encoder:
 𡷗	llbr	0
 𣣗	llbr	0
 𪅁	llbr	0
-𫜃	llbr	0
 䁫	llbu	5790
 䁺	llbu	6080
 峡	llbu	9010000
@@ -53465,14 +51500,12 @@ encoder:
 㠡	llcr	5310
 𡸘	llcx	0
 𡸨	llcx	0
-𪩮	llcx	0
 𡷝	llcz	0
 㟛	llde	3780
 𡺵	lldm	0
 嶊	lldn	48300
 山势	lldq	1320000
 𡷠	lldq	0
-𫜉	lldr	0
 𡻞	llea	0
 㠏	lleb	4660
 崋	lleb	320000
@@ -53480,12 +51513,10 @@ encoder:
 𡶑	lleb	0
 𡻞	lleb	0
 𡻸	lleb	0
-𪩤	lleb	0
 𡸷	llec	0
 𡽼	llef	0
 𡸳	lleg	0
 𩓤	lleg	0
-𪩥	lleh	0
 岵	llej	169000
 崌	llej	744000
 崓	llej	52900
@@ -53500,12 +51531,10 @@ encoder:
 𡸜	llel	0
 𡸽	llel	0
 𡼝	llel	0
-𪩓	llel	0
 嶻	llen	24600
 𡽱	llen	0
 睓	lleo	24000
 𡶵	lleo	0
-𪩨	llep	0
 𡼼	lleq	0
 㠌	ller	4850
 㠤	ller	5050
@@ -53518,19 +51547,15 @@ encoder:
 𡹉	llex	0
 𡽂	llex	0
 𤿣	llex	0
-𪨵	llex	0
 嵁	llez	684000
 𡺯	llez	0
 𦉍	llez	0
-𪩃	llez	0
 𡽒	llfa	0
 㟽	llfb	3930
 峬	llfb	28900
 山村	llfd	8480000
 嶟	llfd	28000
 𡷾	llfd	0
-𪩚	llfd	0
-𪩞	llfd	0
 㟳	llff	3970
 山林	llff	7500000
 山麓	llff	2800000
@@ -53568,7 +51593,6 @@ encoder:
 𡊽	llgb	0
 𡶂	llgb	0
 𡾑	llgb	0
-𪩍	llgb	0
 眏	llgd	164000
 𥈀	llgd	0
 㟸	llge	4160
@@ -53586,7 +51610,6 @@ encoder:
 𡾏	llgg	0
 𡾷	llgg	0
 𡷰	llgh	0
-𪩇	llgh	0
 㞸	llgi	4280
 剬	llgk	407000
 𡾡	llgk	0
@@ -53595,7 +51618,6 @@ encoder:
 耑	llgl	133000
 𡼴	llgl	0
 𩨮	llgl	0
-𪩌	llgl	0
 㟌	llgm	3980
 𡶨	llgm	0
 𡺝	llgm	0
@@ -53629,7 +51651,6 @@ encoder:
 𡻑	llgs	0
 𡽣	llgs	0
 𤟮	llgs	0
-𪩩	llgs	0
 𦓣	llgt	0
 炭	llgu	19400000
 𥋭	llgu	0
@@ -53653,7 +51674,6 @@ encoder:
 㟞	llhh	3680
 嶘	llhh	20200
 𡸚	llhh	0
-𪩰	llhh	0
 岈	llhi	761000
 𡵥	llhi	0
 𡶅	llhj	0
@@ -53664,8 +51684,6 @@ encoder:
 𡶔	llhm	0
 𡶙	llhm	0
 𢧮	llhm	0
-𪩙	llhm	0
-𪭪	llhm	0
 山区	llho	23900000
 岖	llho	225000
 𡼠	llho	0
@@ -53677,7 +51695,6 @@ encoder:
 𡷫	llhy	0
 㞽	llhz	4590
 𡶁	llhz	0
-𪨺	llhz	0
 𣦣	llii	0
 𧔮	llii	0
 岾	llij	61300
@@ -53705,7 +51722,6 @@ encoder:
 𡵊	lliy	0
 𡵋	lliy	0
 𡼕	lliy	0
-𪩗	lliy	0
 山口	llja	58800000
 嶹	lljd	31900
 𡼢	lljd	0
@@ -53715,7 +51731,6 @@ encoder:
 嶑	lljg	30100
 𡾆	lljg	0
 𡿃	lljg	0
-𪩯	lljg	0
 㞲	llji	3650
 嵹	llji	35600
 𡷿	llji	0
@@ -53767,14 +51782,12 @@ encoder:
 𡽡	lljr	0
 𡿢	lljr	0
 𥌡	lljr	0
-𪩉	lljr	0
 㠔	lljs	4490
 䁗	llju	5560
 嵦	llju	37700
 嶝	llju	236000
 豈	llju	3710000
 𡽍	llju	0
-𪩛	lljw	0
 𡷮	lljx	0
 𡸪	lljx	0
 崞	lljy	146000
@@ -53822,12 +51835,10 @@ encoder:
 𡾍	llkk	0
 𡾪	llkk	0
 𣋎	llkk	0
-𪩁	llkk	0
 㠠	llkl	10100
 𡻾	llkl	0
 𡵯	llkm	0
 𡼧	llkm	0
-𪩈	llkm	0
 峺	llko	59700
 峭	llkq	1790000
 𡹌	llkq	0
@@ -53847,7 +51858,6 @@ encoder:
 汖	llkv	22700
 𡵰	llkv	0
 𥉀	llkv	0
-𪩔	llkv	0
 崽	llkw	3940000
 𡾅	llkw	0
 岿	llkx	429000
@@ -53864,8 +51874,6 @@ encoder:
 𡿔	llkz	0
 𡿜	llkz	0
 𥋁	llkz	0
-𪩐	llkz	0
-𪩢	llkz	0
 𡎨	lllb	0
 𡷌	lllb	0
 𡻉	lllb	0
@@ -53901,7 +51909,6 @@ encoder:
 𡾓	lllk	0
 𡾽	lllk	0
 𡿘	lllk	0
-𪩫	lllk	0
 山岗	llll	843000
 屾	llll	2300000
 岀	llll	1170000
@@ -53920,7 +51927,6 @@ encoder:
 𡻗	lllo	0
 𡽆	lllo	0
 𥋻	lllo	0
-𪩊	lllo	0
 𦞄	lllq	0
 山峰	lllr	5180000
 岘	lllr	571000
@@ -53928,7 +51934,6 @@ encoder:
 𡷹	lllr	0
 𪂓	lllr	0
 𪈥	lllr	0
-𪩲	lllt	0
 𡻋	lllw	0
 𡾢	lllw	0
 𡻩	lllx	0
@@ -53944,7 +51949,6 @@ encoder:
 𡾸	lllz	0
 𥌽	lllz	0
 𥍈	lllz	0
-𪩟	lllz	0
 㞺	llma	3680
 𡵜	llmb	0
 𡾬	llmc	0
@@ -53969,7 +51973,6 @@ encoder:
 峼	llmj	25300
 峲	llmk	37300
 𡸉	llmk	0
-𪩅	llmk	0
 𡺗	llml	0
 𡽳	llml	0
 𡽾	llml	0
@@ -53984,7 +51987,6 @@ encoder:
 𥆹	llms	0
 𡺘	llmu	0
 𡻻	llmu	0
-𪩑	llmu	0
 𡶉	llmw	0
 㟹	llmy	3820
 屹	llmy	1720000
@@ -53995,10 +51997,6 @@ encoder:
 𡸬	llmy	0
 𡺇	llmy	0
 𡼅	llmy	0
-𪨲	llmy	0
-𪨶	llmy	0
-𪨼	llmy	0
-𪩱	llmy	0
 崣	llmz	602000
 𡹜	llmz	0
 𡾥	llmz	0
@@ -54007,7 +52005,6 @@ encoder:
 崲	llnc	734000
 𡻇	llnc	0
 𩧚	llnc	0
-𪩖	llnc	0
 山川	llnd	6190000
 𡵅	llnd	0
 崥	llne	650000
@@ -54091,7 +52088,6 @@ encoder:
 峜	lloi	20600
 嵷	lloi	29600
 嵸	lloi	27600
-𪩄	lloi	0
 峪	lloj	3670000
 嵱	lloj	31700
 𡾰	lloj	0
@@ -54109,7 +52105,6 @@ encoder:
 𡵚	llon	0
 𡸻	llon	0
 𥜺	llon	0
-𪩭	llon	0
 山谷	lloo	8960000
 峧	lloo	32500
 峽	lloo	1430000
@@ -54151,7 +52146,6 @@ encoder:
 𡾴	llor	0
 𡿟	llor	0
 𪌨	llor	0
-𪨷	llor	0
 嶦	llos	27200
 𡶍	llos	0
 𡶖	llos	0
@@ -54161,7 +52155,6 @@ encoder:
 𡼶	llou	0
 岭	llow	27200000
 岺	llow	67600
-𪩋	llow	0
 㟟	lloy	3960
 岎	lloy	26100
 𠨤	lloy	0
@@ -54170,7 +52163,6 @@ encoder:
 𡸐	lloy	0
 𡼌	lloy	0
 𢁃	lloy	0
-𪩜	lloy	0
 㟣	lloz	4230
 崧	lloz	1190000
 𡵴	lloz	0
@@ -54220,7 +52212,6 @@ encoder:
 𡹔	llqq	0
 𡼜	llqq	0
 𧢛	llqq	0
-𪨻	llqq	0
 山脉	llqs	4690000
 𡴿	llqs	0
 𡼈	llqs	0
@@ -54228,7 +52219,6 @@ encoder:
 𡴿	llqy	0
 𡺮	llqy	0
 𡻰	llrb	0
-𪩎	llrb	0
 峯	llrc	1410000
 峰	llrc	98100000
 𡷄	llrc	0
@@ -54237,11 +52227,9 @@ encoder:
 婴儿	llrd	26100000
 嶈	llrd	985000
 𡺃	llrd	0
-𪿐	llrd	0
 㟆	llre	3920
 𡸝	llre	0
 𡸇	llrf	0
-𪩝	llrg	0
 㞴	llrh	4340
 𥋛	llri	0
 㟯	llrj	4060
@@ -54251,7 +52239,6 @@ encoder:
 𡷂	llrj	0
 𡺀	llrj	0
 𡽘	llrj	0
-𪩕	llrj	0
 㟜	llrk	3790
 刿	llrk	256000
 峋	llrk	105000
@@ -54332,7 +52319,6 @@ encoder:
 𡵀	llsh	0
 巃	llsi	80300
 巄	llsi	75800
-𪨸	llsi	0
 㟝	llsj	3730
 𡻓	llsj	0
 峕	llsk	25500
@@ -54380,7 +52366,6 @@ encoder:
 嵊	lltr	847000
 𡾌	lltu	0
 𡼂	lltx	0
-𪩠	lltx	0
 䁼	llub	6070
 嵯	llub	307000
 嵳	llub	32000
@@ -54395,7 +52380,6 @@ encoder:
 𡾛	llue	0
 崷	lluf	759000
 𡺚	lluf	0
-𫃤	lluf	0
 㠗	llug	4190
 嵄	llug	59000
 顗	llug	205000
@@ -54433,14 +52417,12 @@ encoder:
 㟡	lluy	3710
 𡸩	lluy	0
 嵝	lluz	165000
-𪩘	lluz	0
 山河	llva	5460000
 𡷍	llvb	0
 山洪	llve	1420000
 𡼗	llve	0
 𡷉	llvi	0
 山沟	llvr	1370000
-𪩂	llvr	0
 㟈	llvs	4040
 山涧	llvt	987000
 䀠	llvv	9360
@@ -54482,7 +52464,6 @@ encoder:
 㟉	llwm	3930
 𡵘	llwm	0
 𡶮	llwm	0
-𪩡	llwn	0
 岤	llwo	21800
 𡹢	llwp	0
 䳥	llwr	4720
@@ -54495,7 +52476,6 @@ encoder:
 𥌂	llws	0
 𡹨	llwx	0
 𡽑	llwx	0
-𪩏	llwx	0
 㟑	llwy	3630
 崂	llwy	281000
 嶗	llwy	29700
@@ -54582,15 +52562,12 @@ encoder:
 𡴭	llyd	0
 𡴯	llyd	0
 𡸠	llye	0
-𫗱	llyg	0
 岷	llyh	1740000
 𡶗	llyh	0
 岗巴	llyi	103000
 岜	llyi	335000
 𡵟	llyi	0
 𡿖	llyi	0
-𪨴	llyi	0
-𪩬	llyi	0
 岧	llyj	43700
 岹	llyj	26500
 𡶐	llyj	0
@@ -54600,7 +52577,6 @@ encoder:
 𠛕	llyk	0
 𡷘	llyk	0
 觊	llyl	194000
-𪩒	llyl	0
 㞧	llym	3970
 㟼	llym	4060
 㠂	llym	7110
@@ -54611,7 +52587,6 @@ encoder:
 𡸅	llym	0
 𡻎	llym	0
 𡽖	llym	0
-𪿙	llym	0
 㠄	llyn	5860
 㠕	llyn	4070
 岪	llyn	25300
@@ -54621,7 +52596,6 @@ encoder:
 𡽢	llyn	0
 凯	llyq	78000000
 𡿚	llyq	0
-𪩦	llyq	0
 㼘	llys	4290
 㼷	llys	5280
 屻	llys	660000
@@ -54636,7 +52610,6 @@ encoder:
 𤮞	llys	0
 𤮯	llys	0
 𤮰	llys	0
-𪩣	llys	0
 嵶	llyt	37800
 𡺒	llyt	0
 𡷞	llyw	0
@@ -54656,11 +52629,7 @@ encoder:
 𦏿	llyy	0
 𦒀	llyy	0
 𨟎	llyy	0
-𪩧	llyy	0
-𫆗	llyy	0
 𡴰	llyz	0
-𪨾	llyz	0
-𪨿	llyz	0
 乢	llza	56200
 屿	llza	3540000
 𡼺	llzb	0
@@ -54724,9 +52693,7 @@ encoder:
 𡼊	llzz	0
 𡼿	llzz	0
 𡽈	llzz	0
-𪨽	llzz	0
 𥅸	lmai	0
-𪿬	lmaj	0
 败坏	lmbg	4600000
 矄	lmbu	45500
 䀒	lmea	5680
@@ -54746,7 +52713,6 @@ encoder:
 𥊈	lmkf	0
 𥅲	lmko	0
 𥋘	lmkq	0
-𪿲	lmkz	0
 𥅧	lmlk	0
 𥇕	lmlk	0
 峨山	lmll	376000
@@ -54766,7 +52732,6 @@ encoder:
 眣	lmod	49100
 𥌛	lmok	0
 𥃶	lmqd	0
-𪿤	lmrb	0
 巍然	lmrg	1130000
 𥌳	lmrk	0
 𥌇	lmrm	0
@@ -54828,26 +52793,21 @@ encoder:
 瞍	lnxs	114000
 𥅀	lnxt	0
 𥅂	lnyi	0
-𪿥	lnym	0
 𥌝	lnzu	0
 貝	loaa	21100000
 贝	loaa	81800000
 𥊤	load	0
 𧵴	load	0
-𫏊	load	0
 𥄺	loae	0
 内政	loai	4560000
 䀫	loaj	6190
 𧵀	loaj	0
 𧵛	loaj	0
-𫏑	loaj	0
 𧸗	loak	0
 睔	loal	44100
 𧸃	loal	0
 𧸽	loal	0
-𫏐	loal	0
 𥌩	loaw	0
-𪿕	loax	0
 盻	loaz	161000
 䝽	lobb	3560
 䝰	lobd	3980
@@ -54869,7 +52829,6 @@ encoder:
 賘	lobs	28400
 内地	lobv	40000000
 睑	lobv	1060000
-𫏣	lobv	0
 贝壳	lobw	6310000
 𧷌	lobx	0
 𧷿	loby	0
@@ -54931,11 +52890,9 @@ encoder:
 内存	logi	61100000
 蠈	logi	60400
 䞅	logj	3640
-𫏒	logj	0
 睎	logl	65600
 𥋎	logl	0
 𧶖	logl	0
-𫏡	logm	0
 网页	logo	437000000
 具有	logq	278000000
 内有	logq	11400000
@@ -54995,14 +52952,11 @@ encoder:
 𥌺	lojl	0
 𧹊	lojl	0
 𧶞	lojm	0
-𫏙	lojm	0
 𥇥	lojo	0
 𧵙	lojo	0
 貺	lojr	56800
 贶	lojr	169000
 𥆟	lojr	0
-𫏔	lojr	0
-𪺕	loju	0
 网吧	lojy	41600000
 𧷚	lojz	0
 𥍀	loka	0
@@ -55012,11 +52966,9 @@ encoder:
 則	lokd	84100000
 𡬷	lokd	0
 贉	loke	32600
-𫏦	loke	0
 𧷣	lokf	0
 𧵦	lokg	0
 𧷸	lokg	0
-𫏝	lokg	0
 𧸉	lokh	0
 䞎	lokk	3400
 𧶧	lokk	0
@@ -55043,7 +52995,6 @@ encoder:
 𧵌	lolg	0
 𧶲	lolg	0
 𧹈	lolg	0
-𪥩	lolg	0
 瞺	lolk	39200
 贈	lolk	18600000
 赠	lolk	62800000
@@ -55104,7 +53055,6 @@ encoder:
 𧸜	lomx	0
 䝯	lomy	4320
 𧷆	lomy	0
-𫏋	lomy	0
 𧶅	lomz	0
 网段	lonc	1220000
 𥄍	lond	0
@@ -55124,7 +53074,6 @@ encoder:
 𧸳	loob	0
 賥	looe	115000
 賝	loof	38900
-𫏤	loof	0
 内行	looi	1890000
 瞛	looi	35900
 䀰	looj	7690
@@ -55169,22 +53118,18 @@ encoder:
 𧸳	lorb	0
 𧵄	lorh	0
 内外	lori	68400000
-𫏌	lori	0
 䝭	lorj	3410
 具名	lorj	2490000
 賂	lorj	237000
 赂	lorj	610000
 𧸚	lorj	0
-𫏢	lorj	0
 具备	lork	71600000
 𧵉	lork	0
 𧵣	lork	0
-𫏚	lork	0
 内角	lorl	400000
 𧹏	lorl	0
 𧸍	lorm	0
 𧸮	lorm	0
-𫏘	lorn	0
 賜	loro	5830000
 赐	loro	21800000
 𧶽	loro	0
@@ -55201,7 +53146,6 @@ encoder:
 𧵈	lorz	0
 䝬	losc	3670
 𥆜	losc	0
-𫏥	losf	0
 网站	losi	1530000000
 贚	losi	32300
 内部	losj	133000000
@@ -55219,7 +53163,6 @@ encoder:
 赆	lost	78200
 内详	losu	819000
 𥄯	losx	0
-𫏍	losy	0
 賍	lotb	92400
 赃	lotb	1470000
 𧴼	lote	0
@@ -55257,7 +53200,6 @@ encoder:
 贝宁	lowa	1360000
 贮	lowa	4980000
 𧶺	lowa	0
-𫏎	lowa	0
 内窥	lowb	1040000
 賩	lowb	123000
 𧸵	lowb	0
@@ -55356,7 +53298,6 @@ encoder:
 𥉟	lpqx	0
 眽	lprh	231000
 瞬	lprm	9380000
-𪿝	lpro	0
 𪅚	lprr	0
 瞬间	lptk	56800000
 𥇶	lpvv	0
@@ -55392,7 +53333,6 @@ encoder:
 𧢡	lrcm	0
 䙷	lrds	3500
 䙸	lrds	3700
-𫍝	lrel	0
 𧡝	lreo	0
 𧡉	lrev	0
 𧡷	lrez	0
@@ -55410,7 +53350,6 @@ encoder:
 睌	lrjr	95900
 见图	lrjr	3200000
 𧢊	lrjr	0
-𫍘	lrjr	0
 𥈈	lrju	0
 罗田	lrki	389000
 䀥	lrko	6430
@@ -55429,7 +53368,6 @@ encoder:
 覞	lrlr	36700
 骶骨	lrlw	177000
 𧢅	lrlw	0
-𪿜	lrmb	0
 𧠑	lrmh	0
 购租	lrml	51500
 购物	lrmr	207000000
@@ -55447,18 +53385,14 @@ encoder:
 𥋂	lror	0
 瞻	lros	5310000
 𥇰	lrow	0
-𪬡	lrow	0
-𫍢	lrpg	0
 购销	lrpk	7820000
 罗盘	lrpl	1340000
 𧡒	lrpr	0
 𧠘	lrpv	0
 覹	lrqm	30800
-𫍨	lrqm	0
 岁月	lrqv	49800000
 𥆯	lrrb	0
 见外	lrri	1080000
-𫍤	lrrj	0
 罗甸	lrrk	160000
 见解	lrrl	13600000
 𧢤	lrrm	0
@@ -55501,8 +53435,6 @@ encoder:
 觃	lrya	32800
 𥅺	lryi	0
 𥉳	lryk	0
-𫍞	lrzf	0
-𫍗	lrzm	0
 𥌲	lsae	0
 罚款	lsbb	13100000
 赔款	lsbb	1790000
@@ -55528,7 +53460,6 @@ encoder:
 嵩县	lslz	309000
 瞝	lslz	32600
 𥊓	lsmm	0
-𪿞	lsmo	0
 䀮	lsnd	7040
 瞓	lsnd	425000
 赔付	lsnd	4470000
@@ -55567,10 +53498,8 @@ encoder:
 𥊚	ltff	0
 𧡆	ltlr	0
 赃物	ltmr	1100000
-𪿳	ltnr	0
 𥌾	ltnw	0
 𥌬	ltob	0
-𪿘	ltro	0
 𥋨	ltrr	0
 𥌜	ltuo	0
 𥋲	ltux	0
@@ -55589,7 +53518,6 @@ encoder:
 𥌨	lugo	0
 赠品	lujj	8770000
 𥆟	lujr	0
-𪿭	lukk	0
 𥉋	lukv	0
 䁬	lulk	5780
 𥋟	lumh	0
@@ -55661,7 +53589,6 @@ encoder:
 用费	lvyn	424000
 用以	lvzo	9290000
 骬	lwad	20000
-𪿗	lwad	0
 䯎	lwae	3250
 骨干	lwae	30200000
 骭	lwae	71200
@@ -55797,7 +53724,6 @@ encoder:
 𩪣	lwkw	0
 髏	lwkz	1080000
 𥉛	lwkz	0
-𪿮	lwkz	0
 矃	lwla	34400
 𩩅	lwld	0
 𩩆	lwlh	0
@@ -55872,7 +53798,6 @@ encoder:
 𩨼	lwpd	0
 𥋺	lwpn	0
 髌	lwpo	348000
-𪿦	lwpo	0
 𩨯	lwps	0
 𩨢	lwpv	0
 𩨩	lwpx	0
@@ -55880,7 +53805,6 @@ encoder:
 𩨺	lwqa	0
 骪	lwqd	19900
 𩨒	lwqd	0
-𫙶	lwqk	0
 骨股	lwqq	21600
 骫	lwqs	45800
 髄	lwqw	835000
@@ -55952,8 +53876,6 @@ encoder:
 𩨭	lwwr	0
 髈	lwws	30700
 崇礼	lwwz	517000
-𫙷	lwxb	0
-𫙸	lwxh	0
 骳	lwxi	64000
 𩩊	lwxj	0
 𩩑	lwxj	0
@@ -56013,7 +53935,6 @@ encoder:
 𥌻	lxfl	0
 䀗	lxgd	5580
 瞩	lxil	584000
-𪿡	lxjm	0
 䁹	lxjs	6180
 眼圈	lxju	7620000
 瞪	lxju	19800000
@@ -56043,11 +53964,9 @@ encoder:
 眼熟	lxsj	2410000
 䁊	lxsl	6130
 𢯲	lxsm	0
-𪿫	lxso	0
 𥄗	lxss	0
 𥄗	lxtd	0
 眼底	lxtr	6730000
-𪿢	lxuf	0
 𤈳	lxuo	0
 眼前	lxuq	53300000
 眼泪	lxvl	49200000
@@ -56156,10 +54075,8 @@ encoder:
 𥃤	lzvv	0
 悬空	lzwb	1910000
 贻害	lzwc	627000
-𫝧	lzws	0
 𥆸	lzxg	0
 𪔊	lzxw	0
-𫝦	lzxy	0
 𥄉	lzzd	0
 𥈒	lzze	0
 䁻	lzzf	6050
@@ -56180,9 +54097,7 @@ encoder:
 筓	maae	32300
 𥏢	maae	0
 𦈨	maae	0
-𫕥	maae	0
 𣔍	maaf	0
-𪥢	maag	0
 𦈢	maai	0
 𦉁	maai	0
 缿	maaj	34700
@@ -56191,8 +54106,6 @@ encoder:
 𥰯	maaj	0
 𠚻	maak	0
 𢆫	maak	0
-𪿸	maak	0
-𪿽	maal	0
 𥏄	maan	0
 𪖬	maan	0
 䍈	maau	4520
@@ -56230,11 +54143,9 @@ encoder:
 𨢮	madf	0
 䵹	madw	4210
 䍋	maeb	3980
-𪿹	maec	0
 午	maed	18800000
 竿	maed	9870000
 𥎧	maed	0
-𫅮	maef	0
 𩑤	maeg	0
 卸载	maeh	9490000
 𦈢	maei	0
@@ -56252,7 +54163,6 @@ encoder:
 𨳱	maex	0
 缶	maez	15400000
 𣫸	maez	0
-𫅰	maez	0
 秤杆	mafa	111000
 缽	mafa	987000
 罇	mafd	39100
@@ -56263,7 +54173,6 @@ encoder:
 𥱄	magi	0
 𦈶	magj	0
 矫	magn	3830000
-𫂢	magr	0
 𥏣	magu	0
 秤砣	magw	135000
 𪓳	magw	0
@@ -56284,14 +54193,12 @@ encoder:
 𥫫	maid	0
 䇥	maii	3930
 䍄	maij	5510
-𫝎	maij	0
 𠛢	maik	0
 䈣	maim	4410
 𦈾	maim	0
 𦉋	maim	0
 𦉌	maim	0
 𦥲	main	0
-𪩴	main	0
 𩛒	maio	0
 䂑	mair	5020
 欫	mair	17700
@@ -56313,7 +54220,6 @@ encoder:
 𦉢	majj	0
 䈏	majk	4660
 智	majk	95600000
-𪵷	majk	0
 䈪	majl	4410
 䝷	majl	3740
 矯	majl	840000
@@ -56357,7 +54263,6 @@ encoder:
 罏	makl	33200
 𣬁	makl	0
 𥏟	makl	0
-𪿷	makm	0
 尓	mako	1350000
 筻	mako	70500
 复	makr	83200000
@@ -56368,7 +54273,6 @@ encoder:
 𥎽	malg	0
 𥫴	mali	0
 矰	malk	79800
-𫃖	mall	0
 𦉎	maln	0
 䇤	malo	4650
 䂓	malr	6120
@@ -56377,9 +54281,7 @@ encoder:
 短短	mama	21900000
 年	mamb	3780000000
 𥏎	mamb	0
-𫅬	mamb	0
 短缺	mame	9590000
-𪿺	mamf	0
 矨	mamg	51000
 竹	mami	95200000
 𥫧	mami	0
@@ -56413,7 +54315,6 @@ encoder:
 𩱢	mana	0
 𥐌	manb	0
 𥬂	mand	0
-𪿼	mand	0
 𥏠	mane	0
 𣜫	manf	0
 雉	mani	2240000
@@ -56453,11 +54354,9 @@ encoder:
 矪	mapy	136000
 𦈴	mapy	0
 𤧧	maqc	0
-𪿾	maqk	0
 䌓	maqz	4730
 𣒧	marf	0
 短处	mari	1280000
-𪟶	mari	0
 𥏍	marj	0
 𥬭	mark	0
 舞	marm	131000000
@@ -56525,7 +54424,6 @@ encoder:
 乞	mayd	5090000
 𨢱	mayf	0
 𩑔	mayg	0
-𫗭	mayg	0
 㐌	mayi	6130
 矧	mayi	506000
 𧆦	mayi	0
@@ -56534,7 +54432,6 @@ encoder:
 刉	mayk	108000
 𥏵	mayk	0
 𦉉	mayk	0
-𪿻	mayk	0
 𧠡	mayl	0
 㩿	maym	4150
 𢼏	maym	0
@@ -56581,7 +54478,6 @@ encoder:
 𥐈	mazm	0
 毓	mazn	5060000
 𦈷	mazn	0
-𫅭	mazn	0
 𦈲	mazo	0
 𩛕	mazo	0
 𨧊	mazp	0
@@ -56619,7 +54515,6 @@ encoder:
 𤜃	mbae	0
 𤘠	mbag	0
 𤙬	mbag	0
-𪞆	mbag	0
 𤘖	mbai	0
 𤙐	mbai	0
 𤚍	mbai	0
@@ -56630,7 +54525,6 @@ encoder:
 㸬	mbal	4700
 𣘈	mbal	0
 𣜱	mbal	0
-𪳴	mbal	0
 特殊	mbar	157000000
 𤘾	mbau	0
 𤘡	mbax	0
@@ -56660,7 +54554,6 @@ encoder:
 𪒷	mbbu	0
 特地	mbbv	11100000
 犍	mbby	364000
-𪴦	mbby	0
 𦉡	mbbz	0
 特长	mbch	13500000
 犗	mbcj	36900
@@ -56710,10 +54603,7 @@ encoder:
 𤚾	mbgd	0
 𤘢	mbgi	0
 𤙅	mbgl	0
-𪻘	mbgl	0
 牻	mbgm	69800
-𪻒	mbgm	0
-𪻕	mbgn	0
 𩑙	mbgo	0
 𩑩	mbgo	0
 特有	mbgq	24400000
@@ -56756,7 +54646,6 @@ encoder:
 𣀖	mbix	0
 𣀶	mbix	0
 𤘴	mbix	0
-𫂣	mbiy	0
 吿	mbja	276000
 等号	mbja	1950000
 𩱩	mbja	0
@@ -56769,7 +54658,6 @@ encoder:
 𢍎	mbje	0
 𤚮	mbje	0
 𥷂	mbje	0
-𪽭	mbje	0
 特困	mbjf	3630000
 𤚦	mbjf	0
 頶	mbjg	22600
@@ -56784,7 +54672,6 @@ encoder:
 靠	mbjk	140000000
 𠜯	mbjk	0
 𤚛	mbjk	0
-𫃙	mbjk	0
 犒	mbjl	317000
 犞	mbjl	32900
 𡷥	mbjl	0
@@ -56792,7 +54679,6 @@ encoder:
 𧠼	mbjl	0
 𩱕	mbjl	0
 𩱩	mbjl	0
-𪢥	mbjl	0
 𢽍	mbjm	0
 䧼	mbjn	3400
 𤜍	mbjn	0
@@ -56851,7 +54737,6 @@ encoder:
 鼄	mbkw	20400
 𢛁	mbkw	0
 𢢹	mbkw	0
-𪻝	mbkw	0
 𤚈	mbkx	0
 邾	mbky	328000
 㹎	mbkz	4720
@@ -56861,8 +54746,6 @@ encoder:
 𤘼	mblb	0
 𤙉	mblb	0
 𥯿	mblb	0
-𪻙	mblb	0
-𪻚	mblb	0
 犅	mbld	57600
 等同	mbld	14600000
 𤙓	mbld	0
@@ -56905,7 +54788,6 @@ encoder:
 等等	mbmb	124000000
 𤘧	mbmb	0
 牲	mbmc	2810000
-𫙒	mbmc	0
 𤘶	mbmd	0
 牛犊	mbme	1500000
 𨌾	mbmf	0
@@ -56915,7 +54797,6 @@ encoder:
 牦	mbmh	1940000
 犠	mbmh	213000
 𤘛	mbmh	0
-𪻑	mbmh	0
 㸲	mbmi	5450
 特种	mbmj	28200000
 牿	mbmj	71600
@@ -56993,7 +54874,6 @@ encoder:
 𤚠	mbor	0
 𤛵	mbor	0
 𪈓	mbor	0
-𫚫	mbor	0
 𠅐	mbos	0
 𤜈	mbos	0
 𤊘	mbou	0
@@ -57025,7 +54905,6 @@ encoder:
 築	mbqf	27700000
 𥳎	mbqi	0
 𤚎	mbqk	0
-𪻔	mbqk	0
 篫	mbqm	33400
 𢲿	mbqm	0
 丢脸	mbqo	4620000
@@ -57033,7 +54912,6 @@ encoder:
 𥰺	mbqq	0
 𩸡	mbqr	0
 𪈢	mbqr	0
-𫛥	mbqr	0
 䉅	mbqs	5970
 牡丹	mbqs	13300000
 𤘪	mbqs	0
@@ -57058,7 +54936,6 @@ encoder:
 𤄳	mbrk	0
 𤙳	mbrk	0
 𤛃	mbrk	0
-𫃄	mbrk	0
 等角	mbrl	94900
 觕	mbrl	40900
 贊	mbrl	4270000
@@ -57066,7 +54943,6 @@ encoder:
 𤛟	mbrl	0
 𧠺	mbrl	0
 𧤊	mbrl	0
-𫍡	mbrl	0
 㪇	mbrm	3640
 𣭟	mbrm	0
 𣭡	mbrm	0
@@ -57140,7 +55016,6 @@ encoder:
 䍧	mbuc	4130
 𥯹	mbue	0
 㹖	mbug	4490
-𪞆	mbug	0
 𥳎	mbui	0
 㹍	mbul	4250
 特性	mbum	55400000
@@ -57148,7 +55023,6 @@ encoder:
 𤘭	mbuo	0
 𥱩	mbuo	0
 𥰺	mbuq	0
-𪻗	mbuu	0
 特快	mbux	12000000
 𤚇	mbux	0
 𤚔	mbux	0
@@ -57172,7 +55046,6 @@ encoder:
 㹙	mbwl	4420
 犏	mbwl	73400
 𤚢	mbwl	0
-𪻜	mbwl	0
 㹊	mbwn	4570
 特邀	mbwn	4640000
 㸿	mbwq	5650
@@ -57281,7 +55154,6 @@ encoder:
 筹款	mcbb	1130000
 生来	mcbk	3910000
 生动	mcbz	20800000
-𪽰	mccb	0
 𥷨	mccc	0
 𤯨	mcce	0
 生长	mcch	29200000
@@ -57308,32 +55180,26 @@ encoder:
 筹码	mcgx	11800000
 筹划	mchk	13900000
 生成	mchv	57300000
-𪽮	mcid	0
 𤯮	mcih	0
 𥳧	mcii	0
-𪯡	mcix	0
 筹足	mcji	101000
 生日	mcka	107000000
 生辉	mckg	2900000
-𪽱	mckl	0
 𥰚	mckm	0
 生肖	mckq	15900000
 𥵦	mckq	0
-𫃁	mckv	0
 甥	mcky	3000000
 生财	mcld	4420000
 𥵇	mclg	0
 𥶤	mclj	0
 箦	mclo	125000
 簀	mclo	125000
-𫃓	mclo	0
 甡	mcmc	233000
 𥱧	mcmf	0
 𥯪	mcmg	0
 𣬺	mcmh	0
 𤯫	mcmh	0
 𠞏	mcmk	0
-𫃃	mcmk	0
 筹算	mcml	67000
 㽓	mcmm	4190
 𤯛	mcmo	0
@@ -57406,7 +55272,6 @@ encoder:
 手工	mdbi	34900000
 手鼓	mdbj	182000
 𢴝	mdbr	0
-𪮗	mdbr	0
 籜	mdbu	60800
 𥲶	mdcb	0
 𥸓	mdcc	0
@@ -57421,7 +55286,6 @@ encoder:
 手执	mddq	1720000
 手指	mddr	36900000
 箝	mdeb	707000
-𪮤	mdef	0
 簎	mdek	49100
 𢵬	mdeo	0
 手艺	mdey	4710000
@@ -57451,7 +55315,6 @@ encoder:
 𧒎	mdii	0
 𥮠	mdij	0
 䉗	mdjc	3830
-𪿱	mdjd	0
 手足	mdji	18400000
 𢬚	mdjl	0
 𢲤	mdjl	0
@@ -57466,7 +55329,6 @@ encoder:
 𢯣	mdkk	0
 䈰	mdkq	5530
 手掌	mdkw	10500000
-𪮦	mdkw	0
 手电	mdkz	1440000
 簼	mdlb	523000
 𢲱	mdlb	0
@@ -57476,14 +55338,12 @@ encoder:
 𢫶	mdma	0
 𢪒	mdmd	0
 𢩷	mdmh	0
-𪮩	mdml	0
 掱	mdmm	660000
 手稿	mdms	2110000
 𢪳	mdms	0
 𥮁	mdms	0
 手段	mdnc	89500000
 篺	mdne	29400
-𪮀	mdnh	0
 𢫗	mdnk	0
 䉟	mdnx	4150
 𥶪	mdok	0
@@ -57493,7 +55353,6 @@ encoder:
 𢴞	mdoo	0
 手铐	mdpb	3600000
 䇽	mdpd	3660
-𪯕	mdpl	0
 𥱮	mdpz	0
 手脚	mdqb	19800000
 𣓞	mdqf	0
@@ -57514,7 +55373,6 @@ encoder:
 手背	mdtr	3930000
 𢵩	mdug	0
 𥲵	mduk	0
-𪯁	mdul	0
 手法	mdvb	31900000
 𥭑	mdvs	0
 𠂌	mdvv	0
@@ -57527,16 +55385,13 @@ encoder:
 𥴻	mdxj	0
 籒	mdxk	21800
 𢭶	mdxm	0
-𪮊	mdxo	0
 𢩥	mdyd	0
 筢	mdyi	85500
 籀	mdyk	1590000
 劧	mdym	345000
 掰	mdym	6340000
 𥷘	mdyn	0
-𫂵	mdyn	0
 𢲒	mdyy	0
-𫆝	mdyy	0
 手续	mdze	111000000
 手绢	mdzj	1320000
 𢱞	mdzz	0
@@ -57553,7 +55408,6 @@ encoder:
 𠂯	mebi	0
 𠝤	mebk	0
 𠝶	mebk	0
-𪟑	mebk	0
 𨤯	mebl	0
 𥠭	mebm	0
 千赫	mebn	133000
@@ -57610,11 +55464,9 @@ encoder:
 𨜲	mejy	0
 𠚟	mejz	0
 籖	meka	72800
-𫃡	meka	0
 千里	mekb	67400000
 重	mekb	376000000
 𨤶	mekb	0
-𪟗	mekd	0
 𥱹	mekg	0
 濌	mekk	35900
 𠜕	mekk	0
@@ -57692,7 +55544,6 @@ encoder:
 缺欠	mero	258000
 𥳽	mero	0
 𣪜	merq	0
-𪞵	merq	0
 𥶂	merr	0
 𥷀	meru	0
 𥷥	meru	0
@@ -57707,7 +55558,6 @@ encoder:
 午夜	mesn	22200000
 垂询	mesr	7360000
 𧜻	mesr	0
-𫃟	mesy	0
 𥪵	mesz	0
 罐装	metb	1410000
 缺席	mete	6730000
@@ -57729,7 +55579,6 @@ encoder:
 勳	meuy	3660000
 𠜫	mevk	0
 千兆	mevr	3360000
-𪜎	mevr	0
 升	mevv	171000000
 𥫠	mevv	0
 升学	mevw	5870000
@@ -57741,18 +55590,14 @@ encoder:
 缺额	mewr	380000
 𥶃	mewr	0
 甜蜜	meww	35100000
-𫂰	mewy	0
 忎	mewz	300000
 𥰼	mewz	0
 𡙇	mexg	0
 簸	mexi	943000
 𦦘	mexi	0
 𨤴	mexi	0
-𫓁	mexr	0
-𫓃	mexx	0
 𠦚	meya	0
 𠡦	meyb	0
-𪥦	meyg	0
 千阳	meyk	253000
 𡼉	meyl	0
 㔓	meym	4240
@@ -57798,7 +55643,6 @@ encoder:
 𥣛	mfag	0
 䅠	mfai	4530
 𣗱	mfai	0
-𫂻	mfai	0
 䭲	mfaj	4090
 秴	mfaj	501000
 𠲆	mfaj	0
@@ -57807,12 +55651,10 @@ encoder:
 𥠆	mfaj	0
 𥠫	mfaj	0
 𥵰	mfaj	0
-𫁡	mfaj	0
 䅉	mfak	5420
 穢	mfak	1450000
 𥡳	mfak	0
 𥡴	mfak	0
-𫁱	mfak	0
 䅪	mfal	4130
 稐	mfal	377000
 穨	mfal	346000
@@ -57833,13 +55675,11 @@ encoder:
 𥣄	mfaz	0
 𪏱	mfaz	0
 䅅	mfbb	7500
-𫙀	mfbb	0
 秲	mfbd	42300
 𥢜	mfbd	0
 穘	mfbg	55400
 𡚕	mfbg	0
 𥞟	mfbi	0
-𫁗	mfbi	0
 秸	mfbj	3480000
 稠	mfbj	7620000
 篻	mfbk	25600
@@ -57853,7 +55693,6 @@ encoder:
 𥡩	mfbq	0
 𥞠	mfbr	0
 𦓌	mfbr	0
-𫁦	mfbr	0
 䆀	mfbu	5800
 䆁	mfbu	4470
 䵩	mfbu	4380
@@ -57874,13 +55713,11 @@ encoder:
 𥢘	mfbz	0
 𥢚	mfbz	0
 𪏳	mfbz	0
-𫁲	mfbz	0
 䭰	mfcb	4480
 𥴇	mfcb	0
 𪐃	mfcb	0
 𩡔	mfcj	0
 積	mfcl	14400000
-𫙅	mfcl	0
 𥡟	mfcn	0
 𥠔	mfco	0
 𥟀	mfcr	0
@@ -57948,7 +55785,6 @@ encoder:
 𥠵	mffd	0
 𥡵	mffd	0
 𥢎	mffd	0
-𫃉	mffd	0
 𥠲	mfff	0
 𥢂	mfff	0
 𪐎	mfff	0
@@ -57960,11 +55796,9 @@ encoder:
 𥤕	mffj	0
 𥱛	mffj	0
 𪐓	mffj	0
-𫃘	mffj	0
 䵔	mffk	5550
 𨋟	mffk	0
 𩠼	mffk	0
-𫃒	mffl	0
 𥢖	mffm	0
 𪅌	mffr	0
 秫	mffs	3080000
@@ -58055,7 +55889,6 @@ encoder:
 𥞘	mfiy	0
 𥝽	mfiz	0
 𥣨	mfiz	0
-𫁥	mfiz	0
 稢	mfja	26000
 稶	mfja	34100
 程	mfjc	343000000
@@ -58089,7 +55922,6 @@ encoder:
 𥵰	mfjl	0
 稛	mfjm	75800
 稦	mfjm	79200
-𫃊	mfjm	0
 𥤊	mfjn	0
 䄼	mfjo	5510
 䅩	mfjo	4320
@@ -58107,7 +55939,6 @@ encoder:
 簌	mfjr	3240000
 𥞏	mfjr	0
 𥡉	mfjr	0
-𫁢	mfjr	0
 𥢍	mfjs	0
 䅱	mfju	3900
 𥣎	mfju	0
@@ -58125,7 +55956,6 @@ encoder:
 𥟨	mfka	0
 𩐖	mfka	0
 𩠺	mfka	0
-𫂯	mfka	0
 種	mfkb	103000000
 穜	mfkb	141000
 𡍺	mfkb	0
@@ -58133,7 +55963,6 @@ encoder:
 𥤐	mfkb	0
 𥷈	mfkb	0
 𪐈	mfkb	0
-𫁤	mfkb	0
 𥟍	mfkc	0
 利	mfkd	429000000
 簟	mfke	995000
@@ -58161,7 +55990,6 @@ encoder:
 𥞁	mfki	0
 𥵉	mfki	0
 𧒁	mfki	0
-𫁚	mfki	0
 𨃾	mfkj	0
 㓿	mfkk	5110
 䅛	mfkk	3710
@@ -58195,10 +56023,8 @@ encoder:
 𥠝	mfkm	0
 𥣲	mfkm	0
 𩡄	mfkm	0
-𫁮	mfkm	0
 𩁄	mfkn	0
 𩁟	mfkn	0
-𫚐	mfkn	0
 稉	mfko	385000
 穔	mfko	26500
 𥣀	mfko	0
@@ -58211,8 +56037,6 @@ encoder:
 稍	mfkq	204000000
 稩	mfkq	20700
 𩡈	mfkq	0
-𫁩	mfkq	0
-𫁴	mfkq	0
 䅥	mfkr	4670
 䱘	mfkr	4300
 稪	mfkr	59200
@@ -58227,7 +56051,6 @@ encoder:
 𪆜	mfkr	0
 𪏶	mfkr	0
 𪐒	mfkr	0
-𫙇	mfkr	0
 𪐖	mfks	0
 穙	mfku	27200
 𤉉	mfku	0
@@ -58248,11 +56071,8 @@ encoder:
 邌	mfkw	25800
 𢤂	mfkw	0
 𥣒	mfkw	0
-𫁬	mfkw	0
-𫁸	mfkw	0
 𥟧	mfkx	0
 𩧸	mfkx	0
-𫁞	mfkx	0
 𠜣	mfky	0
 𠡩	mfky	0
 𡥬	mfky	0
@@ -58307,7 +56127,6 @@ encoder:
 䅐	mflr	7450
 秽	mflr	1890000
 𥡽	mflr	0
-𫁘	mflr	0
 穲	mflt	24000
 𤏤	mflu	0
 𥤎	mflu	0
@@ -58319,8 +56138,6 @@ encoder:
 黐	mflz	295000
 𥣭	mflz	0
 𪐑	mflz	0
-𫁭	mflz	0
-𫙂	mflz	0
 𣫽	mfma	0
 䄵	mfmb	4840
 䅍	mfmb	6090
@@ -58334,7 +56151,6 @@ encoder:
 秊	mfme	323000
 𠦿	mfme	0
 𥟑	mfme	0
-𫁙	mfme	0
 棃	mfmf	499000
 秝	mfmf	87100
 𥠊	mfmf	0
@@ -58364,7 +56180,6 @@ encoder:
 𪏿	mfmk	0
 睝	mfml	39100
 𥡘	mfml	0
-𫁳	mfml	0
 牺牲	mfmm	26000000
 犂	mfmm	86100
 𢮃	mfmm	0
@@ -58372,7 +56187,6 @@ encoder:
 𤛿	mfmm	0
 䅤	mfmn	5080
 𨿯	mfmn	0
-𫙃	mfmn	0
 秩	mfmo	1790000
 𥯍	mfmo	0
 錅	mfmp	18400
@@ -58381,7 +56195,6 @@ encoder:
 鵹	mfmr	21600
 𪁮	mfmr	0
 𪇺	mfmr	0
-𫛤	mfmr	0
 𥝥	mfms	0
 𥠰	mfms	0
 䊍	mfmu	4050
@@ -58406,7 +56219,6 @@ encoder:
 𥟯	mfmz	0
 𥴟	mfmz	0
 𪏾	mfmz	0
-𫃋	mfmz	0
 𥟅	mfnb	0
 䅣	mfnc	4860
 𥞂	mfnd	0
@@ -58414,7 +56226,6 @@ encoder:
 𥴖	mfne	0
 𪐄	mfne	0
 穕	mfnf	58700
-𫙆	mfnf	0
 𥗶	mfng	0
 𥣩	mfnh	0
 稚	mfni	4530000
@@ -58444,7 +56255,6 @@ encoder:
 稑	mfob	745000
 𥢤	mfob	0
 𥵏	mfoc	0
-𫙁	mfoc	0
 秂	mfod	2210000
 稡	mfoe	30800
 𡦧	mfoe	0
@@ -58456,7 +56266,6 @@ encoder:
 穃	mfoj	57800
 𥢑	mfoj	0
 𧯄	mfoj	0
-𫎽	mfoj	0
 㴝	mfok	4580
 黍	mfok	5090000
 黎	mfok	42400000
@@ -58472,14 +56281,12 @@ encoder:
 𥣪	mfol	0
 𥤒	mfol	0
 𥤟	mfol	0
-𫁶	mfol	0
 䄹	mfom	4470
 䅷	mfom	4750
 稌	mfom	38500
 𥠛	mfom	0
 𥣆	mfom	0
 𥷭	mfom	0
-𪻛	mfom	0
 𥝵	mfon	0
 𥞙	mfon	0
 𥠸	mfon	0
@@ -58495,12 +56302,10 @@ encoder:
 𥢰	mfoo	0
 𥤞	mfoo	0
 𩡙	mfoo	0
-𫁹	mfoo	0
 穇	mfop	39600
 穋	mfop	44400
 𥤇	mfop	0
 𥶠	mfop	0
-𫁷	mfop	0
 䴻	mfor	4300
 稄	mfor	48900
 稜	mfor	1770000
@@ -58544,7 +56349,6 @@ encoder:
 颓	mfqg	2010000
 𥟺	mfqg	0
 𥠕	mfqk	0
-𫁟	mfqk	0
 𥞇	mfql	0
 𢵥	mfqm	0
 𢽈	mfqm	0
@@ -58603,7 +56407,6 @@ encoder:
 𥣡	mfrm	0
 𥣿	mfrm	0
 𪏯	mfrm	0
-𫁪	mfrm	0
 稭	mfrn	38300
 穧	mfrn	34100
 𩀒	mfrn	0
@@ -58634,7 +56437,6 @@ encoder:
 𪚼	mfrw	0
 𥣾	mfrx	0
 𥤈	mfrx	0
-𫁜	mfrx	0
 𥟶	mfry	0
 𥠈	mfry	0
 𨝄	mfry	0
@@ -58642,10 +56444,8 @@ encoder:
 穒	mfrz	35100
 𥠎	mfrz	0
 𥡚	mfrz	0
-𫛺	mfrz	0
 𥡒	mfsc	0
 𥯸	mfsc	0
-𪝴	mfsc	0
 𥞽	mfse	0
 𥝕	mfsh	0
 䆍	mfsi	3990
@@ -58661,14 +56461,12 @@ encoder:
 秔	mfsq	33500
 𥮕	mfsq	0
 𧚩	mfsr	0
-𫍈	mfsr	0
 𥞯	mfsu	0
 𥢯	mfsu	0
 𥠡	mfsw	0
 𥡥	mfsw	0
 𥵅	mfsw	0
 𪐁	mfsw	0
-𫁧	mfsw	0
 稂	mfsx	105000
 𩠻	mfsx	0
 䄱	mfsy	5470
@@ -58684,7 +56482,6 @@ encoder:
 𥞉	mfua	0
 秚	mfub	28200
 𥣺	mfub	0
-𫆾	mfuc	0
 𥞩	mfue	0
 醔	mfuf	42000
 𥞪	mfuf	0
@@ -58736,7 +56533,6 @@ encoder:
 䄻	mfvr	4290
 𥰜	mfvr	0
 𩡂	mfvr	0
-𫁠	mfvr	0
 𥟇	mfvs	0
 𥝌	mfvv	0
 𥠣	mfwa	0
@@ -58772,7 +56568,6 @@ encoder:
 𥤓	mfws	0
 𥤚	mfwu	0
 𥷻	mfwu	0
-𪺳	mfwu	0
 馞	mfwy	37600
 𥞳	mfwy	0
 𥟓	mfwy	0
@@ -58780,14 +56575,12 @@ encoder:
 䅴	mfwz	5380
 𢘳	mfwz	0
 𥞬	mfwz	0
-𫃑	mfwz	0
 䵛	mfxb	3720
 秉	mfxb	6990000
 𥞓	mfxb	0
 𥞭	mfxb	0
 𥞰	mfxb	0
 𥴍	mfxb	0
-𫁰	mfxb	0
 穱	mfxd	523000
 𥤏	mfxd	0
 𥝦	mfxe	0
@@ -58815,7 +56608,6 @@ encoder:
 䅏	mfxm	4510
 𥡕	mfxo	0
 𦫌	mfxo	0
-𫁫	mfxo	0
 𩡜	mfxq	0
 秜	mfxr	32000
 馜	mfxr	50000
@@ -58845,7 +56637,6 @@ encoder:
 箱子	mfya	8390000
 𥝔	mfya	0
 𥝎	mfyd	0
-𫂴	mfyd	0
 𥝡	mfye	0
 稧	mfyg	41400
 𥞔	mfyh	0
@@ -58853,7 +56644,6 @@ encoder:
 𥝧	mfyi	0
 𥝼	mfyi	0
 𥝿	mfyj	0
-𫁨	mfyj	0
 籕	mfyk	22200
 𥞲	mfyk	0
 𥠷	mfyk	0
@@ -58862,8 +56652,6 @@ encoder:
 䅎	mfym	6810
 秀	mfym	208000000
 𥟄	mfym	0
-𫁝	mfym	0
-𫙄	mfym	0
 䄶	mfyn	5000
 𥣞	mfyn	0
 䵑	mfys	4130
@@ -58897,7 +56685,6 @@ encoder:
 𩡦	mfzf	0
 䫋	mfzg	3470
 𥟔	mfzg	0
-𫁯	mfzg	0
 𠚉	mfzi	0
 秮	mfzj	417000
 𥞚	mfzj	0
@@ -58909,8 +56696,6 @@ encoder:
 𥠃	mfzl	0
 𩡎	mfzl	0
 𩡤	mfzl	0
-𫙂	mfzl	0
-𫙈	mfzl	0
 䄿	mfzm	5350
 委	mfzm	199000000
 魏	mfzn	72100000
@@ -58974,7 +56759,6 @@ encoder:
 𥵐	mgku	0
 𡙶	mgkz	0
 𥯃	mgkz	0
-𫃂	mgkz	0
 𡰘	mglg	0
 笼罩	mgli	11900000
 𠛻	mglk	0
@@ -59019,14 +56803,12 @@ encoder:
 𥮎	mgse	0
 𠛦	mgsk	0
 𠿕	mgsq	0
-𪜏	mgsq	0
 乔装	mgtb	940000
 𠂷	mgub	0
 𥱇	mguo	0
 𥲩	mguo	0
 𪇙	mgur	0
 𡴘	mguz	0
-𪜐	mguz	0
 𥵯	mgxi	0
 叐	mgxs	40900
 笼子	mgya	2600000
@@ -59057,7 +56839,6 @@ encoder:
 𣰼	mhcc	0
 𣭞	mhce	0
 𣭿	mhce	0
-𪵾	mhck	0
 𣭌	mhcn	0
 𣮛	mhcq	0
 𣰜	mhcq	0
@@ -59124,7 +56905,6 @@ encoder:
 𣮑	mhkk	0
 𣮜	mhkl	0
 𣯀	mhkl	0
-𪶅	mhkl	0
 𣮅	mhkm	0
 𣮶	mhkm	0
 𣰔	mhkm	0
@@ -59139,7 +56919,6 @@ encoder:
 𣮼	mhlg	0
 毛巾	mhli	7520000
 𣬢	mhli	0
-𫂩	mhli	0
 𣯿	mhlk	0
 𥰎	mhlk	0
 𥱔	mhlk	0
@@ -59148,7 +56927,6 @@ encoder:
 𣰏	mhln	0
 𣰽	mhln	0
 𣯒	mhlo	0
-𪶃	mhlo	0
 覒	mhlr	24400
 𣮨	mhlz	0
 𣮽	mhlz	0
@@ -59175,7 +56953,6 @@ encoder:
 𣬬	mhms	0
 毛毯	mhmu	2590000
 𥼛	mhmu	0
-𪺖	mhmu	0
 㦌	mhmw	4530
 𣭛	mhmw	0
 𣯘	mhmy	0
@@ -59216,7 +56993,6 @@ encoder:
 𥬗	mhrd	0
 𣭤	mhre	0
 𣭨	mhrj	0
-𪵼	mhrj	0
 毥	mhrk	24000
 氇	mhrk	199000
 氌	mhrk	33500
@@ -59245,14 +57021,11 @@ encoder:
 𣮍	mhsz	0
 毛病	mhta	17200000
 𣬯	mhte	0
-𪶄	mhtx	0
 毩	mhuf	28700
 𣮩	mhuf	0
 𣮺	mhug	0
-𪵿	mhug	0
 𣮹	mhun	0
 𤆬	mhuo	0
-𪵻	mhuo	0
 毛料	mhut	991000
 毯	mhuu	5520000
 毛糙	mhuw	371000
@@ -59270,16 +57043,13 @@ encoder:
 毛皮	mhxi	5240000
 𣬼	mhxi	0
 𣯙	mhxj	0
-𪶁	mhxk	0
 䉯	mhxl	4700
-𪶂	mhxl	0
 𣮣	mhxo	0
 𦥺	mhxo	0
 𣭙	mhxr	0
 毛驴	mhxw	1510000
 𣬥	mhya	0
 𣬞	mhyd	0
-𪵹	mhyd	0
 矩阵	mhyh	12000000
 𣬶	mhyi	0
 𣭋	mhyj	0
@@ -59308,7 +57078,6 @@ encoder:
 毛纺	mhzs	1060000
 𣭇	mhzy	0
 𣭑	mhzz	0
-𪵽	mhzz	0
 𣥋	miaa	0
 𥵂	miag	0
 𦧧	miai	0
@@ -59337,7 +57106,6 @@ encoder:
 𣥋	miib	0
 𦧽	miii	0
 𢼤	miix	0
-𫃍	miix	0
 𥸛	miji	0
 𥭔	mijk	0
 𥱾	mijo	0
@@ -59385,7 +57153,6 @@ encoder:
 𥷳	mimy	0
 𦧓	mimy	0
 怎么	mimz	403000000
-𫖜	mini	0
 憩	minw	3000000
 𦧯	minw	0
 𦧹	miob	0
@@ -59397,7 +57164,6 @@ encoder:
 𥳭	mipy	0
 𨟭	miqy	0
 舐	mirh	1880000
-𫈍	mirl	0
 舓	miro	24000
 𣢯	miro	0
 𥱿	mirq	0
@@ -59408,7 +57174,6 @@ encoder:
 鸹	mirz	133000
 𥲕	mirz	0
 辞	mise	26700000
-𫈋	misj	0
 𥱲	miso	0
 𦧈	misx	0
 𥫪	mitd	0
@@ -59462,7 +57227,6 @@ encoder:
 箿	mjce	29500
 𥭤	mjci	0
 䉷	mjcm	3940
-𫂷	mjcs	0
 积聚	mjcx	3430000
 告捷	mjda	1580000
 靠拢	mjdg	6210000
@@ -59485,7 +57249,6 @@ encoder:
 𥭒	mjhz	0
 𢘗	mjiw	0
 簂	mjja	34800
-𫃌	mjjb	0
 知足	mjji	7680000
 𥭾	mjji	0
 𥰔	mjjj	0
@@ -59496,7 +57259,6 @@ encoder:
 告别	mjjy	25100000
 𥱐	mjkb	0
 簞	mjke	588000
-𫂾	mjke	0
 知晓	mjkh	6910000
 和田	mjki	10900000
 种田	mjki	1900000
@@ -59524,7 +57286,6 @@ encoder:
 𥱅	mjoe	0
 𥭮	mjol	0
 𥸑	mjol	0
-𫂽	mjom	0
 𥶟	mjou	0
 积分	mjoy	446000000
 和风	mjqo	3580000
@@ -59628,7 +57389,6 @@ encoder:
 重要	mkfv	433000000
 重大	mkgd	113000000
 𥭍	mkgd	0
-𫂱	mkgd	0
 𥴵	mkgi	0
 𥰻	mkgj	0
 朱砂	mkgk	786000
@@ -59638,7 +57398,6 @@ encoder:
 𥲸	mkgu	0
 重码	mkgx	292000
 复式	mkhb	8830000
-𫃅	mkhm	0
 笛	mkia	18300000
 笚	mkib	468000
 𥬐	mkic	0
@@ -59858,11 +57617,9 @@ encoder:
 纂	mlgz	1640000
 制式	mlhb	6130000
 𧑬	mlhi	0
-𫃚	mlhi	0
 看到	mlhk	360000000
 簚	mlhl	74200
 𥱡	mlhm	0
-𫂶	mlhr	0
 篾	mlhs	704000
 衊	mlhs	711000
 𥯣	mlhs	0
@@ -59890,7 +57647,6 @@ encoder:
 𠜄	mlkd	0
 𠟬	mlkd	0
 𥵙	mlke	0
-𫌧	mlke	0
 秧田	mlki	254000
 篎	mlkm	34100
 租界	mlko	1010000
@@ -59941,7 +57697,6 @@ encoder:
 看似	mlnz	17500000
 看待	mlob	21100000
 笍	mlod	32900
-𪥕	mlog	0
 𥰓	mloh	0
 𧖼	mloj	0
 算得	mlok	8100000
@@ -59961,7 +57716,6 @@ encoder:
 𥶋	mlpk	0
 算盘	mlpl	3740000
 衇	mlpr	21800
-𫂬	mlqd	0
 血肿	mlqj	675000
 血腥	mlqk	4730000
 制胜	mlqm	3870000
@@ -59979,7 +57733,6 @@ encoder:
 箆	mlrr	124000
 𥰕	mlrr	0
 𥶓	mlrr	0
-𫌥	mlrr	0
 箩	mlrs	1150000
 𥸣	mlrs	0
 𧖪	mlrs	0
@@ -60029,7 +57782,6 @@ encoder:
 看过	mlwd	48700000
 𥵒	mlwl	0
 制造	mlwm	203000000
-𫃎	mlwr	0
 血迹	mlws	7710000
 稠密	mlww	1180000
 制退	mlwx	57900
@@ -60090,12 +57842,10 @@ encoder:
 矮柜	mmfh	192000
 年检	mmfo	5110000
 敌机	mmfq	768000
-𫃛	mmfx	0
 笑	mmgd	568000000
 笑靥	mmgg	1390000
 𥮂	mmgj	0
 𡮜	mmgk	0
-𫜔	mmgr	0
 年历	mmgy	4860000
 𥫬	mmhd	0
 年轮	mmho	1940000
@@ -60203,7 +57953,6 @@ encoder:
 年终	mmzr	19600000
 年级	mmzy	47300000
 年纪	mmzy	38800000
-𫂲	mmzy	0
 𥰉	mnag	0
 𥮆	mnaj	0
 𥰧	mnaj	0
@@ -60253,10 +58002,8 @@ encoder:
 𥵸	mnrl	0
 𥱤	mnrp	0
 篦	mnrr	795000
-𫂸	mnrs	0
 𥮴	mnrt	0
 䉣	mnru	4040
-𫃆	mnsj	0
 籩	mnsw	167000
 䉛	mnug	3830
 𥶵	mnuq	0
@@ -60272,7 +58019,6 @@ encoder:
 篗	mnxs	85500
 𥰞	mnxs	0
 𥸌	mnxx	0
-𫂫	mnya	0
 𥰗	mnyi	0
 攵	moaa	2920000
 𥰊	moai	0
@@ -60377,7 +58123,6 @@ encoder:
 䉠	moqm	208
 𥳴	moqq	0
 黏胶	moqs	76200
-𫃝	morg	0
 签名	morj	166000000
 答疑	morm	70600000
 𥷲	morm	0
@@ -60430,7 +58175,6 @@ encoder:
 籞	moyb	26200
 失陷	moyr	495000
 失陪	moys	450000
-𪽪	moys	0
 䈵	moyy	4670
 签收	mozm	3030000
 签约	mozr	21600000
@@ -60445,7 +58189,6 @@ encoder:
 稻草	mpek	4690000
 𥳗	mpgo	0
 䈠	mpgx	8620
-𫃇	mpgx	0
 籛	mphh	38300
 篯	mphm	45100
 篪	mpih	251000
@@ -60483,7 +58226,6 @@ encoder:
 䈀	mqak	16600
 𥵍	mqal	0
 𠂸	mqbe	0
-𪽳	mqbi	0
 𥮚	mqbk	0
 竼	mqda	40500
 颓势	mqdq	1430000
@@ -60510,7 +58252,6 @@ encoder:
 𥸫	mquf	0
 籐	mquk	3920000
 𥭳	mquo	0
-𫃞	mqus	0
 籘	mquz	45900
 𣍝	mqvv	0
 𥬅	mqvv	0
@@ -60553,14 +58294,12 @@ encoder:
 稳步	mrik	11700000
 称号	mrja	29100000
 稳固	mrje	5090000
-𫃕	mrjg	0
 物品	mrjj	142000000
 称呼	mrjm	15900000
 𥲾	mrjm	0
 称叹	mrjx	149000
 赞叹	mrjx	6580000
 𥰿	mrkf	0
-𫂿	mrkg	0
 先辈	mrkh	1400000
 𥳩	mrkk	0
 𥬞	mrko	0
@@ -60691,7 +58430,6 @@ encoder:
 𥲰	msgq	0
 笇	msid	104000
 𥱱	msij	0
-𫃠	msiq	0
 辞呈	msjc	713000
 𥯲	msjf	0
 䈞	msjk	4050
@@ -60758,7 +58496,6 @@ encoder:
 筤	msxo	36000
 辞书	msxy	1620000
 𥱳	msxy	0
-𫂺	msxy	0
 稿子	msya	4520000
 𥴜	msyj	0
 稿费	msyn	3460000
@@ -60785,14 +58522,12 @@ encoder:
 简捷	mtda	1650000
 科技	mtde	534000000
 简报	mtdy	12000000
-𫂥	mted	0
 简直	mtel	79200000
 𥱊	mtel	0
 乘警	mter	390000
 䉀	mteu	5850
 𥯖	mtex	0
 科协	mtey	3360000
-𫃐	mtff	0
 简朴	mtfi	1750000
 乘机	mtfq	4960000
 简要	mtfv	14200000
@@ -60820,13 +58555,11 @@ encoder:
 简体	mtnf	121000000
 𥴯	mtnj	0
 简化	mtnr	16700000
-𫂤	mtod	0
 剩余	mtom	46900000
 简介	mton	404000000
 乘坐	mtoo	12400000
 𥵬	mtop	0
 乘船	mtpq	2190000
-𫂳	mtso	0
 简谱	mtsu	711000
 简讯	mtsy	4340000
 简装	mttb	4880000
@@ -60847,8 +58580,6 @@ encoder:
 科室	mtwh	10400000
 乘客	mtwr	13200000
 篖	mtxj	42100
-𫃏	mtxk	0
-𫂹	mtxs	0
 简阳	mtyk	502000
 乘除	mtyo	402000
 䉬	mtyq	4590
@@ -60901,7 +58632,6 @@ encoder:
 𥭂	muqd	0
 箭	muqk	24900000
 秋风	muqo	8090000
-𫃀	muqs	0
 氮肥	muqy	3070000
 𥯚	murj	0
 𥳞	murm	0
@@ -60911,7 +58641,6 @@ encoder:
 秋色	mury	5150000
 税务	mury	33500000
 𥱑	murz	0
-𫛼	murz	0
 税率	musv	9250000
 𥶑	musx	0
 箭头	mutg	5980000
@@ -61074,15 +58803,12 @@ encoder:
 𥶘	mwru	0
 箢	mwry	80500
 鴔	mwrz	32200
-𫜧	mwrz	0
 篇章	mwsk	11100000
 䈿	mwso	5230
 秘诀	mwsx	17900000
-𫃈	mwuf	0
 𥴦	mwug	0
 𥯴	mwux	0
 乏	mwvv	8690000
-𫃗	mwwb	0
 管家	mwwg	8540000
 𥳥	mwwl	0
 𥸅	mwwl	0
@@ -61156,7 +58882,6 @@ encoder:
 𥬩	mxrr	0
 𥰱	mxsi	0
 簢	mxso	30000
-𫂭	mxso	0
 箳	mxue	196000
 𥵧	mxul	0
 秉性	mxum	1060000
@@ -61165,7 +58890,6 @@ encoder:
 䉍	mxwz	5600
 𥮢	mxxe	0
 𥬖	mxxs	0
-𫂧	mxxs	0
 䈔	mxxx	4400
 𥲝	mxxx	0
 蠞	mxyi	27000
@@ -61185,7 +58909,6 @@ encoder:
 笥	myaj	1170000
 𥰮	myaj	0
 𥴩	myaj	0
-𪶇	myaj	0
 氩	myak	1070000
 師	myal	70500000
 秀丽	myal	7630000
@@ -61227,7 +58950,6 @@ encoder:
 气节	myey	1090000
 𣱪	myfb	0
 𣱯	myfb	0
-𫃜	myfd	0
 氥	myfj	432000
 氭	myfk	1550000
 𣱨	myfl	0
@@ -61315,8 +59037,6 @@ encoder:
 筵	mymi	3630000
 气血	myml	2900000
 气氛	mymo	35800000
-𪯤	mymo	0
-𫓸	mymp	0
 笈	myms	29900000
 气管	mymw	9890000
 𥴲	mymw	0
@@ -61329,12 +59049,10 @@ encoder:
 𨽴	mymy	0
 𨽵	mymy	0
 𥱖	mymz	0
-𪶈	mymz	0
 氘	mynd	361000
 氚	mynd	692000
 笰	mynd	79100
 气体	mynf	29400000
-𪴇	mynf	0
 气候	myni	19400000
 气魄	mynn	2930000
 气化	mynr	1700000
@@ -61367,7 +59085,6 @@ encoder:
 第九	myqy	35700000
 𥲎	myrb	0
 𥱥	myrf	0
-𪪕	myrf	0
 气象	myrj	30500000
 𥭫	myrk	0
 𥮜	myrk	0
@@ -61384,7 +59101,6 @@ encoder:
 阜新	mysf	3890000
 𥭰	mysf	0
 𥴉	mysk	0
-𪸇	mysk	0
 第六	myso	59600000
 𧜚	mysr	0
 𣱠	mysu	0
@@ -61438,7 +59154,6 @@ encoder:
 气力	myym	2950000
 氖	myym	1570000
 𠡒	myym	0
-𪶊	myym	0
 氟	myyn	15000000
 籊	myyn	38800
 𥱵	myyn	0
@@ -61611,7 +59326,6 @@ encoder:
 便于	naad	21600000
 佰万	naay	310000
 使者	nabm	22500000
-𪝭	nacx	0
 便捷	nada	17700000
 便携	nadn	14500000
 使其	naec	22300000
@@ -61724,7 +59438,6 @@ encoder:
 佤	nays	576000
 𠇐	naza	0
 例如	nazj	135000000
-𪜩	nazm	0
 何以	nazo	11500000
 傿	nazu	38700
 𠈯	nazx	0
@@ -61734,7 +59447,6 @@ encoder:
 𦥦	nbaf	0
 𠑯	nbag	0
 𦦅	nbag	0
-𪡶	nbag	0
 𦦯	nbai	0
 䑔	nbal	6060
 佳丽	nbal	4500000
@@ -61757,7 +59469,6 @@ encoder:
 僥	nbbg	472000
 毁坏	nbbg	3310000
 𪕖	nbbj	0
-𪝨	nbbj	0
 传来	nbbk	30100000
 𧡞	nbbl	0
 𤰁	nbbm	0
@@ -61817,7 +59528,6 @@ encoder:
 𡘑	nbgd	0
 𡘩	nbgd	0
 𦥸	nbge	0
-𪫍	nbge	0
 䢅	nbgh	3910
 𧖥	nbgi	0
 传布	nbgl	440000
@@ -61843,7 +59553,6 @@ encoder:
 𪕅	nbhz	0
 㼂	nbic	6220
 𧕧	nbii	0
-𪵡	nbii	0
 𪕐	nbij	0
 𥝊	nbil	0
 與	nbio	308000000
@@ -61870,7 +59579,6 @@ encoder:
 𥂤	nbjl	0
 𩱬	nbjl	0
 传呼	nbjm	2370000
-𪡦	nbjn	0
 𪕱	nbjq	0
 仁兄	nbjr	1260000
 传唤	nbjr	985000
@@ -61881,7 +59589,6 @@ encoder:
 𩸔	nbjr	0
 𠊪	nbju	0
 𠍼	nbju	0
-𫝩	nbju	0
 𡡋	nbjz	0
 𪖎	nbka	0
 𦦋	nbkb	0
@@ -61929,8 +59636,6 @@ encoder:
 𠔻	nblo	0
 𦥷	nblo	0
 𦧅	nblo	0
-𪝘	nblo	0
-𫏏	nblo	0
 𨮆	nblp	0
 𨯜	nblp	0
 𧭒	nbls	0
@@ -61954,7 +59659,6 @@ encoder:
 嚳	nbmj	75000
 𧗕	nbml	0
 𦦈	nbmn	0
-𫔑	nbmp	0
 𪕉	nbmu	0
 㐦	nbmy	4430
 𠒍	nbmy	0
@@ -61974,7 +59678,6 @@ encoder:
 𦦚	nbno	0
 𦦪	nbno	0
 𦦲	nbno	0
-𪜼	nbno	0
 𪕨	nbnr	0
 𢤒	nbnw	0
 伍亿	nbny	146000
@@ -62010,7 +59713,6 @@ encoder:
 𥕭	nbog	0
 𦦉	nbog	0
 𦧂	nbog	0
-𫀬	nbog	0
 𦦶	nboh	0
 𦥳	nboi	0
 𪖁	nboi	0
@@ -62029,7 +59731,6 @@ encoder:
 𥂞	nbol	0
 𧸧	nbol	0
 𪕶	nbol	0
-𪿇	nbol	0
 擧	nbom	378000
 𢸁	nbom	0
 𢹏	nbom	0
@@ -62061,7 +59762,6 @@ encoder:
 𪇬	nbor	0
 𪌲	nbor	0
 𪕞	nbor	0
-𫛉	nbor	0
 譽	nbos	3530000
 𦦦	nbos	0
 𦦭	nbos	0
@@ -62122,7 +59822,6 @@ encoder:
 𪕩	nbro	0
 𪕫	nbro	0
 𩰪	nbrp	0
-𫔑	nbrp	0
 𪖃	nbrq	0
 佬	nbrr	25100000
 鶂	nbrr	28300
@@ -62187,7 +59886,6 @@ encoder:
 𠣆	nbuy	0
 𪕧	nbuy	0
 仁慈	nbuz	3570000
-𫈈	nbvf	0
 传染	nbvq	10700000
 𦦬	nbvq	0
 仕	nbvv	38300000
@@ -62222,7 +59920,6 @@ encoder:
 㲣	nbxm	4880
 叟	nbxs	3610000
 鼥	nbxs	25400
-𪠫	nbxs	0
 𪕠	nbxu	0
 遚	nbxw	23700
 𪕰	nbxx	0
@@ -62244,7 +59941,6 @@ encoder:
 𢑅	nbyy	0
 𦑹	nbyy	0
 𨟦	nbyy	0
-𫝨	nbza	0
 𤪭	nbzc	0
 𪕔	nbzc	0
 鼠	nbzd	145000000
@@ -62264,7 +59960,6 @@ encoder:
 𪕍	nbzl	0
 𪕙	nbzl	0
 𪕥	nbzl	0
-𪝛	nbzl	0
 仕女	nbzm	1970000
 仾	nbzm	223000
 佞	nbzm	1110000
@@ -62326,16 +60021,13 @@ encoder:
 身长	ncch	2820000
 躼	ncch	19800
 𨉩	ncco	0
-𪞀	ncco	0
 𨉨	nccq	0
 𨉸	nccu	0
-𪝲	nccu	0
 僵持	ncdb	3250000
 𧎭	ncdi	0
 俦	ncds	546000
 射	ncds	61100000
 𨉠	ncdu	0
-𪨈	ncdu	0
 𨉡	nceb	0
 𨉴	ncec	0
 𨈰	ncej	0
@@ -62378,7 +60070,6 @@ encoder:
 𨉏	ncjr	0
 䠽	ncju	4210
 軆	ncju	233000
-𫐫	ncju	0
 𨊘	ncjw	0
 𨉟	ncjy	0
 䡀	ncka	5390
@@ -62414,7 +60105,6 @@ encoder:
 𨈭	nclb	0
 𨉄	nclb	0
 𨈹	ncld	0
-𫐬	nclk	0
 𨊋	ncll	0
 债	nclo	19900000
 債	nclo	6780000
@@ -62429,7 +60119,6 @@ encoder:
 𣕼	ncmf	0
 𨈥	ncmh	0
 𨉐	ncmh	0
-𫐦	ncmh	0
 𨈸	ncmi	0
 𨊛	ncmi	0
 𨉾	ncml	0
@@ -62443,7 +60132,6 @@ encoder:
 𠌴	ncnb	0
 身段	ncnc	3820000
 𨉤	ncnc	0
-𫐧	ncnc	0
 䠵	ncnd	3940
 身体	ncnf	146000000
 身躯	ncnh	10100000
@@ -62468,7 +60156,6 @@ encoder:
 躮	ncoy	24000
 皇后	ncpa	12800000
 身后	ncpa	50100000
-𪞀	ncpc	0
 𨈬	ncpd	0
 𨊝	ncpj	0
 𨊄	ncpk	0
@@ -62476,7 +60163,6 @@ encoder:
 躲	ncqf	70600000
 䠼	ncqk	4790
 儬	ncql	148000
-𫐨	ncqm	0
 𨈝	ncqs	0
 𢝪	ncqw	0
 段	ncqx	199000000
@@ -62489,7 +60175,6 @@ encoder:
 𨈳	ncrj	0
 𨊌	ncrm	0
 𨊜	ncrm	0
-𫐪	ncrq	0
 𨈚	ncrr	0
 𨉮	ncrr	0
 𪈬	ncrr	0
@@ -62526,7 +60211,6 @@ encoder:
 𨊏	ncus	0
 身为	ncuv	15700000
 债券	ncuy	22600000
-𫐩	ncuz	0
 䠷	ncvr	4280
 仼	ncvv	251000
 𨉬	ncwa	0
@@ -62599,7 +60283,6 @@ encoder:
 倳	ndjx	193000
 𠍣	ndkc	0
 𢍖	ndke	0
-𫗩	ndkl	0
 射界	ndko	115000
 射影	ndks	300000
 付账	ndlc	1260000
@@ -62617,7 +60300,6 @@ encoder:
 付诸	ndsb	4170000
 射门	ndtl	3400000
 𩇨	ndtt	0
-𫃢	nduf	0
 川江	ndvb	348000
 射洪	ndve	557000
 川沙	ndvk	717000
@@ -62665,7 +60347,6 @@ encoder:
 做梦	neff	12700000
 供需	nefg	12900000
 儎	nefk	308000
-𪝺	nefs	0
 偌大	negd	3080000
 偌	negj	1300000
 𠐾	nego	0
@@ -62683,11 +60364,8 @@ encoder:
 𠍔	neji	0
 做	nejm	910000000
 儆	nejm	1530000
-𪝏	nejq	0
 估量	neka	3550000
-𪝣	nekg	0
 㑤	neki	4560
-𪝎	neki	0
 傮	nekk	35800
 借鉴	nekm	19000000
 卑劣	nekm	2600000
@@ -62752,7 +60430,6 @@ encoder:
 供词	nesy	148000
 借方	nesy	542000
 𠑦	nesy	0
-𪝈	nesy	0
 借阅	netu	9110000
 供应	netv	400000000
 供养	neun	3490000
@@ -62816,7 +60493,6 @@ encoder:
 体态	nfgs	3430000
 僊	nfgy	138000
 𠍍	nfgz	0
-𪝢	nfhm	0
 集成	nfhv	53400000
 休止	nfii	11000000
 𠏹	nfjc	0
@@ -62831,7 +60507,6 @@ encoder:
 𠋖	nflk	0
 体内	nflo	38800000
 價	nflo	87900000
-𫍛	nflr	0
 体罚	nfls	1460000
 休眠	nfly	2790000
 𠉟	nfme	0
@@ -62839,12 +60514,10 @@ encoder:
 体重	nfmk	44300000
 体制	nfml	49900000
 僌	nfmo	36800
-𪝇	nfmo	0
 体委	nfmz	721000
 体系	nfmz	92100000
 集体	nfnf	53300000
 𠐶	nfni	0
-𪝹	nfnr	0
 体倦	nfnu	145000
 休息	nfnw	64400000
 休假	nfnx	8020000
@@ -62855,7 +60528,6 @@ encoder:
 倈	nfoo	40100
 𠍅	nfor	0
 𠏡	nfow	0
-𪝐	nfow	0
 倯	nfoz	103000
 𠌲	nfpd	0
 体质	nfpe	8830000
@@ -62893,7 +60565,6 @@ encoder:
 集安	nfwz	552000
 儊	nfxi	167000
 体验	nfxo	91500000
-𪝼	nfxx	0
 体力	nfym	32500000
 集结	nfzb	34700000
 偠	nfzm	921000
@@ -62912,7 +60583,6 @@ encoder:
 顺境	ngbs	577000
 伏击	ngbz	1900000
 侉	ngbz	174000
-𪝆	ngbz	0
 顺耳	ngce	359000
 优抚	ngda	1040000
 优势	ngdq	106000000
@@ -62923,7 +60593,6 @@ encoder:
 偄	nggd	435000
 𠐞	nggg	0
 优厚	nggk	2680000
-𪝧	nggl	0
 顺致	nghm	102000
 臭虫	ngia	842000
 𠈚	ngib	0
@@ -62940,7 +60609,6 @@ encoder:
 𠏗	ngku	0
 顺当	ngkx	107000
 顺畅	ngky	8610000
-𪝒	ngky	0
 俺	ngkz	132000000
 𠋊	ngld	0
 佈	ngli	14800000
@@ -62964,7 +60632,6 @@ encoder:
 俺们	ngnt	4920000
 优待	ngob	2100000
 顺德	ngoe	11300000
-𪝮	ngoe	0
 𠋙	ngok	0
 俠	ngoo	10600000
 傸	ngoo	24000
@@ -63012,7 +60679,6 @@ encoder:
 躯干	nhae	1150000
 倒下	nhai	8520000
 𠊭	nhaj	0
-𪝑	nhaj	0
 傶	nhak	27400
 𠏺	nhal	0
 𠋘	nhaz	0
@@ -63099,7 +60765,6 @@ encoder:
 𤇰	nhuo	0
 代数	nhuz	2930000
 倒数	nhuz	9590000
-𪝽	nhvf	0
 㒑	nhvn	4570
 代沟	nhvr	1140000
 𠈄	nhvv	0
@@ -63175,8 +60840,6 @@ encoder:
 俶	nikx	1020000
 𧔰	nild	0
 𠌚	nile	0
-𪝿	nilg	0
-𪝉	nilm	0
 侦	nilo	9710000
 偵	nilo	5420000
 𧵰	nilo	0
@@ -63200,14 +60863,12 @@ encoder:
 𠌒	nimo	0
 𩛢	nimo	0
 鋚	nimp	23200
-𫜅	nimr	0
 修辞	nims	2160000
 焂	nimu	29200
 悠	nimw	17100000
 𨾻	nimy	0
 㛜	nimz	3710
 𠧐	nine	0
-𪟾	nine	0
 雧	ninf	20200
 雔	nini	41200
 㘜	ninj	4080
@@ -63231,7 +60892,6 @@ encoder:
 𠏻	niol	0
 修饰	niom	6540000
 𨿇	nioo	0
-𫖛	nioo	0
 𩀗	nipi	0
 𢟅	nipw	0
 𪅭	niqr	0
@@ -63322,7 +60982,6 @@ encoder:
 修建	niyx	18700000
 翛	niyy	122000
 𦐻	niyy	0
-𪝯	nizg	0
 侦缉	nizj	353000
 修缮	nizu	2440000
 修好	nizy	4770000
@@ -63364,7 +61023,6 @@ encoder:
 𩳆	njck	0
 儼	njcm	1490000
 𩥢	njcu	0
-𪜷	njda	0
 保持	njdb	225000000
 𩲅	njds	0
 保护	njdw	270000000
@@ -63464,7 +61122,6 @@ encoder:
 僤	njke	517000
 𢍘	njke	0
 𩴫	njke	0
-𫚓	njke	0
 䰠	njki	10100
 𩲳	njki	0
 𩴤	njkk	0
@@ -63537,7 +61194,6 @@ encoder:
 𩴍	njnx	0
 𩵈	njnx	0
 保健	njny	159000000
-𫚌	njoa	0
 保全	njoc	12100000
 保德	njoe	983000
 𠂺	njoe	0
@@ -63555,7 +61211,6 @@ encoder:
 魎	njoo	326000
 𩲻	njoo	0
 𩳳	njoo	0
-𫚍	njoo	0
 𩴑	njop	0
 𩴎	njoq	0
 𠒆	njor	0
@@ -63589,7 +61244,6 @@ encoder:
 𩳉	njpy	0
 𩳎	njpy	0
 𩳕	njpz	0
-𫒾	njpz	0
 促膝	njqf	709000
 𩴰	njqm	0
 鬼脸	njqo	9910000
@@ -63629,7 +61283,6 @@ encoder:
 㔡	njry	4440
 保证	njsa	218000000
 保靖	njsc	300000
-𫚏	njsc	0
 𢍍	njse	0
 𠵓	njsi	0
 鬼话	njsm	12600000
@@ -63643,7 +61296,6 @@ encoder:
 保康	njtx	601000
 𩲯	njub	0
 𩴴	njub	0
-𫚎	njuc	0
 保单	njuk	2010000
 𣉭	njuk	0
 向着	njul	15900000
@@ -63689,9 +61341,7 @@ encoder:
 保驾	njyj	2060000
 𩲤	njyj	0
 向阳	njyk	5590000
-𫚒	njyl	0
 𩱹	njym	0
-𪜰	njym	0
 𩴹	njyn	0
 保险	njyo	102000000
 㼰	njys	6850
@@ -63740,7 +61390,6 @@ encoder:
 偿	nkbz	8430000
 𤽎	nkbz	0
 𤾼	nkbz	0
-𪾯	nkbz	0
 𤽯	nkcd	0
 𩔇	nkcg	0
 伸长	nkch	2710000
@@ -63832,8 +61481,6 @@ encoder:
 𢿉	nkix	0
 𢿎	nkix	0
 𤽐	nkix	0
-𪯦	nkix	0
-𪾮	nkja	0
 㑽	nkjb	4070
 㿧	nkjd	6590
 但因	nkjd	7020000
@@ -63847,13 +61494,10 @@ encoder:
 償	nkjl	2260000
 皜	nkjl	581000
 𤾘	nkjl	0
-𪾱	nkjm	0
 白喉	nkjn	359000
 傥	nkjr	318000
 𤽪	nkjr	0
 𤾮	nkjr	0
-𪾭	nkjr	0
-𪾰	nkjr	0
 僼	nkju	60200
 皚	nkju	188000
 𤾢	nkju	0
@@ -63868,7 +61512,6 @@ encoder:
 儂	nkkg	1920000
 皝	nkkg	167000
 皩	nkkg	22800
-𪝜	nkkg	0
 畠	nkki	949000
 鼻甲	nkki	172000
 𤽙	nkki	0
@@ -63879,7 +61522,6 @@ encoder:
 𪏓	nkko	0
 㣎	nkkp	3800
 㣐	nkkp	3900
-𪵀	nkkq	0
 㿣	nkkr	7560
 𤾣	nkku	0
 𤾧	nkku	0
@@ -63895,7 +61537,6 @@ encoder:
 倘	nkld	6140000
 帛	nkli	3710000
 𤾥	nklk	0
-𪝓	nklk	0
 𢄗	nkll	0
 𣻮	nkll	0
 僘	nklm	55500
@@ -63903,7 +61544,6 @@ encoder:
 𦧠	nklm	0
 皠	nkln	86600
 𢅬	nklo	0
-𪾬	nklo	0
 𢄝	nklr	0
 𪁼	nklr	0
 僈	nklx	134000
@@ -63958,7 +61598,6 @@ encoder:
 𢅉	nknr	0
 𤾆	nknr	0
 𤾇	nknr	0
-𫜞	nknr	0
 但他	nknv	41400000
 鼻息	nknw	2160000
 𢀎	nknz	0
@@ -63968,10 +61607,7 @@ encoder:
 𤾹	nkob	0
 𤿂	nkoc	0
 白人	nkod	5510000
-𪾫	nkoe	0
 儤	nkok	539000
-𪟉	nkok	0
-𪽽	nkon	0
 皎	nkoo	1760000
 舅父	nkoo	485000
 𤽬	nkoo	0
@@ -63988,7 +61624,6 @@ encoder:
 鼻饲	nkoy	282000
 𤽉	nkoy	0
 𣌣	nkoz	0
-𪾪	nkpa	0
 皤	nkpk	235000
 𢿬	nkpm	0
 𥡻	nkpm	0
@@ -64047,7 +61682,6 @@ encoder:
 白族	nksm	1470000
 白话	nksm	1950000
 皦	nksm	76800
-𪾩	nkso	0
 𣪧	nksq	0
 㰾	nksr	16800
 𤽕	nksr	0
@@ -64070,7 +61704,6 @@ encoder:
 白糖	nkut	4710000
 𤎥	nkuu	0
 𤾃	nkuu	0
-𪝩	nkuu	0
 偶数	nkuz	1450000
 白河	nkva	4030000
 偿清	nkvc	151000
@@ -64105,7 +61738,6 @@ encoder:
 伸展	nkxe	5480000
 俏皮	nkxi	5170000
 𤾰	nkxi	0
-𪾔	nkxi	0
 𤾙	nkxj	0
 𤾭	nkxk	0
 𠍦	nkxl	0
@@ -64113,7 +61745,6 @@ encoder:
 𤽶	nkxm	0
 𠙡	nkxq	0
 𠙧	nkxq	0
-𪵏	nkxr	0
 白昼	nkxs	2880000
 但对	nkxv	14900000
 𤽿	nkxw	0
@@ -64129,7 +61760,6 @@ encoder:
 𠡈	nkym	0
 白费	nkyn	5420000
 𤾫	nkyn	0
-𪾲	nkyq	0
 𣣝	nkyr	0
 㼟	nkys	4790
 𤾡	nkyu	0
@@ -64145,7 +61775,6 @@ encoder:
 𤽸	nkzb	0
 皪	nkzf	67000
 𤾾	nkzf	0
-𪾳	nkzh	0
 𠈷	nkzi	0
 𢅞	nkzk	0
 𤽺	nkzk	0
@@ -64154,7 +61783,6 @@ encoder:
 𠈐	nkzm	0
 𠈤	nkzm	0
 𠐍	nkzm	0
-𪝀	nkzm	0
 𣌣	nkzo	0
 𣪕	nkzq	0
 白纸	nkzr	4160000
@@ -64179,7 +61807,6 @@ encoder:
 倶	nlao	807000
 𠔙	nlao	0
 𦥺	nlax	0
-𫁛	nlaz	0
 𪖢	nlbb	0
 𣍝	nlbd	0
 倜	nlbj	330000
@@ -64237,7 +61864,6 @@ encoder:
 齅	nlgs	21800
 𠋬	nlgs	0
 𤠩	nlgs	0
-𫝪	nlgs	0
 𠋌	nlgu	0
 𤒝	nlgu	0
 𦤠	nlgu	0
@@ -64280,7 +61906,6 @@ encoder:
 𣳻	nlkv	0
 𦤓	nlkz	0
 𪖹	nlkz	0
-𫈁	nlkz	0
 𠈕	nlld	0
 䶐	nllk	3830
 𪖾	nlln	0
@@ -64288,7 +61913,6 @@ encoder:
 自用	nllv	9440000
 催眠	nlly	13800000
 自助	nlly	106000000
-𪝾	nllz	0
 自筹	nlmc	1440000
 𡘠	nlmg	0
 𦧗	nlmi	0
@@ -64321,14 +61945,12 @@ encoder:
 𠎺	nlnj	0
 𩳈	nlnj	0
 劓	nlnk	124000
-𫈀	nlnk	0
 儶	nlnl	43200
 皑皑	nlnl	754000
 𪖖	nlnm	0
 𪖴	nlnm	0
 𪖛	nlnp	0
 鼽	nlnq	68700
-𫘈	nlnq	0
 䶌	nlnr	3760
 催化	nlnr	4720000
 𪖗	nlnr	0
@@ -64369,7 +61991,6 @@ encoder:
 𧠆	nlrd	0
 自然	nlrg	310000000
 㒔	nlri	4420
-𪝳	nlri	0
 齁	nlrj	1320000
 𪖼	nlrk	0
 儩	nlro	63800
@@ -64403,7 +62024,6 @@ encoder:
 𠏩	nlsr	0
 𧚡	nlsr	0
 𧛲	nlsr	0
-𪝤	nlsr	0
 自立	nlsu	11800000
 侺	nlsx	41600
 侧记	nlsy	1450000
@@ -64415,7 +62035,6 @@ encoder:
 自尊	nluf	9350000
 奥	nlug	161000000
 𠏥	nlug	0
-𫈂	nluk	0
 𣀐	nlum	0
 自首	nlun	3320000
 𦤩	nlux	0
@@ -64423,7 +62042,6 @@ encoder:
 𪖦	nluy	0
 自满	nlve	1290000
 臯	nlve	69700
-𪜯	nlvv	0
 自学	nlvw	16600000
 自觉	nlvw	42000000
 自治	nlvz	14100000
@@ -64434,7 +62052,6 @@ encoder:
 𪖰	nlwl	0
 自选	nlwm	17600000
 𦧰	nlwm	0
-𪬻	nlwm	0
 𦤤	nlwn	0
 𪃼	nlwr	0
 𪕿	nlwr	0
@@ -64443,7 +62060,6 @@ encoder:
 𠕫	nlww	0
 𪖧	nlwx	0
 鄎	nlwy	37800
-𫇿	nlwy	0
 息	nlwz	79900000
 䶊	nlxe	3770
 𦤊	nlxe	0
@@ -64459,7 +62075,6 @@ encoder:
 自卫	nlya	3520000
 自强	nlyj	6010000
 𪖠	nlyj	0
-𪜿	nlym	0
 自费	nlyn	4180000
 𠍟	nlyn	0
 甈	nlys	55600
@@ -64469,13 +62084,11 @@ encoder:
 翺	nlyy	73700
 自己	nlyy	962000000
 𦤥	nlyy	0
-𫆣	nlyy	0
 𪖶	nlze	0
 䶑	nlzi	3730
 自如	nlzj	11100000
 𠟲	nlzk	0
 仙女	nlzm	8180000
-𪥽	nlzm	0
 儸	nlzn	627000
 𪖿	nlzn	0
 自给	nlzo	2040000
@@ -64488,7 +62101,6 @@ encoder:
 倂	nmae	165000
 𠍹	nmaj	0
 作恶	nmak	637000
-𪝞	nmal	0
 伤残	nmar	2590000
 仟万	nmay	226000
 𠋐	nmaz	0
@@ -64566,7 +62178,6 @@ encoder:
 作用	nmlv	192000000
 任县	nmlz	497000
 𠈠	nmmb	0
-𪜽	nmmb	0
 𠐬	nmmg	0
 𠎔	nmmm	0
 作答	nmmo	2850000
@@ -64646,7 +62257,6 @@ encoder:
 𠐉	nmxy	0
 㑧	nmya	4270
 仡	nmyd	757000
-𪜔	nmyd	0
 侨民	nmyh	655000
 𪘗	nmyi	0
 伤	nmym	112000000
@@ -64664,7 +62274,6 @@ encoder:
 𠇓	nmzz	0
 𠏿	nnan	0
 𠋐	nnaz	0
-𪝔	nncq	0
 俾	nned	11800000
 牌楼	nnfu	1240000
 𠌞	nngx	0
@@ -64675,7 +62284,6 @@ encoder:
 儁	nniy	149000
 牌号	nnja	4670000
 㑖	nnji	4480
-𫗅	nnjk	0
 牌照	nnky	9440000
 傻笑	nnmm	16000000
 𢻺	nnmo	0
@@ -64712,7 +62320,6 @@ encoder:
 㑺	nnym	5250
 𠏙	nnzd	0
 𡠓	nnzm	0
-𪦁	nnzm	0
 伯母	nnzy	1830000
 佮	noaj	115000
 倫	noal	15900000
@@ -64728,7 +62335,6 @@ encoder:
 𪙼	nobi	0
 𩁅	nobn	0
 𠈖	nobo	0
-𪝕	nobq	0
 𧭨	nobs	0
 俭	nobv	4710000
 𨞄	noby	0
@@ -64810,7 +62416,6 @@ encoder:
 俗名	norj	1160000
 伦	norr	49700000
 𦆗	nors	0
-𪜨	nosa	0
 俗语	nosb	5260000
 𠉫	nosc	0
 伦敦	nosj	26600000
@@ -64836,8 +62441,6 @@ encoder:
 份	noyd	240000000
 𠌋	noyg	0
 伦巴	noyi	733000
-𪝗	noyl	0
-𪬈	noyw	0
 㒆	noyy	4660
 伧	noyy	234000
 傟	noyy	32700
@@ -64877,7 +62480,6 @@ encoder:
 𠍖	nprs	0
 𠊄	npvv	0
 僾	npwr	892000
-𪝊	npwx	0
 僁	npwz	27800
 𠊻	npxf	0
 𠌀	npxk	0
@@ -64885,7 +62487,6 @@ encoder:
 㒚	npxw	4300
 俘	npya	5230000
 𠈊	npyi	0
-𪝝	npyq	0
 僞	npyu	701000
 傒	npzg	125000
 俀	npzm	103000
@@ -64907,7 +62508,6 @@ encoder:
 㐽	nqos	5350
 佩服	nqqy	25600000
 仇怨	nqry	550000
-𪝟	nqug	0
 𠑇	nqul	0
 仇恨	nqux	40300000
 仴	nqvv	529000
@@ -64972,7 +62572,6 @@ encoder:
 倾听	nrjp	24300000
 俛	nrjr	111000
 华中	nrjv	33500000
-𪜶	nrka	0
 华里	nrkb	1420000
 仰光	nrkg	361000
 俻	nrki	57300
@@ -64983,10 +62582,8 @@ encoder:
 𠉎	nrkv	0
 您	nrkw	3090000000
 𠊫	nrky	0
-𪝁	nrlb	0
 偕同	nrld	655000
 𠊇	nrld	0
-𪝁	nrld	0
 华山	nrll	9500000
 偩	nrlo	448000
 貨	nrlo	52000000
@@ -65002,7 +62599,6 @@ encoder:
 𠏤	nrml	0
 低矮	nrmm	1630000
 货物	nrmr	26200000
-𪝪	nrmu	0
 𠇩	nrmy	0
 化身	nrnc	11200000
 低估	nrne	14300000
@@ -65027,7 +62623,6 @@ encoder:
 倾盆	nroy	1440000
 俢	nrpd	98200
 倾销	nrpk	1980000
-𪝷	nrpk	0
 货舱	nrpo	365000
 货船	nrpq	944000
 你所	nrpv	27900000
@@ -65043,7 +62638,6 @@ encoder:
 𣢉	nrro	0
 仳	nrrr	205000
 𪂄	nrrr	0
-𪜫	nrrr	0
 侈	nrrs	951000
 儳	nrrs	854000
 𠋂	nrrt	0
@@ -65113,19 +62707,16 @@ encoder:
 𠌃	nryk	0
 𠎿	nrym	0
 华阴	nryq	443000
-𪝖	nryw	0
 𠆿	nrza	0
 𠌥	nrza	0
 化纤	nrzm	16100000
 𠈍	nrzm	0
 低能	nrzq	5820000
 华约	nrzr	151000
-𪜪	nrzs	0
 低级	nrzy	7280000
 你好	nrzy	125000000
 您好	nrzy	83200000
 位于	nsad	84100000
-𪝱	nsad	0
 停刊	nsae	823000
 𠎂	nsag	0
 𠋣	nsaj	0
@@ -65179,7 +62770,6 @@ encoder:
 储量	nska	3240000
 儃	nska	44800
 𠑠	nska	0
-𪝃	nska	0
 僮	nskb	1550000
 傽	nske	39200
 僦	nskg	1230000
@@ -65208,7 +62798,6 @@ encoder:
 倣	nsmo	1260000
 偐	nsmp	655000
 位移	nsmr	2090000
-𪝰	nsmr	0
 𠍭	nsms	0
 㑪	nsnd	4290
 侪	nsnd	329000
@@ -65320,12 +62909,10 @@ encoder:
 俯	ntnd	8950000
 㒣	ntnw	4600
 𠏛	ntos	0
-𪝌	ntra	0
 佽	ntro	1750000
 偝	ntrq	771000
 𠉆	ntrr	0
 𠊒	ntrr	0
-𪝌	ntrs	0
 俯冲	nttj	1120000
 儦	ntuo	38200
 𠊴	ntuz	0
@@ -65350,7 +62937,6 @@ encoder:
 焦虑	nuiw	9200000
 焦距	nujh	7260000
 焦躁	nujj	2590000
-𪝫	nujl	0
 侻	nujr	58800
 𠐹	nukl	0
 伪劣	nukm	5110000
@@ -65365,7 +62951,6 @@ encoder:
 僧侣	nunj	1560000
 焦作	nunm	6160000
 伙伴	nunu	305000000
-𪝠	nuol	0
 伙食	nuox	6180000
 𠐒	nuox	0
 𠉅	nuoy	0
@@ -65411,7 +62996,6 @@ encoder:
 𠊶	nuzm	0
 𠋄	nuzm	0
 𠈼	nuzx	0
-𪝵	nvbo	0
 𠑊	nvcm	0
 他的	nvdv	209000000
 𠍀	nvfk	0
@@ -65434,7 +63018,6 @@ encoder:
 𠎢	nvzw	0
 佇	nwai	779000
 偏下	nwai	347000
-𪝥	nwaj	0
 𠍊	nwan	0
 儙	nway	94300
 倥	nwbi	789000
@@ -65453,10 +63036,8 @@ encoder:
 偏大	nwgd	2120000
 𠉂	nwgd	0
 傢	nwgq	10900000
-𪝚	nwgq	0
 㑦	nwgs	4520
 𠊲	nwgs	0
-𪝶	nwgy	0
 偏转	nwhb	799000
 𠋤	nwhb	0
 偏上	nwiv	538000
@@ -65464,9 +63045,7 @@ encoder:
 𠑅	nwju	0
 𠐟	nwkk	0
 儐	nwkl	607000
-𪝻	nwkm	0
 偏小	nwko	1650000
-𪝦	nwko	0
 儜	nwla	410000
 𠊙	nwlc	0
 偏	nwld	84600000
@@ -65529,7 +63108,6 @@ encoder:
 偏心	nwwz	2560000
 僒	nwxj	40400
 𠌣	nwxj	0
-𪜹	nwya	0
 傓	nwyy	39700
 侒	nwzm	142000
 𠊢	nwzm	0
@@ -65559,21 +63137,18 @@ encoder:
 僻壤	nxbs	157000
 伊吾	nxbx	196000
 健	nxby	86300000
-𪻋	nxcd	0
 𤗮	nxcl	0
 㒈	nxcm	4570
 𠑨	nxcm	0
 伊春	nxco	2390000
 僻静	nxcq	1510000
 侵扰	nxdg	1380000
-𪜬	nxed	0
 𤗥	nxef	0
 假若	nxeg	3490000
 𠌄	nxeh	0
 𧌛	nxei	0
 倨	nxej	708000
 𤖲	nxej	0
-𪻎	nxek	0
 𤗸	nxel	0
 𧡦	nxel	0
 假期	nxeq	25600000
@@ -65766,7 +63341,6 @@ encoder:
 侵犯	nxqy	70500000
 𤗅	nxqz	0
 片儿	nxrd	862000
-𪝬	nxri	0
 假名	nxrj	1420000
 假象	nxrj	3950000
 𤖵	nxrj	0
@@ -65848,9 +63422,7 @@ encoder:
 𧌿	nxxi	0
 牗	nxxl	273000
 片尾	nxxm	1250000
-𪻊	nxxo	0
 𠃆	nxxp	0
-𪻍	nxxw	0
 假	nxxx	214000000
 𤖰	nxxx	0
 𤗜	nxxx	0
@@ -65859,7 +63431,6 @@ encoder:
 侷	nxyj	1260000
 倔强	nxyj	6600000
 牊	nxyj	636000
-𪻌	nxyk	0
 𤗖	nxyl	0
 𠡒	nxym	0
 𤗨	nxyn	0
@@ -65901,7 +63472,6 @@ encoder:
 仍不	nygi	7860000
 仍有	nygq	21200000
 健在	nygv	5430000
-𪜴	nyhd	0
 佛牙	nyhi	148000
 𠊽	nyhk	0
 𠇕	nyia	0
@@ -65910,7 +63480,6 @@ encoder:
 亿吨	nyjh	3670000
 𠎦	nyji	0
 𩎵	nyjm	0
-𪝂	nyjr	0
 伽师	nyka	196000
 佛光	nykg	2680000
 仍是	nykv	26300000
@@ -65921,7 +63490,6 @@ encoder:
 侹	nymb	57900
 㺱	nymc	4320
 佛手	nymd	2130000
-𪜸	nymf	0
 𠈰	nymi	0
 𠋉	nymn	0
 伋	nyms	133000
@@ -65940,7 +63508,6 @@ encoder:
 仍然	nyrg	108000000
 㒊	nysi	4720
 健忘	nysw	2730000
-𪬂	nysw	0
 健壮	nytb	7430000
 佛门	nytl	1810000
 健康	nytx	529000000
@@ -65955,19 +63522,14 @@ encoder:
 𠊩	nyya	0
 㐶	nyyb	8080
 㒛	nyyn	4060
-𪝡	nyyo	0
-𪜺	nyyt	0
-𪝡	nyyt	0
 佛陀	nyyw	2870000
 仔细	nyzk	91500000
 仍能	nyzq	4500000
-𪜵	nyzs	0
 佛经	nyzx	3350000
 似无	nzag	1200000
 𠊦	nzai	0
 𠋷	nzai	0
 𠎨	nzaj	0
-𪜻	nzds	0
 似的	nzdv	35800000
 牒	nzef	1750000
 㑬	nzej	4390
@@ -66000,7 +63562,6 @@ encoder:
 鼠害	nzwc	362000
 𢘂	nzwz	0
 伮	nzxs	47800
-𪝄	nzxs	0
 㑁	nzzi	4940
 𠆺	nzzi	0
 㑃	nzzy	5280
@@ -66029,7 +63590,6 @@ encoder:
 𧯚	oaju	0
 命中	oajv	24700000
 命题	oaka	8220000
-𫝢	oakl	0
 合影	oaks	8870000
 合水	oakv	345000
 合同	oald	162000000
@@ -66038,7 +63598,6 @@ encoder:
 惩罚	oals	21100000
 合用	oalv	2660000
 征用	oalv	3020000
-𪟤	oaly	0
 命悬	oalz	726000
 歙县	oalz	1110000
 八千	oame	5430000
@@ -66322,7 +63881,6 @@ encoder:
 兦	odaz	56700
 𠆦	odaz	0
 𠋒	odaz	0
-𪞸	odaz	0
 人士	odba	129000000
 𠈘	odbb	0
 𡒟	odbb	0
@@ -66334,7 +63892,6 @@ encoder:
 佘	odbk	3530000
 剉	odbk	292000
 畲	odbk	643000
-𪜭	odbk	0
 𡎬	odbl	0
 𢁭	odbl	0
 𠐸	odbn	0
@@ -66355,8 +63912,6 @@ encoder:
 侌	odbz	30700
 𠆭	odbz	0
 𦣹	odbz	0
-𪼵	odcc	0
-𪼶	odcc	0
 入球	odcd	2400000
 𠑋	odce	0
 𦔴	odce	0
@@ -66369,7 +63924,6 @@ encoder:
 㙦	odeb	4320
 仐	oded	81500
 𢨍	odeh	0
-𫆎	odej	0
 侴	odek	27100
 𠜋	odek	0
 𠝢	odek	0
@@ -66407,7 +63961,6 @@ encoder:
 𡬴	odhd	0
 人车	odhe	3150000
 㒪	odhg	4380
-𪾇	odhk	0
 𠌆	odhx	0
 𠓴	odhx	0
 𠆳	odia	0
@@ -66455,7 +64008,6 @@ encoder:
 畣	odjk	48200
 𠑱	odjk	0
 𣌭	odjk	0
-𫖾	odjk	0
 人员	odjl	313000000
 盒	odjl	124000000
 龠	odjl	226000
@@ -66495,13 +64047,10 @@ encoder:
 𨛣	odjy	0
 𨜾	odjy	0
 𨞡	odjy	0
-𪠄	odjy	0
-𪧆	odjy	0
 韱	odka	63500
 𨤾	odka	0
 𩚃	odka	0
 𡍑	odkb	0
-𪜾	odkb	0
 入时	odkd	1600000
 𠌓	odke	0
 𣡰	odkf	0
@@ -66539,7 +64088,6 @@ encoder:
 愈	odkw	61300000
 逾	odkw	37000000
 𥀟	odkx	0
-𪠬	odkx	0
 鄃	odky	37800
 鄶	odky	32300
 𠉒	odkz	0
@@ -66582,7 +64130,6 @@ encoder:
 入手	odmd	50200000
 余	odmf	143000000
 舖	odmf	20600000
-𪜲	odmf	0
 𩓱	odmg	0
 𢧅	odmh	0
 舍	odmi	58600000
@@ -66608,10 +64155,8 @@ encoder:
 人物	odmr	224000000
 人称	odmr	13600000
 鵨	odmr	25700
-𫜲	odmr	0
 𠐖	odms	0
 𣁏	odms	0
-𫈊	odms	0
 入秋	odmu	1260000
 𠏸	odmu	0
 𤒥	odmu	0
@@ -66718,7 +64263,6 @@ encoder:
 劎	odoy	363000
 𠝏	odoy	0
 𡦸	odoy	0
-𪞉	odoy	0
 𠚄	odoz	0
 𠚕	odoz	0
 𦃚	odoz	0
@@ -66738,7 +64282,6 @@ encoder:
 𠈛	odqk	0
 𠍐	odqp	0
 入狱	odqs	2960000
-𫘁	odqt	0
 𨝙	odqy	0
 兪	odqz	522000
 𠉽	odqz	0
@@ -66749,7 +64292,6 @@ encoder:
 𡎢	odri	0
 𡎦	odri	0
 𧓀	odri	0
-𪬍	odri	0
 人名	odrj	19600000
 𠐂	odrj	0
 𠷜	odrj	0
@@ -66845,8 +64387,6 @@ encoder:
 邻	odwy	28700000
 人心	odwz	40500000
 人马	odxa	3010000
-𪣼	odxb	0
-𪣾	odxb	0
 酓	odxf	25900
 𣜈	odxf	0
 𩑟	odxg	0
@@ -66854,7 +64394,6 @@ encoder:
 𦢢	odxh	0
 舒	odxi	45100000
 𧆺	odxi	0
-𪝸	odxi	0
 人群	odxj	45000000
 倉	odxj	9650000
 含	odxj	171000000
@@ -66877,9 +64416,7 @@ encoder:
 鳹	odxr	37000
 𠉞	odxr	0
 𣢝	odxr	0
-𪝸	odxr	0
 𪚕	odxs	0
-𪝅	odxs	0
 念	odxw	93700000
 𠇀	odxx	0
 𨙽	odxy	0
@@ -66897,7 +64434,6 @@ encoder:
 𠑝	odyn	0
 𠟐	odyo	0
 𡦈	odyp	0
-𪵯	odyq	0
 歙	odyr	2020000
 鸧	odyr	50500
 𪂤	odyr	0
@@ -66923,9 +64459,7 @@ encoder:
 𦒈	odyy	0
 𨝫	odyy	0
 𢎦	odyz	0
-𪫐	odyz	0
 𥃋	odza	0
-𪝸	odza	0
 人参	odzg	8880000
 𠁮	odzi	0
 𠍺	odzi	0
@@ -66935,7 +64469,6 @@ encoder:
 𠋔	odzl	0
 𢄕	odzl	0
 𥁧	odzl	0
-𫈎	odzl	0
 㠩	odzn	4780
 𡄬	odzn	0
 𠆹	odzp	0
@@ -67042,7 +64575,6 @@ encoder:
 𢓁	oibi	0
 㣟	oibj	3960
 徟	oibj	25000
-𫌩	oibj	0
 徕	oibk	3350000
 𢓛	oibk	0
 𢖂	oibl	0
@@ -67061,9 +64593,7 @@ encoder:
 㣵	oibu	4520
 𢔛	oibu	0
 𢖛	oibu	0
-𪫰	oibu	0
 𢡹	oibw	0
-𪫤	oibw	0
 徤	oiby	68200
 𢓧	oiby	0
 行动	oibz	102000000
@@ -67106,11 +64636,9 @@ encoder:
 𢔇	oiez	0
 徱	oifb	20400
 𢕰	oifd	0
-𪫭	oifd	0
 㣩	oiff	5670
 䵈	oiff	4030
 𪎓	oiff	0
-𪫲	oifg	0
 徆	oifj	66300
 䡓	oifk	4660
 𠝨	oifk	0
@@ -67131,7 +64659,6 @@ encoder:
 𧲞	oigl	0
 㣸	oigm	7660
 𢖢	oigm	0
-𪫣	oigm	0
 𢓻	oigq	0
 𧗢	oigr	0
 㣖	oigs	3590
@@ -67156,7 +64683,6 @@ encoder:
 衐	oihx	21400
 彻	oihy	9980000
 聳	oiic	1330000
-𫇃	oiic	0
 𢖤	oiig	0
 徙	oiii	1890000
 𢓊	oiii	0
@@ -67170,7 +64696,6 @@ encoder:
 𢔼	oiim	0
 𢖄	oiim	0
 𣯨	oiim	0
-𪫦	oiim	0
 𩀰	oiin	0
 𩞐	oiio	0
 𢔞	oiiq	0
@@ -67189,11 +64714,9 @@ encoder:
 行距	oijh	1280000
 㣡	oiji	7680
 𢖀	oiji	0
-𪫯	oiji	0
 徊	oijj	3010000
 𢕓	oijj	0
 𢔯	oijk	0
-𫌫	oijk	0
 𢔸	oijl	0
 𢔹	oijl	0
 𢕪	oijl	0
@@ -67201,7 +64724,6 @@ encoder:
 徫	oijm	76900
 衛	oijm	17200000
 𢕡	oijm	0
-𪫥	oijm	0
 衚	oijq	106000
 企图	oijr	23800000
 𡕴	oijr	0
@@ -67227,7 +64749,6 @@ encoder:
 𢓥	oikg	0
 𧗯	oikg	0
 𧗰	oikg	0
-𪫨	oikh	0
 㣙	oiki	3580
 𢔒	oikk	0
 徜	oikl	3820000
@@ -67248,7 +64769,6 @@ encoder:
 企业	oiku	756000000
 行业	oiku	403000000
 𢖃	oiku	0
-𪭁	oikw	0
 𢔂	oikz	0
 𢔈	oikz	0
 㣷	oila	15100
@@ -67267,7 +64787,6 @@ encoder:
 𧗽	oilg	0
 𧗾	oilg	0
 𧲔	oilg	0
-𫌨	oilg	0
 躛	oilj	19400
 𢕮	oilj	0
 徻	oilk	69000
@@ -67296,7 +64815,6 @@ encoder:
 𢖘	oilw	0
 𢖠	oilz	0
 𧗼	oilz	0
-𫌬	oilz	0
 𢓐	oimb	0
 𢔉	oimb	0
 徃	oimc	519000
@@ -67307,7 +64825,6 @@ encoder:
 𢓩	oimi	0
 𢖙	oimi	0
 𧘆	oimi	0
-𪫮	oimi	0
 行程	oimj	35700000
 躗	oimj	11700
 𢔊	oimj	0
@@ -67316,7 +64833,6 @@ encoder:
 𥋪	oiml	0
 𧢒	oiml	0
 𧢓	oiml	0
-𪿰	oiml	0
 𢔣	oimn	0
 𢔖	oimo	0
 𢔜	oimp	0
@@ -67336,7 +64852,6 @@ encoder:
 𢖟	oimz	0
 行使	oina	15000000
 徨	oinc	1720000
-𫌪	oinc	0
 𡭑	oind	0
 𧘄	oind	0
 𢔌	oine	0
@@ -67403,8 +64918,6 @@ encoder:
 𢕝	oirc	0
 𢔨	oird	0
 衡	oirg	10900000
-𪫫	oirg	0
-𪫪	oiri	0
 㣘	oirj	3750
 𢓜	oirj	0
 徇	oirk	752000
@@ -67423,7 +64936,6 @@ encoder:
 𢔚	oirs	0
 𢕻	oirs	0
 𢖞	oirs	0
-𪫧	oirs	0
 㣠	oirt	4770
 𢓈	oirt	0
 𢓘	oirt	0
@@ -67442,13 +64954,11 @@ encoder:
 𢕉	oisi	0
 𢕬	oisi	0
 𧗹	oisk	0
-𪪊	oisl	0
 徼	oism	781000
 徾	oism	26900
 𢕟	oism	0
 𥟲	oism	0
 𢓌	oiso	0
-𪫢	oiso	0
 䘕	oisq	3690
 𢓔	oisu	0
 𢕦	oisx	0
@@ -67486,7 +64996,6 @@ encoder:
 徧	oiwl	183000
 㣗	oiwm	3410
 𢖒	oiwr	0
-𪫩	oiwr	0
 徬	oiws	907000
 𢕨	oiws	0
 𢔀	oiwx	0
@@ -67546,8 +65055,6 @@ encoder:
 徽	oizm	14200000
 𢓪	oizm	0
 𢕄	oizm	0
-𪫬	oizm	0
-𪫳	oizm	0
 𢔫	oizq	0
 𢔮	oizq	0
 㣞	oizr	3410
@@ -67644,7 +65151,6 @@ encoder:
 余年	ommm	10100000
 饰物	ommr	5670000
 舍身	omnc	1490000
-𪰉	omnr	0
 舒服	omqy	43500000
 叙永	omsk	314000
 叙说	omsv	756000
@@ -67714,7 +65220,6 @@ encoder:
 𧮴	ooej	0
 谼	ooeo	30100
 坐落	ooev	7980000
-𪻃	ooez	0
 坐标	oofb	9670000
 丛林	ooff	7690000
 谷雨	oofv	573000
@@ -67742,7 +65247,6 @@ encoder:
 欲	oojr	141000000
 鵒	oojr	36300
 鹆	oojr	172000
-𫎻	oojr	0
 豅	oojs	32500
 𪚡	oojs	0
 从中	oojv	44000000
@@ -67845,7 +65349,6 @@ encoder:
 𧯎	ooxq	0
 𣢲	ooxr	0
 丛书	ooxy	27300000
-𪻄	ooxy	0
 斧子	ooya	1060000
 父子	ooya	10400000
 谷子	ooya	1920000
@@ -67854,7 +65357,6 @@ encoder:
 𧮬	ooye	0
 爸	ooyi	78000000
 𤭏	ooys	0
-𪽫	ooys	0
 豀	oozg	28600
 𧯗	oozg	0
 𠚁	oozi	0
@@ -67935,7 +65437,6 @@ encoder:
 𣌇	osck	0
 今春	osco	2840000
 往事	osdj	25000000
-𪳝	osdp	0
 含蓄	oses	5690000
 𢺽	osex	0
 贪婪	osff	10100000
@@ -67948,7 +65449,6 @@ encoder:
 𪀣	osfr	0
 𣏂	osfs	0
 𨐖	osfs	0
-𫃰	osfu	0
 𠯌	osgj	0
 希	osgl	70200000
 𢂞	osgl	0
@@ -68007,7 +65507,6 @@ encoder:
 𧠔	osol	0
 𢼂	osom	0
 𢼫	osom	0
-𪻅	osom	0
 彷徨	oson	6130000
 㸚	osoo	4560
 𨌸	osoo	0
@@ -68047,7 +65546,6 @@ encoder:
 念头	ostg	15600000
 含糊	osue	6980000
 含着	osul	6110000
-𪞌	osul	0
 𤉧	osum	0
 含羞	osux	2380000
 贪污	osvb	12800000
@@ -68063,11 +65561,9 @@ encoder:
 𤕟	osxi	0
 𩰠	osxi	0
 閷	osxo	82800
-𪠦	osxs	0
 𠮁	osxx	0
 念书	osxy	2940000
 饺子	osya	5860000
-𪡜	osyb	0
 𠫲	osye	0
 敎	osym	2330000
 𢽌	osym	0
@@ -68165,7 +65661,6 @@ encoder:
 餠	oxae	181000
 𩛧	oxae	0
 𩝂	oxae	0
-𫘢	oxae	0
 䬴	oxaf	6320
 饛	oxag	31900
 𩝬	oxag	0
@@ -68206,7 +65701,6 @@ encoder:
 𩞢	oxbq	0
 𩟆	oxbq	0
 䬧	oxbr	3650
-𫘣	oxbr	0
 䭞	oxbu	3640
 𤏼	oxbu	0
 𩜜	oxbu	0
@@ -68223,10 +65717,8 @@ encoder:
 饵	oxce	4010000
 很长	oxch	25300000
 餦	oxch	46900
-𫘤	oxch	0
 𩝛	oxcj	0
 䭍	oxcl	4270
-𫘝	oxcl	0
 䭛	oxcm	3810
 𩜎	oxcq	0
 𩚽	oxcs	0
@@ -68245,11 +65737,9 @@ encoder:
 䭅	oxej	4300
 𩚩	oxej	0
 𩛶	oxej	0
-𫘥	oxej	0
 𩜅	oxek	0
 饙	oxel	28600
 𩟲	oxel	0
-𫘙	oxel	0
 𩝟	oxen	0
 𩟙	oxen	0
 餀	oxeo	34600
@@ -68258,12 +65748,10 @@ encoder:
 𩛘	oxeo	0
 𩛛	oxeo	0
 𩞫	oxeo	0
-𫘶	oxep	0
 饟	oxer	42300
 饢	oxer	30200
 馕	oxer	515000
 𩟻	oxer	0
-𫘹	oxer	0
 餝	oxes	39000
 𩛲	oxes	0
 䭖	oxeu	3780
@@ -68275,17 +65763,14 @@ encoder:
 𩝒	oxez	0
 䬱	oxfa	3910
 餔	oxfb	179000
-𫘪	oxfb	0
 䭦	oxfd	3930
 餺	oxfd	31300
 馎	oxfd	38900
 𩟛	oxfd	0
 食槽	oxfe	174000
 饝	oxfg	22500
-𫘘	oxfg	0
 餗	oxfj	54100
 𩞍	oxfj	0
-𫘫	oxfj	0
 䭩	oxfk	4020
 𩜍	oxfk	0
 𩜫	oxfm	0
@@ -68308,14 +65793,12 @@ encoder:
 很不	oxgi	38100000
 𩛷	oxgj	0
 餙	oxgl	56100
-𫘠	oxgl	0
 𩛫	oxgm	0
 𩝍	oxgm	0
 𩝗	oxgo	0
 𩜽	oxgp	0
 很有	oxgq	77300000
 餚	oxgq	87400
-𫘓	oxgq	0
 𩚌	oxgr	0
 𩝠	oxgs	0
 餸	oxgw	261000
@@ -68323,7 +65806,6 @@ encoder:
 𩝘	oxgx	0
 𩚚	oxgy	0
 𩛌	oxgz	0
-𫘨	oxgz	0
 䬹	oxhb	4140
 饶	oxhg	16500000
 餞	oxhh	213000
@@ -68337,7 +65819,6 @@ encoder:
 𩜚	oxhr	0
 𩞊	oxhr	0
 𩞞	oxhr	0
-𫘒	oxhx	0
 𩚦	oxhy	0
 𩜮	oxhy	0
 𩝮	oxhy	0
@@ -68365,7 +65846,6 @@ encoder:
 𩞛	oxjf	0
 𩟎	oxjf	0
 𩞧	oxjg	0
-𫘷	oxji	0
 食品	oxjj	317000000
 饇	oxjj	23900
 𩞒	oxjj	0
@@ -68374,16 +65854,12 @@ encoder:
 𩜰	oxjk	0
 𩞮	oxjk	0
 𩟈	oxjk	0
-𫘚	oxjk	0
-𫘟	oxjk	0
 𩝝	oxjl	0
-𫘜	oxjl	0
 𩞦	oxjm	0
 𩟍	oxjm	0
 𩠏	oxjm	0
 䬼	oxjq	3960
 餬	oxjq	86700
-𫘯	oxjq	0
 䬽	oxjr	4060
 𩚶	oxjr	0
 𩛟	oxjr	0
@@ -68404,7 +65880,6 @@ encoder:
 饘	oxka	64200
 馇	oxka	170000
 𩟶	oxka	0
-𫘸	oxka	0
 䭚	oxkb	3600
 䭪	oxkb	3870
 𩞯	oxkb	0
@@ -68415,7 +65890,6 @@ encoder:
 𩟊	oxkg	0
 餵	oxkh	4090000
 𩞡	oxkh	0
-𫘱	oxkh	0
 𩚲	oxki	0
 䭜	oxkk	3720
 𩞄	oxkk	0
@@ -68452,7 +65926,6 @@ encoder:
 𩜵	oxlg	0
 𩝆	oxlg	0
 𩠊	oxlg	0
-𫘰	oxlg	0
 𩚍	oxli	0
 𩛎	oxlj	0
 𩝄	oxlj	0
@@ -68466,7 +65939,6 @@ encoder:
 𩜃	oxlo	0
 𩝻	oxlo	0
 𩟿	oxlo	0
-𫘭	oxlr	0
 食用	oxlv	28000000
 餶	oxlw	55200
 馉	oxlw	29000
@@ -68493,15 +65965,12 @@ encoder:
 𩚊	oxmh	0
 飵	oxmi	43000
 餂	oxmi	44600
-𫘦	oxmi	0
-𫘗	oxmj	0
 很重	oxmk	6990000
 𩚸	oxmk	0
 飾	oxml	21200000
 饰	oxml	56700000
 𩝳	oxml	0
 𩟺	oxml	0
-𫘡	oxml	0
 𩝟	oxmn	0
 𩝧	oxmp	0
 食物	oxmr	57800000
@@ -68522,13 +65991,10 @@ encoder:
 𩛪	oxmy	0
 𩛵	oxmy	0
 𩠂	oxmy	0
-𫘴	oxmy	0
 很乱	oxmz	2040000
 餧	oxmz	57300
 𩛸	oxmz	0
-𫘮	oxmz	0
 餭	oxnc	33000
-𫘲	oxnc	0
 𩚭	oxnd	0
 𩟦	oxnh	0
 𩜑	oxni	0
@@ -68547,7 +66013,6 @@ encoder:
 𩟓	oxnx	0
 𩛀	oxoa	0
 𩛠	oxob	0
-𫘔	oxoc	0
 飤	oxod	26600
 𩚆	oxod	0
 𩜘	oxoe	0
@@ -68596,7 +66061,6 @@ encoder:
 𩛝	oxpd	0
 𩜓	oxpf	0
 𩟇	oxpg	0
-𪿅	oxpl	0
 饀	oxpn	39700
 𩛃	oxps	0
 飯	oxpx	33800000
@@ -68645,7 +66109,6 @@ encoder:
 𩞃	oxro	0
 䬨	oxrq	4240
 𩜧	oxrq	0
-𫘕	oxrq	0
 䬷	oxrr	4210
 餛	oxrr	798000
 馄	oxrr	1710000
@@ -68684,7 +66147,6 @@ encoder:
 𩚕	oxsx	0
 𩛡	oxsx	0
 𩟼	oxsx	0
-𫘬	oxsx	0
 𩚠	oxsy	0
 𩜛	oxsy	0
 𩜭	oxte	0
@@ -68721,7 +66183,6 @@ encoder:
 䭑	oxux	4020
 䭠	oxux	4350
 很快	oxux	84800000
-𫘵	oxux	0
 䬾	oxuy	3990
 𩜇	oxuy	0
 𩠉	oxuy	0
@@ -68737,12 +66198,10 @@ encoder:
 𩞙	oxwf	0
 𩞈	oxwg	0
 𩠅	oxwg	0
-𫘩	oxwh	0
 食补	oxwi	1160000
 䭏	oxwl	4200
 𩟂	oxwl	0
 飶	oxwm	46900
-𫘧	oxwm	0
 食宿	oxwn	4960000
 𩚗	oxwq	0
 𩟞	oxwr	0
@@ -68756,7 +66215,6 @@ encoder:
 𩚬	oxwy	0
 𩛓	oxwy	0
 𩛖	oxwz	0
-𫘖	oxwz	0
 䭈	oxxb	4350
 𩛐	oxxb	0
 饈	oxxe	53200
@@ -68773,10 +66231,8 @@ encoder:
 𩞷	oxxk	0
 𩛤	oxxl	0
 𩞋	oxxl	0
-𫘛	oxxl	0
 䬿	oxxm	4550
 餱	oxxm	41800
-𫘳	oxxm	0
 很难	oxxn	58700000
 䬶	oxxo	4100
 𩚯	oxxr	0
@@ -68929,11 +66385,9 @@ encoder:
 𠔑	oyoy	0
 分钟	oypj	135000000
 𤫫	oyps	0
-𪟒	oypx	0
 分外	oyri	4940000
 分解	oyrl	24400000
 𣢏	oyro	0
-𪟒	oyrx	0
 分色	oyry	875000
 鳻	oyrz	37100
 𩿈	oyrz	0
@@ -68958,7 +66412,6 @@ encoder:
 炃	oyuo	36300
 饲料	oyut	21000000
 分为	oyuv	51300000
-𪭉	oyux	0
 分数	oyuz	23700000
 创举	oyva	2730000
 分清	oyvc	6430000
@@ -68978,8 +66431,6 @@ encoder:
 分层	oyxb	3850000
 分居	oyxe	3560000
 𣗰	oyxf	0
-𪭓	oyxl	0
-𫏟	oyxl	0
 分属	oyxm	1180000
 𠬰	oyxs	0
 分局	oyxy	13500000
@@ -69061,7 +66512,6 @@ encoder:
 公斤	ozpd	63800000
 公猪	ozqb	559000
 公猫	ozqe	370000
-𫗾	ozqi	0
 公狗	ozqr	594000
 凶狠	ozqx	3990000
 凶猛	ozqy	5910000
@@ -69112,7 +66562,6 @@ encoder:
 公尺	ozxs	6090000
 公司	ozya	1240000000
 公子	ozya	19000000
-𪞊	ozya	0
 𩔚	ozyg	0
 公民	ozyh	42900000
 公孙	ozyk	1870000
@@ -69120,7 +66569,6 @@ encoder:
 凶险	ozyo	2360000
 鶲	ozyr	111000
 鹟	ozyr	54300
-𪵓	ozyr	0
 瓮	ozys	1690000
 勜	ozyy	24300
 翁	ozyy	22700000
@@ -69183,7 +66631,6 @@ encoder:
 金昌	pakk	2290000
 𨭀	pakl	0
 金星	pakm	9610000
-𫓛	pako	0
 铔	paku	171000
 金堂	pakw	1080000
 𨫍	pakw	0
@@ -69236,7 +66683,6 @@ encoder:
 后悔	paum	35400000
 金粉	pauo	3170000
 錽	paur	46600
-𫔶	paur	0
 鋄	paux	26100
 金湖	pave	1860000
 金沙	pavk	5700000
@@ -69271,9 +66717,7 @@ encoder:
 𨩥	pbbd	0
 鐃	pbbg	93900
 䥗	pbbr	4390
-𫕉	pbbr	0
 𨭸	pbex	0
-𫕎	pbex	0
 𨬰	pbgo	0
 𨮚	pbhj	0
 𨮩	pbhj	0
@@ -69282,8 +66726,6 @@ encoder:
 𨮾	pbjd	0
 鎱	pbjr	572000
 𨯨	pbju	0
-𫓦	pbki	0
-𪾙	pbko	0
 銢	pbkv	36000
 銾	pbkv	22600
 铼	pbkv	1170000
@@ -69296,22 +66738,18 @@ encoder:
 䤲	pbno	4320
 錴	pbob	26400
 鈇	pbod	97900
-𫔥	pbod	0
 𨯉	pbof	0
 鐟	pbok	1270000
 鑚	pbol	566000
 錂	pbor	47400
 𨱋	pbor	0
 𨮕	pbpd	0
-𫔞	pbqc	0
 鈨	pbrd	34500
 𨪌	pbrk	0
-𫓮	pbrm	0
 銠	pbrr	125000
 铑	pbrr	610000
 𨦿	pbsk	0
 﨨	pbub	24400
-𫔂	pbud	0
 𨭎	pbuj	0
 𨪲	pbuk	0
 铗	pbuo	315000
@@ -69321,7 +66759,6 @@ encoder:
 钍	pbvv	327000
 𨰀	pbwf	0
 𨧣	pbwq	0
-𫓶	pbwr	0
 鋕	pbwz	66100
 鐚	pbwz	631000
 鋙	pbxj	55800
@@ -69340,10 +66777,7 @@ encoder:
 铸型	pcae	151000
 𨨯	pcag	0
 𨬩	pcax	0
-𫓧	pcbi	0
 鑷	pccc	828000
-𫔆	pccl	0
-𫔛	pccp	0
 𨫎	pccs	0
 鏏	pccx	26200
 鋳	pcds	712000
@@ -69389,11 +66823,9 @@ encoder:
 𡊣	pdab	0
 𩓥	pdag	0
 𩓭	pdag	0
-𫗸	pdag	0
 后	pdaj	909000000
 𠵲	pdaj	0
 岳	pdal	26600000
-𫙺	pdal	0
 乒	pdam	6700000
 𨖁	pdan	0
 兵	pdao	88600000
@@ -69411,7 +66843,6 @@ encoder:
 𠃘	pday	0
 𨚬	pday	0
 𨛪	pday	0
-𪟚	pday	0
 𡐠	pdbb	0
 𨨲	pdbd	0
 䫇	pdbg	3510
@@ -69420,7 +66851,6 @@ encoder:
 乕	pdbl	138000
 𨦶	pdbo	0
 𪃫	pdbr	0
-𫑯	pdbu	0
 𨑛	pdbz	0
 𤑊	pdcu	0
 𨟈	pddy	0
@@ -69440,7 +66870,6 @@ encoder:
 澃	pdgk	122000
 盨	pdgl	34800
 𢄼	pdgl	0
-𪿂	pdgl	0
 須	pdgo	19500000
 頎	pdgo	122000
 须	pdgo	76400000
@@ -69455,7 +66884,6 @@ encoder:
 𧏁	pdib	0
 𨑡	pdib	0
 䫢	pdig	3200
-𫗣	pdig	0
 䖐	pdih	3920
 虒	pdih	49500
 辵	pdii	304000
@@ -69509,7 +66937,6 @@ encoder:
 𧖴	pdml	0
 𧗃	pdml	0
 𨗝	pdml	0
-𪰊	pdmo	0
 𩔾	pdne	0
 𨫻	pdni	0
 𣂝	pdnj	0
@@ -69534,31 +66961,26 @@ encoder:
 斶	pdri	29800
 覛	pdrl	24000
 𧠨	pdrl	0
-𫍥	pdrl	0
 欣	pdro	48300000
 𣂥	pdrp	0
 𡖰	pdrr	0
-𫜀	pdrr	0
 𣃅	pdrs	0
 𤊑	pdru	0
 𢜛	pdrw	0
 𨐍	pdse	0
 𩓣	pdsg	0
 𩖕	pdsg	0
-𫗡	pdsg	0
 䟟	pdsj	3350
 𢒷	pdsj	0
 𩿪	pdsr	0
 𪉄	pdsr	0
 𨫨	pdsu	0
 㿭	pdsx	5740
-𪰅	pdte	0
 丘北	pdtr	267000
 𢨛	pduh	0
 𨕪	pduu	0
 𨖤	pduu	0
 𨗬	pduu	0
-𪢌	pduz	0
 銶	pdvs	143000
 𨱇	pdvs	0
 𣂴	pdwa	0
@@ -69581,7 +67003,6 @@ encoder:
 𠂬	pdyi	0
 𠂰	pdyl	0
 𢁺	pdyl	0
-𪠰	pdyl	0
 劤	pdym	285000
 殷	pdyq	12500000
 𠂘	pdys	0
@@ -69589,7 +67010,6 @@ encoder:
 𢀴	pdyy	0
 𡡓	pdzg	0
 𦅨	pdzg	0
-𪠚	pdzj	0
 𨒠	pdzk	0
 𤓰	pdzs	0
 𨕼	pdzx	0
@@ -69622,13 +67042,10 @@ encoder:
 鏵	peeb	218000
 鐷	peef	40500
 鐼	peel	33800
-𫔿	peel	0
 错落	peev	2890000
 𨧾	peex	0
-𫓾	peey	0
 䥬	pefd	3290
 鑮	pefd	36500
-𫔄	pefd	0
 质朴	pefi	6090000
 钄	pefl	165000
 针刺	pefl	2050000
@@ -69667,7 +67084,6 @@ encoder:
 𨫍	pekw	0
 𨪇	pelb	0
 𨪋	pelb	0
-𫓤	pelc	0
 𨩇	peld	0
 鍈	pelg	66100
 锳	pelg	61200
@@ -69702,7 +67118,6 @@ encoder:
 𨭠	pepd	0
 𨮇	peqi	0
 鏾	peqm	89700
-𫕊	peqm	0
 𨯓	perb	0
 𨫱	perc	0
 错处	peri	279000
@@ -69721,7 +67136,6 @@ encoder:
 错误	pesj	161000000
 错话	pesm	1490000
 质询	pesr	1640000
-𫔏	pesw	0
 质变	pesx	1990000
 錺	pesy	143000
 𨪠	pesy	0
@@ -69740,14 +67154,12 @@ encoder:
 𨪪	pewf	0
 𨯌	pewf	0
 𨯠	pewl	0
-𫓽	pewl	0
 𨮒	pewr	0
 鋍	pewy	41800
 铹	pewy	109000
 错字	pewy	1720000
 鎍	pewz	156000
 错案	pewz	788000
-𫕃	pewz	0
 𨮤	pexj	0
 鈘	pexs	17400
 𨨈	pexs	0
@@ -69800,7 +67212,6 @@ encoder:
 彩带	pfew	823000
 彩票	pffb	45800000
 𨭺	pffb	0
-𫔅	pffl	0
 采样	pffu	4030000
 彩霞	pffx	1820000
 采石	pfga	1180000
@@ -69822,7 +67233,6 @@ encoder:
 𢿥	pfix	0
 𨁢	pfji	0
 𨯻	pfjj	0
-𫔜	pfjj	0
 𨫾	pfjm	0
 鏉	pfjr	2190000
 铺路	pfjr	1830000
@@ -69856,7 +67266,6 @@ encoder:
 𨤚	pflb	0
 𨦉	pfld	0
 鍊	pflk	15000000
-𫔾	pflk	0
 采购	pflr	239000000
 采用	pflv	194000000
 𨤞	pflz	0
@@ -69870,7 +67279,6 @@ encoder:
 采伐	pfnh	811000
 䧽	pfni	3180
 𨯟	pfni	0
-𫕑	pfni	0
 铺位	pfns	1010000
 𨤛	pfoj	0
 錸	pfoo	675000
@@ -69896,7 +67304,6 @@ encoder:
 䥔	pfuf	7100
 铺盖	pful	609000
 錰	pfuo	20600
-𪺠	pfuo	0
 彩卷	pfuy	376000
 采油	pfvk	1630000
 鈢	pfvv	21000
@@ -69929,7 +67336,6 @@ encoder:
 𨨵	pgae	0
 錡	pgaj	1150000
 锜	pgaj	166000
-𫔙	pgan	0
 𨦄	pgax	0
 𨦌	pgay	0
 鍷	pgbb	36600
@@ -69976,7 +67382,6 @@ encoder:
 须留	pgrs	202000
 鈦	pgsa	2400000
 钛	pgsa	9200000
-𫔃	pgse	0
 𨪴	pgsk	0
 𨦄	pgsx	0
 镢头	pgtg	77000
@@ -70005,7 +67410,6 @@ encoder:
 鉽	phbi	51200
 鋞	phbi	70000
 𧸶	phbl	0
-𫓜	phed	0
 钱票	phfb	107000
 铙	phgr	268000
 𥗛	phhg	0
@@ -70024,18 +67428,15 @@ encoder:
 𨫓	phjc	0
 鏂	phjj	3220000
 䥲	phjr	4450
-𫔍	phjw	0
 𨧄	phki	0
 䤷	phkz	4820
 钱财	phld	6620000
 鉔	phli	32200
-𫔪	phli	0
 𨰲	phll	0
 𨧇	phlo	0
 𨰹	phlp	0
 鈛	phma	36200
 銭	phma	4740000
-𫔮	phma	0
 𨦑	phmb	0
 鑑	phml	9120000
 鑬	phml	22800
@@ -70071,7 +67472,6 @@ encoder:
 𨫴	piaz	0
 𨮣	pibi	0
 钻井	pibn	1520000
-𫔕	pibu	0
 釙	pida	47300
 钋	pida	275000
 钻探	pidw	1870000
@@ -70081,7 +67481,6 @@ encoder:
 钻研	piga	9370000
 鐻	pigq	34800
 钀	pigs	514000
-𫔉	piii	0
 鉆	pija	484000
 钻	pija	46000000
 𨭴	pijm	0
@@ -70123,10 +67522,8 @@ encoder:
 𥂲	pixl	0
 鈙	pixs	28800
 𨮏	pixu	0
-𫔈	pixx	0
 𨩘	piya	0
 𨨍	piym	0
-𫔸	piym	0
 𨰳	pizi	0
 𨮦	pizk	0
 鋘	pjag	98900
@@ -70159,7 +67556,6 @@ encoder:
 鋁	pjja	5490000
 铝	pjja	76400000
 𨫵	pjja	0
-𫔝	pjjc	0
 鐰	pjjf	35300
 鋛	pjji	27900
 𨩗	pjjj	0
@@ -70177,7 +67573,6 @@ encoder:
 鉂	pjos	106000
 钟爱	pjpw	4580000
 鏴	pjrj	169000
-𫓎	pjrr	0
 钟头	pjtg	2650000
 钟情	pjuc	7280000
 锅炉	pjuw	11200000
@@ -70196,7 +67591,6 @@ encoder:
 銲	pkae	134000
 𨨊	pkae	0
 鍉	pkai	73300
-𫕀	pkai	0
 锂	pkba	23100000
 𨫉	pkbd	0
 䥵	pkbg	3900
@@ -70239,13 +67633,10 @@ encoder:
 销路	pkjr	2280000
 镋	pkjr	37100
 𨬋	pkjr	0
-𫔎	pkju	0
 销量	pkka	18600000
 鑸	pkkb	830000
-𫔇	pkkb	0
 𨦈	pkkd	0
 鎤	pkkg	35400
-𫔐	pkkg	0
 鑘	pkkk	26000
 番禺	pkkl	6360000
 𨬚	pkkl	0
@@ -70260,13 +67651,11 @@ encoder:
 鏝	pklx	164000
 镘	pklx	139000
 鍝	pklz	1400000
-𫓯	pkma	0
 𨨌	pkmb	0
 鍟	pkmc	1150000
 𨩛	pkmc	0
 𨧛	pkmg	0
 𨩠	pkml	0
-𫕁	pkml	0
 𨨚	pkmu	0
 𨦒	pkmy	0
 销毁	pknb	5620000
@@ -70300,7 +67689,6 @@ encoder:
 锟	pkrr	2820000
 𨦆	pkrr	0
 鍻	pkry	23200
-𫓷	pkry	0
 翻新	pksf	6200000
 𥃅	pksl	0
 𨩄	pksu	0
@@ -70332,9 +67720,7 @@ encoder:
 鏤	pkzm	308000
 𨧉	pkzm	0
 𨯃	pkzm	0
-𫓕	pkzm	0
 䥪	pkzu	4320
-𫔡	pkzu	0
 錌	plae	50400
 鎠	plai	32000
 𨩡	plar	0
@@ -70344,7 +67730,6 @@ encoder:
 鐸	plbu	1310000
 𨭆	plbu	0
 盘亏	plbz	281000
-𫕄	plbz	0
 钢琴	plcc	17200000
 钢珠	plcm	825000
 𨬠	plcm	0
@@ -70358,7 +67743,6 @@ encoder:
 钢板	plfp	10900000
 铜板	plfp	4390000
 鉠	plgd	38900
-𫔫	plgd	0
 盘面	plgj	3380000
 鍴	plgl	80600
 𨬸	plgq	0
@@ -70375,7 +67759,6 @@ encoder:
 镮	pljr	46100
 鎧	plju	3830000
 盘踞	pljx	1220000
-𫓍	plka	0
 鍘	plkd	1950000
 铡	plkd	2730000
 铠甲	plki	2500000
@@ -70388,7 +67771,6 @@ encoder:
 铜山	plll	711000
 鑺	plln	789000
 𨰃	pllz	0
-𫕇	pllz	0
 盘升	plme	1600000
 盘算	plml	1130000
 钢笔	plmm	3940000
@@ -70400,7 +67782,6 @@ encoder:
 铜臭	plng	392000
 鏙	plni	24900
 鑴	plnl	725000
-𫕒	plnl	0
 铜牌	plnn	2400000
 盘货	plnr	49700
 䦆	plnx	26000
@@ -70437,12 +67818,10 @@ encoder:
 𨰟	plru	0
 钢包	plry	227000
 𪆷	plrz	0
-𫝄	plrz	0
 盘旋	plsm	4550000
 䤫	plsx	5120
 锄头	pltg	2080000
 盘问	pltj	1950000
-𫔟	plum	0
 𨯴	plup	0
 𨬫	pluq	0
 钢塑	pluz	454000
@@ -70452,7 +67831,6 @@ encoder:
 钼	plvv	2870000
 岳池	plvy	321000
 钢梁	plvy	415000
-𫓿	plwb	0
 盘子	plya	4730000
 铜陵	plyb	4700000
 岳阳	plyk	7960000
@@ -70468,9 +67846,7 @@ encoder:
 鑼	plzn	1460000
 钢丝	plzz	6970000
 𨨴	plzz	0
-𫓰	pmac	0
 𨮼	pmaj	0
-𫔊	pmaj	0
 𨫝	pman	0
 乒坛	pmbb	503000
 𨬻	pmbd	0
@@ -70488,23 +67864,19 @@ encoder:
 钎	pmea	2660000
 錘	pmeb	1740000
 锤	pmeb	12500000
-𫓋	pmed	0
 𨪻	pmee	0
 𨮱	pmej	0
 䥷	pmek	4150
 𨰉	pmep	0
 铁芯	pmew	627000
 𨪸	pmez	0
-𫓖	pmez	0
 鏼	pmfl	23900
 铁板	pmfp	2170000
 𨥜	pmgd	0
 𨧐	pmgj	0
-𫔯	pmgn	0
 铁矿	pmgt	2720000
 𨰭	pmgz	0
 䤜	pmhd	3760
-𫓅	pmhd	0
 鋨	pmhm	121000
 锇	pmhm	235000
 铁匠	pmhp	2080000
@@ -70512,7 +67884,6 @@ encoder:
 銛	pmia	190000
 铦	pmia	123000
 鈼	pmid	114000
-𫓱	pmil	0
 𨥦	pmim	0
 鋋	pmiy	61600
 𨨶	pmiy	0
@@ -70522,7 +67893,6 @@ encoder:
 鐈	pmjl	24600
 铁路	pmjr	40500000
 𨫙	pmjr	0
-𫔢	pmka	0
 鍾	pmkb	9100000
 锺	pmkb	2710000
 鋓	pmkd	57600
@@ -70583,8 +67953,6 @@ encoder:
 懖	pmwz	378000
 𨧺	pmxb	0
 𨬾	pmxb	0
-𫓟	pmxi	0
-𫔵	pmxi	0
 𨰝	pmxk	0
 𨰓	pmxq	0
 锤子	pmya	1990000
@@ -70649,7 +68017,6 @@ encoder:
 𨯰	pnoy	0
 𨭾	pnqk	0
 𨥐	pnqy	0
-𫓨	pnrd	0
 铧	pnre	522000
 𨫖	pnro	0
 鎀	pnrp	49800
@@ -70657,10 +68024,7 @@ encoder:
 鈋	pnrr	33800
 鎞	pnrr	45000
 𨱂	pnrr	0
-𫓪	pnrr	0
-𫕅	pnrr	0
 𨦱	pnrs	0
-𫓩	pnrs	0
 鏓	pnrw	26400
 𨦪	pnry	0
 䥞	pnsm	3590
@@ -70672,7 +68036,6 @@ encoder:
 𨱓	pnuo	0
 锦江	pnvb	4320000
 锦州	pnvn	7150000
-𪹿	pnvu	0
 锻造	pnwm	3660000
 鎴	pnwz	3310000
 𨫡	pnxb	0
@@ -70691,11 +68054,9 @@ encoder:
 铪	poaj	329000
 錀	poal	69700
 𨥟	poaz	0
-𫔩	poaz	0
 兵士	poba	3460000
 𨦓	pobs	0
 铃声	pobx	107000000
-𫓏	pobz	0
 銓	poca	2080000
 铨	poca	967000
 釞	poda	36100
@@ -70709,24 +68070,19 @@ encoder:
 兵器	pojj	19200000
 鑰	pojl	1840000
 𨫸	pojl	0
-𫔀	pojl	0
 鎿	pojm	198000
 镎	pojm	41700
 銳	pojr	3010000
 鑯	poka	41100
 鉩	poko	48900
-𫔋	pokr	0
 𨮋	pokw	0
 𨭗	polk	0
-𫓝	pomf	0
 𨨝	pomi	0
 兵种	pomj	2050000
-𫓊	pond	0
 舱位	pons	638000
 銼	poob	170000
 锉	poob	908000
 𨥎	pood	0
-𫔧	pood	0
 鏦	pooi	73600
 鋊	pooj	72000
 䥘	pook	4290
@@ -70755,13 +68111,11 @@ encoder:
 𨪯	pouw	0
 兵法	povb	7200000
 釟	povv	51800
-𫔣	povv	0
 鈴	powa	27600000
 兵马	poxa	1900000
 鋡	poxj	42500
 鎗	poxj	1290000
 錜	poxw	29400
-𫔹	poxw	0
 𨯣	poyb	0
 鈖	poyd	89000
 锉刀	poyd	394000
@@ -70772,7 +68126,6 @@ encoder:
 𨥍	pozi	0
 𨦣	pozr	0
 鈆	pozs	50200
-𫔨	pozs	0
 𨨟	pozw	0
 銗	ppaj	111000
 𨧌	ppax	0
@@ -70780,7 +68133,6 @@ encoder:
 𨦜	ppaz	0
 𨧑	ppbi	0
 𨰪	ppbu	0
-𫓐	ppda	0
 鋝	ppds	62200
 锊	ppds	101000
 鍎	ppel	2370000
@@ -70792,7 +68144,6 @@ encoder:
 𨪉	ppih	0
 𨪾	ppio	0
 鐇	ppki	48000
-𫕋	ppki	0
 䤾	ppnb	4200
 𨧌	ppow	0
 𨐃	pppf	0
@@ -70866,7 +68217,6 @@ encoder:
 𧳐	pqgl	0
 𧳑	pqgm	0
 䫉	pqgo	3750
-𫏆	pqgq	0
 𧲶	pqgs	0
 𧳂	pqgs	0
 𢤧	pqgw	0
@@ -70874,7 +68224,6 @@ encoder:
 𧳗	pqgy	0
 𧳲	pqhg	0
 䝙	pqho	3650
-𫏅	pqhs	0
 𧲽	pqhx	0
 𧴘	pqig	0
 䝞	pqih	3450
@@ -70991,7 +68340,6 @@ encoder:
 㦝	pqrw	3940
 邈	pqrw	4370000
 𧲼	pqry	0
-𫏈	pqry	0
 𧳹	pqrz	0
 𨭷	pqrz	0
 𪁰	pqrz	0
@@ -71010,7 +68358,6 @@ encoder:
 𧳋	pquy	0
 𧳼	pquy	0
 𧴉	pquy	0
-𫏇	pquz	0
 䝥	pqve	3890
 铅油	pqvk	36300
 鈅	pqvv	985000
@@ -71071,7 +68418,6 @@ encoder:
 𨩀	prgm	0
 𨫫	prgo	0
 䤥	prgy	5410
-𫓑	prid	0
 𦘉	prjc	0
 鐌	prjg	82500
 𨅠	prji	0
@@ -71108,7 +68454,6 @@ encoder:
 钓鱼	prra	16500000
 𨪭	prrc	0
 欣然	prrg	6280000
-𪿆	prrl	0
 鍇	prrn	98800
 锴	prrn	994000
 鈚	prrr	52200
@@ -71132,7 +68477,6 @@ encoder:
 欣慰	prxb	9590000
 錚	prxb	951000
 铮	prxb	3210000
-𫔬	prxb	0
 𨨽	prxm	0
 豹子	prya	3290000
 钩子	prya	1840000
@@ -71159,7 +68503,6 @@ encoder:
 𨪆	psaj	0
 𤫸	psbz	0
 𤬅	psch	0
-𪽡	psch	0
 𤫬	psci	0
 斥责	pscl	896000
 航班	pscu	20400000
@@ -71178,7 +68521,6 @@ encoder:
 航校	psfs	204000
 舷梯	psfu	260000
 航权	psfx	411000
-𪽠	psgd	0
 瓥	psgi	477000
 𥂻	psgl	0
 𨭢	psgs	0
@@ -71206,7 +68548,6 @@ encoder:
 𨧤	psjy	0
 𨭖	pska	0
 𨰸	pska	0
-𫕏	pska	0
 鐘	pskb	45000000
 𠛒	pskd	0
 鏱	pske	12200
@@ -71216,7 +68557,6 @@ encoder:
 鏡	pskr	34200000
 镜	pskr	122000000
 𨮈	pskr	0
-𫔚	psku	0
 鐿	pskw	102000
 镱	pskw	410000
 𨬧	psla	0
@@ -71225,7 +68565,6 @@ encoder:
 铈	psli	444000
 𤬋	pslj	0
 𨬙	pslj	0
-𫔓	pslk	0
 𤫽	pslr	0
 铲	psma	7200000
 𤫵	psmi	0
@@ -71239,7 +68578,6 @@ encoder:
 鍦	psmy	1390000
 𤫺	psmz	0
 航向	psnj	1230000
-𫓘	psno	0
 䤳	psnr	4490
 镜像	psnr	65100000
 镜片	psnx	3400000
@@ -71292,13 +68630,11 @@ encoder:
 𤬊	pswl	0
 𤬎	pswl	0
 鏲	pswm	35200
-𫓹	pswm	0
 㼉	pswr	4450
 𨩎	pswr	0
 鎊	psws	439000
 镑	psws	2040000
 航道	pswu	7430000
-𫓣	pswz	0
 鏇	psxi	1820000
 镟	psxi	251000
 鋃	psxo	97500
@@ -71309,14 +68645,12 @@ encoder:
 瓜子	psya	4810000
 铲子	psya	616000
 镜子	psya	15000000
-𫓢	psya	0
 鐓	psym	2040000
 镦	psym	600000
 𤫰	psyn	0
 铲除	psyo	5300000
 䥋	psyu	4150
 𨬤	psyu	0
-𫓚	pszb	0
 𨫏	psze	0
 𨧲	pszf	0
 航线	pszh	7660000
@@ -71330,7 +68664,6 @@ encoder:
 䤤	pszo	9520
 錥	pszq	41400
 𨯤	pszq	0
-𫔼	pszq	0
 銃	pszr	7330000
 铳	pszr	454000
 鉉	pszz	1750000
@@ -71349,7 +68682,6 @@ encoder:
 𨫆	ptmb	0
 𨫈	ptob	0
 𨮻	ptob	0
-𫔖	ptoo	0
 𨮛	ptop	0
 镀金	ptpa	3190000
 𨪙	ptpd	0
@@ -71402,7 +68734,6 @@ encoder:
 鐠	pukk	1090000
 镨	pukk	436000
 鏳	pulk	20700
-𫔒	pumh	0
 锐利	pumk	5140000
 锐气	pumy	1490000
 锐敏	pumz	127000
@@ -71417,11 +68748,8 @@ encoder:
 锐角	purl	366000
 鏻	purm	55100
 𨨢	puro	0
-𫔽	puro	0
 𨪢	purz	0
-𫓳	purz	0
 𨰥	pusg	0
-𫕓	pusg	0
 锐意	pusk	2940000
 锐减	puth	2100000
 𨬢	putr	0
@@ -71430,7 +68758,6 @@ encoder:
 	puuj	0
 錟	puuo	81500
 锬	puuo	167000
-𫓻	puuo	0
 镂空	puwb	3920000
 𨯗	puwc	0
 鑅	puwf	42400
@@ -71445,7 +68772,6 @@ encoder:
 𨩍	puzm	0
 𨩐	puzm	0
 鎙	puzq	127000
-𫕆	puzq	0
 𨭨	puzw	0
 鎡	puzz	76700
 镃	puzz	49300
@@ -71464,14 +68790,11 @@ encoder:
 𤔘	pvbb	0
 𩔋	pvbg	0
 𨮟	pvbo	0
-𪺿	pvbr	0
 𤔌	pvbx	0
 𨩾	pvby	0
 鍅	pvbz	102000
 𤔧	pvbz	0
 所长	pvch	12000000
-𪺹	pvch	0
-𪺸	pvcx	0
 頱	pvdg	22600
 𩕖	pvdg	0
 虢	pvdi	1350000
@@ -71497,11 +68820,9 @@ encoder:
 𡗮	pvgd	0
 䫣	pvgg	3360
 𥂼	pvgl	0
-𪜜	pvgl	0
 𥡙	pvgm	0
 雞	pvgn	20700000
 所有	pvgq	2270000000
-𪺷	pvgq	0
 㰿	pvgr	5360
 鷄	pvgr	617000
 𪅊	pvgr	0
@@ -71537,7 +68858,6 @@ encoder:
 𤕈	pvjn	0
 𩀓	pvjn	0
 𤔓	pvjr	0
-𪺶	pvjr	0
 𠭖	pvjx	0
 𤕆	pvjy	0
 𠃭	pvjz	0
@@ -71545,14 +68865,11 @@ encoder:
 𠄉	pvkb	0
 𡦢	pvkb	0
 𤔉	pvki	0
-𪽸	pvki	0
 𤔱	pvkk	0
 𤕌	pvkk	0
 𤴋	pvkk	0
 𤴎	pvkk	0
 䤬	pvkm	8640
-𪻁	pvks	0
-𪺾	pvla	0
 爯	pvlb	48500
 𤔈	pvlc	0
 𡬳	pvld	0
@@ -71563,7 +68880,6 @@ encoder:
 覓	pvlr	2460000
 觅	pvlr	5470000
 𧠙	pvlr	0
-𪺺	pvlr	0
 辭	pvls	5620000
 𨐲	pvls	0
 𤕉	pvlu	0
@@ -71585,7 +68901,6 @@ encoder:
 繇	pvmz	751000
 𤔞	pvmz	0
 𨪍	pvmz	0
-𪺻	pvna	0
 舀	pvnb	2200000
 𤔘	pvnb	0
 𦥝	pvnb	0
@@ -71613,7 +68928,6 @@ encoder:
 𠙙	pvoq	0
 鶏	pvor	9630000
 𤓼	pvoy	0
-𫒰	pvoy	0
 𤨽	pvpc	0
 𤕁	pvpi	0
 𡚘	pvpk	0
@@ -71633,13 +68947,11 @@ encoder:
 所处	pvri	12600000
 嗠	pvrj	38100
 𠄇	pvrj	0
-𪺼	pvrl	0
 舜	pvrm	8500000
 鐋	pvro	21700
 𤔰	pvro	0
 𣩖	pvrr	0
 𪇈	pvrr	0
-𪻂	pvrr	0
 𤓵	pvrs	0
 𤓶	pvrx	0
 𩰣	pvrx	0
@@ -71652,13 +68964,11 @@ encoder:
 𦨁	pvsc	0
 𤔢	pvsi	0
 所谓	pvsk	78200000
-𪥬	pvsn	0
 𣁝	pvsp	0
 所说	pvsv	33000000
 𦫑	pvsx	0
 𧧞	pvsx	0
 𨩾	pvsy	0
-𫒜	pvsy	0
 𣁷	pvte	0
 𤓺	pvte	0
 𡐼	pvub	0
@@ -71666,7 +68976,6 @@ encoder:
 𤳿	pvuk	0
 𢅌	pvul	0
 𢮣	pvum	0
-𫜚	pvur	0
 𤏜	pvuu	0
 𤑀	pvuu	0
 𤔵	pvuu	0
@@ -71690,7 +68999,6 @@ encoder:
 𤕀	pvwz	0
 爭	pvxb	17000000
 𤔯	pvxb	0
-𪺵	pvxb	0
 爵	pvxd	9520000
 𤔸	pvxd	0
 𤓽	pvxf	0
@@ -71723,7 +69031,6 @@ encoder:
 𨦥	pvyi	0
 𠹾	pvyj	0
 𦦌	pvyj	0
-𪨎	pvyk	0
 𧠾	pvyl	0
 㲗	pvym	3570
 𢾢	pvym	0
@@ -71781,20 +69088,15 @@ encoder:
 𤔞	pvzz	0
 𦃟	pvzz	0
 𦆩	pvzz	0
-𪺽	pvzz	0
 𨦦	pwad	0
-𫓠	pwae	0
 䥂	pwag	5370
 𨯯	pwal	0
 鏥	pwan	28100
-𫕈	pwan	0
-𫔁	pwao	0
 鑓	pway	177000
 铵盐	pwbi	316000
 𨨀	pwbi	0
 錝	pwbk	90800
 鍹	pwbk	36300
-𫔻	pwbk	0
 䥦	pwbq	6160
 鋎	pwbr	36100
 鐽	pwbu	45900
@@ -71803,7 +69105,6 @@ encoder:
 鎋	pwcj	33900
 受理	pwck	28100000
 受聘	pwck	1830000
-𫓫	pwcs	0
 爱抚	pwda	3320000
 锭	pwda	3870000
 受损	pwdj	9080000
@@ -71811,7 +69112,6 @@ encoder:
 受挫	pwdo	3680000
 受热	pwdq	1570000
 链接	pwds	627000000
-𫓗	pwds	0
 爱护	pwdw	19800000
 受苦	pwee	4280000
 爱慕	pwek	6360000
@@ -71887,7 +69187,6 @@ encoder:
 𨩶	pwrd	0
 链条	pwrf	5780000
 𨨥	pwrf	0
-𫓲	pwrj	0
 𨫕	pwrm	0
 鉈	pwrr	672000
 铊	pwrr	662000
@@ -71914,7 +69213,6 @@ encoder:
 𨬄	pwuu	0
 䤹	pwux	6060
 𨮄	pwux	0
-𫓺	pwuz	0
 受害	pwwc	17100000
 受灾	pwwu	3390000
 悉心	pwwz	3230000
@@ -71925,14 +69223,12 @@ encoder:
 受骗	pwxw	9640000
 链子	pwya	2690000
 锭子	pwya	299000
-𫓙	pwya	0
 爱民	pwyh	2640000
 受阻	pwyl	5940000
 䥇	pwyy	20200
 䦂	pwyy	15600
 	pwyy	0
 	pwyy	0
-𫓬	pwyz	0
 䥾	pwza	3440
 𨰰	pwzl	0
 銨	pwzm	691000
@@ -71974,7 +69270,6 @@ encoder:
 反而	pxgl	61100000
 银灰	pxgu	1610000
 反感	pxha	10700000
-𫓵	pxhb	0
 殷切	pxhy	2060000
 鈹	pxia	1150000
 铍	pxia	585000
@@ -72008,12 +69303,10 @@ encoder:
 𨧵	pxmb	0
 反手	pxmd	3010000
 鍒	pxmf	3150000
-𫕂	pxmf	0
 𨪅	pxmh	0
 𨥨	pxmi	0
 反复	pxmk	34800000
 鐍	pxml	46100
-𫕌	pxml	0
 𨩺	pxmm	0
 银税	pxmu	35800
 反射	pxnd	32300000
@@ -72074,7 +69367,6 @@ encoder:
 反弹	pxyu	21500000
 𨬖	pxyy	0
 𨰏	pxyy	0
-𫕍	pxyy	0
 𨰎	pxzo	0
 银婚	pxzr	206000
 𨧱	pxzz	0
@@ -72138,14 +69430,12 @@ encoder:
 䒈	pyel	5100
 舼	pyeo	27400
 鐉	pyeo	27000
-𫔠	pyeo	0
 艔	pyex	19700
 𦨟	pyex	0
 𦩾	pyez	0
 𦪚	pyfd	0
 键槽	pyfe	155000
 舾	pyfj	267000
-𫈖	pyfl	0
 𦩚	pyfm	0
 艝	pyfx	77500
 乳酸	pyfz	5270000
@@ -72155,7 +69445,6 @@ encoder:
 𦩎	pyge	0
 𦪶	pygi	0
 𨇐	pygj	0
-𫈑	pygj	0
 𥂏	pygl	0
 𦨩	pygm	0
 䑢	pygr	4190
@@ -72180,8 +69469,6 @@ encoder:
 爬上	pyiv	7530000
 舻	pyix	360000
 𦨗	pyix	0
-𫈐	pyiy	0
-𫈕	pyjd	0
 𦩪	pyjf	0
 𩕎	pyjg	0
 舯	pyji	135000
@@ -72231,7 +69518,6 @@ encoder:
 𦩥	pykr	0
 乳业	pyku	2590000
 𦩭	pykw	0
-𫈔	pykw	0
 𦩇	pykx	0
 艣	pyky	29900
 艛	pykz	25600
@@ -72248,19 +69534,16 @@ encoder:
 䚀	pylr	4910
 舰	pylr	5140000
 𦪻	pyls	0
-𫈓	pylx	0
 𥎻	pyma	0
 艇	pymb	7930000
 鋌	pymb	125000
 铤	pymb	239000
 𦪅	pymb	0
 𦪵	pyme	0
-𫈏	pyme	0
 𨦃	pymf	0
 艤	pymh	82100
 𦨎	pymh	0
 𦩆	pymh	0
-𫈘	pymh	0
 舴	pymi	270000
 鋋	pymi	61600
 𦨯	pymi	0
@@ -72302,12 +69585,10 @@ encoder:
 艧	pynx	30700
 艭	pynx	28800
 𦫇	pynx	0
-𫔌	pyny	0
 𦪂	pyob	0
 钖	pyod	169000
 键入	pyod	1980000
 𦨈	pyod	0
-𫔘	pyoe	0
 𦩺	pyof	0
 爬行	pyoi	12900000
 𦨵	pyoi	0
@@ -72327,7 +69608,6 @@ encoder:
 𥃑	pyor	0
 𦪁	pyor	0
 𨫭	pyor	0
-𪿋	pyor	0
 𧭔	pyos	0
 𦪜	pyou	0
 舲	pyow	91600
@@ -72342,7 +69622,6 @@ encoder:
 𦩹	pypn	0
 舨	pypx	141000
 艀	pypy	66700
-𪤎	pyqb	0
 舤	pyqd	61300
 鞶	pyqe	43100
 䑮	pyqf	3790
@@ -72457,7 +69736,6 @@ encoder:
 釕	pyvv	202000
 鈻	pyvv	463000
 钌	pyvv	520000
-𫓇	pyvv	0
 𦨲	pyvy	0
 䑸	pywb	4150
 𦩘	pywd	0
@@ -72489,8 +69767,6 @@ encoder:
 䑡	pyxs	5030
 𦪫	pyxu	0
 艌	pyxw	47800
-𫈒	pyxx	0
-𫓴	pyxz	0
 釲	pyyb	20300
 舠	pyyd	62400
 𦨇	pyyd	0
@@ -72519,7 +69795,6 @@ encoder:
 𦩄	pyzb	0
 艓	pyzf	24900
 𦩶	pyzg	0
-𫈗	pyzh	0
 𦩈	pyzm	0
 艈	pyzn	19300
 𦪘	pyzr	0
@@ -72538,8 +69813,6 @@ encoder:
 𨨕	pzgp	0
 䤸	pzgq	4640
 鐖	pzho	1150000
-𫓭	pzjr	0
-𫓴	pzjx	0
 鏁	pzkf	3470000
 錙	pzki	77700
 锱	pzki	136000
@@ -72550,15 +69823,12 @@ encoder:
 鏆	pzlo	851000
 𨦖	pzlo	0
 𨱌	pzlo	0
-𫓼	pzlo	0
 𨨴	pzlz	0
 釹	pzma	988000
 钕	pzma	714000
 𨧚	pzma	0
 鉾	pzmb	550000
-𫔲	pzmb	0
 𨰺	pzmo	0
-𫔗	pzni	0
 𨮨	pznl	0
 鉯	pzod	50800
 鏒	pzop	49200
@@ -72569,7 +69839,6 @@ encoder:
 鈗	pzrd	44100
 鏘	pzrd	856000
 𨮳	pzru	0
-𫕐	pzru	0
 𨰽	pzrz	0
 妥善	pzuu	26700000
 釓	pzvv	67400
@@ -72585,7 +69854,6 @@ encoder:
 肝	qaed	46300000
 𦣘	qaer	0
 夙愿	qagn	973000
-𫇍	qaid	0
 𦙫	qaii	0
 肺虚	qaik	210000
 腷	qajk	55500
@@ -72600,13 +69868,11 @@ encoder:
 𦛍	qalb	0
 肺	qali	25000000
 𣍪	qalo	0
-𫇸	qalt	0
 𣍠	qand	0
 脜	qanl	268000
 脼	qaoo	101000
 𦢈	qaoo	0
 𦜒	qaor	0
-𫇤	qaor	0
 肝胆	qaqk	3400000
 肝脏	qaqt	5030000
 𦘵	qaqy	0
@@ -72622,7 +69888,6 @@ encoder:
 𦙻	qauo	0
 肝炎	qauu	14800000
 𦞃	qauu	0
-𪱽	qaux	0
 肺泡	qavr	449000
 𦠖	qawr	0
 脻	qaxi	98000
@@ -72716,7 +69981,6 @@ encoder:
 脹	qcha	2400000
 狂躁	qcjj	1420000
 狂暴	qcke	2960000
-𪲅	qckv	0
 𦟜	qclo	0
 𣎔	qclr	0
 狂笑	qcmm	2310000
@@ -72741,7 +70005,6 @@ encoder:
 狂怒	qczx	1320000
 𠘧	qdaa	0
 𠘨	qdaa	0
-𫗿	qdaf	0
 几天	qdag	72700000
 凬	qdak	52900
 𠙒	qdal	0
@@ -72759,7 +70022,6 @@ encoder:
 凨	qdbz	139000
 𠘾	qdbz	0
 𠙣	qdbz	0
-𫘌	qdcb	0
 𩙧	qdcd	0
 𠱰	qdcj	0
 𠙲	qdck	0
@@ -72769,7 +70031,6 @@ encoder:
 𠙈	qdez	0
 剁	qdfk	6010000
 几枚	qdfm	613000
-𪞷	qdfx	0
 𠙗	qdgh	0
 𩑏	qdgo	0
 𢒝	qdhp	0
@@ -72777,7 +70038,6 @@ encoder:
 凪	qdii	2000000
 几点	qdij	24800000
 飐	qdij	67000
-𪞴	qdij	0
 𩙰	qdjf	0
 𩙮	qdjl	0
 𠙂	qdjo	0
@@ -72788,7 +70048,6 @@ encoder:
 𦢟	qdku	0
 凡是	qdkv	21700000
 飔	qdkw	93400
-𫘇	qdkw	0
 𠙘	qdlb	0
 凧	qdli	1440000
 𠘳	qdll	0
@@ -72802,7 +70061,6 @@ encoder:
 几笔	qdmm	899000
 几乎	qdmu	202000000
 𠙄	qdmz	0
-𫘃	qdmz	0
 几何	qdna	22400000
 几例	qdna	543000
 𠙔	qdnb	0
@@ -72812,13 +70070,11 @@ encoder:
 几位	qdns	16800000
 几倍	qdns	3040000
 飕	qdnx	785000
-𫘊	qdok	0
 𩙦	qdon	0
 飑	qdor	462000
 风	qdos	312000000
 𠘰	qdos	0
 几个	qdov	170000000
-𫘀	qdox	0
 几分	qdoy	26900000
 䏳	qdpd	3700
 𠘱	qdpd	0
@@ -72828,28 +70084,20 @@ encoder:
 𠘪	qdqy	0
 㓘	qdrc	3770
 𤥔	qdrc	0
-𪵮	qdrr	0
 𡖆	qdrs	0
 鳯	qdrz	287000
 𧦔	qdse	0
-𪞶	qdse	0
 𩙫	qdsi	0
-𫘍	qdsk	0
 𠙅	qdsu	0
 𠙤	qdsz	0
 几次	qdtr	40000000
 𠙌	qduc	0
-𫘂	qdug	0
 㶡	qduo	4090
 飚	qduu	9450000
 𩙪	qduu	0
 凲	qdux	27100
 𠘵	qduz	0
 脙	qdvs	437000
-𫘎	qdwm	0
-𫘄	qdwx	0
-𫘅	qdwx	0
-𫘋	qdwy	0
 𩙭	qdwz	0
 凤	qdxs	41700000
 𠘫	qdxs	0
@@ -72873,7 +70121,6 @@ encoder:
 猎取	qecx	1030000
 𦠜	qeeb	0
 膹	qeel	34800
-𪲂	qeel	0
 猎获	qeeq	326000
 𣎢	qeeq	0
 𦢲	qeeu	0
@@ -72906,10 +70153,8 @@ encoder:
 猫鼠	qenz	524000
 猎人	qeod	21000000
 膵	qeoe	531000
-𫇮	qeok	0
 𦣎	qeon	0
 䐽	qeoo	4200
-𫇳	qeos	0
 𦠭	qepd	0
 𦟵	qepy	0
 朦胧	qeqg	2000000
@@ -72931,11 +70176,9 @@ encoder:
 𦢧	qewl	0
 䑅	qewr	7830
 𣎙	qews	0
-𫇱	qews	0
 𦢬	qeww	0
 脖	qewy	3460000
 𦛨	qewy	0
-𫇧	qewy	0
 𦡐	qexb	0
 𦢁	qexj	0
 𦢩	qexn	0
@@ -72945,7 +70188,6 @@ encoder:
 䐑	qezf	4850
 臟	qezh	1390000
 𦟍	qezo	0
-𫇦	qfay	0
 膘	qfbk	2280000
 𦣕	qfbq	0
 杂志	qfbw	148000000
@@ -72985,7 +70227,6 @@ encoder:
 膝盖	qful	5280000
 杂粮	qfus	1770000
 𦙣	qfvv	0
-𫇪	qfwz	0
 膤	qfxb	79600
 杂费	qfyn	3110000
 𦟊	qfyy	0
@@ -73018,7 +70259,6 @@ encoder:
 𦞴	qgkz	0
 𧱔	qgli	0
 𦞑	qglk	0
-𫇵	qgmi	0
 𦝐	qgmy	0
 𦟩	qgnz	0
 𦡀	qgok	0
@@ -73321,7 +70561,6 @@ encoder:
 𩙚	qixn	0
 𩖹	qixr	0
 颰	qixs	23300
-𫘉	qixw	0
 䫸	qiyd	3580
 𦘸	qiyd	0
 𩖜	qiye	0
@@ -73352,7 +70591,6 @@ encoder:
 䐕	qjce	4190
 𦠾	qjch	0
 腘	qjcs	118000
-𫇘	qjej	0
 𣎫	qjfd	0
 肿大	qjgd	1620000
 𦞢	qjgq	0
@@ -73399,7 +70637,6 @@ encoder:
 𦝈	qkgo	0
 胱	qkgr	1610000
 𦣃	qkgu	0
-𫇏	qkia	0
 胛	qkib	433000
 胂	qkic	1310000
 𦜉	qkie	0
@@ -73416,12 +70653,10 @@ encoder:
 𦛭	qkli	0
 腽	qklk	77700
 䐝	qklo	3940
-𫇨	qklx	0
 腢	qklz	65100
 腥	qkmc	9570000
 𣍺	qkmc	0
 𦜉	qkme	0
-𫇛	qkml	0
 胆管	qkmw	779000
 𦚤	qkod	0
 𦢊	qkok	0
@@ -73433,7 +70668,6 @@ encoder:
 腸	qkro	9000000
 䐊	qkrr	4900
 𦚢	qkrr	0
-𫇟	qkrr	0
 𦜄	qkrs	0
 𣎅	qkry	0
 𦝲	qkry	0
@@ -73444,7 +70678,6 @@ encoder:
 𦢂	qkug	0
 胆汁	qkve	1580000
 胆寒	qkwe	1170000
-𫇔	qkwy	0
 腮	qkwz	5790000
 胆敢	qkxc	3110000
 狮子	qkya	14100000
@@ -73515,7 +70748,6 @@ encoder:
 𤠄	qmaj	0
 𤠙	qmaj	0
 𤠟	qmaj	0
-𪻱	qmaj	0
 獩	qmak	474000
 𤠽	qmak	0
 犻	qmal	1470000
@@ -73531,7 +70763,6 @@ encoder:
 𤡌	qmay	0
 𤝐	qmaz	0
 𤞇	qmbb	0
-𪻨	qmbb	0
 橥	qmbf	275000
 獟	qmbg	124000
 狤	qmbj	142000
@@ -73561,7 +70792,6 @@ encoder:
 腹地	qmbv	5620000
 𢟆	qmbw	0
 𦜙	qmbw	0
-𪻴	qmbx	0
 㹲	qmby	6840
 脡	qmby	237000
 𤠃	qmby	0
@@ -73588,7 +70818,6 @@ encoder:
 猜	qmcq	47100000
 鵟	qmcr	91700
 𩷬	qmcr	0
-𫜳	qmcr	0
 獁	qmcu	41200
 㤮	qmcw	5750
 逛	qmcw	99600000
@@ -73601,7 +70830,6 @@ encoder:
 𤜮	qmds	0
 腄	qmeb	87500
 𤠺	qmeb	0
-𪣰	qmeb	0
 猉	qmec	21800
 㬳	qmed	7930
 𤠇	qmee	0
@@ -73613,7 +70841,6 @@ encoder:
 峱	qmel	58500
 獖	qmel	24400
 𤣡	qmel	0
-𪻬	qmel	0
 猠	qmeo	83800
 𤞒	qmeo	0
 玂	qmep	207000
@@ -73648,7 +70875,6 @@ encoder:
 𤟦	qmgg	0
 𤡤	qmgg	0
 𤢿	qmgg	0
-𪻦	qmgh	0
 腹面	qmgj	449000
 𤞜	qmgj	0
 㺆	qmgl	4190
@@ -73686,7 +70912,6 @@ encoder:
 㹽	qmhh	4960
 犽	qmhi	620000
 𢦖	qmhm	0
-𪻪	qmho	0
 𤞄	qmhr	0
 𤡚	qmhr	0
 𤞉	qmhs	0
@@ -73702,7 +70927,6 @@ encoder:
 𤠧	qmik	0
 𤡣	qmik	0
 𤡼	qmik	0
-𪱿	qmik	0
 𤟝	qmil	0
 𦞇	qmil	0
 胏	qmim	36300
@@ -73718,7 +70942,6 @@ encoder:
 𤞐	qmiy	0
 𤡓	qmja	0
 𤝱	qmjd	0
-𪻤	qmjd	0
 𤞥	qmjf	0
 𤞧	qmjf	0
 𤢖	qmjf	0
@@ -73918,7 +71141,6 @@ encoder:
 㹯	qmnf	4100
 𦠱	qmnh	0
 猚	qmni	25300
-𪻰	qmnj	0
 狛	qmnk	282000
 獂	qmnk	62500
 𤝼	qmnl	0
@@ -73948,14 +71170,12 @@ encoder:
 猝	qmoe	1230000
 𤡶	qmoe	0
 𤣜	qmog	0
-𪻪	qmoh	0
 𤡆	qmoi	0
 𤣝	qmoi	0
 𤞞	qmoj	0
 𤝝	qmok	0
 𤡅	qmok	0
 𤢾	qmok	0
-𪻶	qmok	0
 獈	qmol	27200
 狳	qmom	123000
 猞	qmom	260000
@@ -73976,14 +71196,12 @@ encoder:
 猣	qmor	11400
 獿	qmor	28900
 𤠎	qmor	0
-𫇶	qmor	0
 𤝜	qmos	0
 㺀	qmow	5500
 狑	qmow	30100
 𤟋	qmoy	0
 𤟳	qmoy	0
 𤣌	qmoy	0
-𪻠	qmoy	0
 獵	qmoz	4700000
 𤝅	qmoz	0
 㹞	qmpd	4160
@@ -74064,7 +71282,6 @@ encoder:
 𤠞	qmrr	0
 𤢔	qmrr	0
 𦙋	qmrr	0
-𫜜	qmrr	0
 㺥	qmrs	4090
 犳	qmrs	1650000
 𤝇	qmrs	0
@@ -74076,7 +71293,6 @@ encoder:
 𤜼	qmrt	0
 㹼	qmru	4880
 狰	qmrx	6740000
-𪻡	qmrx	0
 狍	qmry	244000
 𤟊	qmry	0
 𤣚	qmry	0
@@ -74099,7 +71315,6 @@ encoder:
 獥	qmsm	497000
 𤠤	qmsn	0
 𩁓	qmsn	0
-𪻳	qmsn	0
 猽	qmso	42200
 𤜥	qmso	0
 𤝋	qmso	0
@@ -74121,15 +71336,12 @@ encoder:
 𤝪	qmub	0
 𤠝	qmub	0
 𦍕	qmuc	0
-𪻵	qmud	0
 𤝴	qmue	0
 猶	qmuf	4360000
 𤝸	qmuf	0
-𪻮	qmug	0
 㺣	qmuh	4840
 𤢀	qmuj	0
 𤣋	qmuk	0
-𪻫	qmuk	0
 𤠻	qmul	0
 𤢼	qmul	0
 𤠁	qmun	0
@@ -74174,7 +71386,6 @@ encoder:
 獶	qmwr	133000
 𤜴	qmwr	0
 𤝛	qmwr	0
-𪻥	qmwr	0
 𤡖	qmws	0
 𤡧	qmww	0
 𤟗	qmwx	0
@@ -74186,8 +71397,6 @@ encoder:
 𤝽	qmxb	0
 𤠿	qmxb	0
 𤢇	qmxb	0
-𪻭	qmxb	0
-𪻩	qmxd	0
 狃	qmxe	158000
 𤞎	qmxf	0
 𤡦	qmxf	0
@@ -74210,7 +71419,6 @@ encoder:
 𤟣	qmxl	0
 猴	qmxm	38100000
 𤠣	qmxm	0
-𪻳	qmxn	0
 㹹	qmxo	5810
 狠	qmxo	68100000
 𤡥	qmxq	0
@@ -74260,13 +71468,11 @@ encoder:
 𤝲	qmzg	0
 𤠓	qmzg	0
 𤜟	qmzi	0
-𪻲	qmzi	0
 𤠂	qmzj	0
 𤠕	qmzk	0
 㺙	qmzl	4800
 𤝾	qmzl	0
 𤠡	qmzl	0
-𪻯	qmzl	0
 㹭	qmzm	5200
 腇	qmzm	40600
 𤠱	qmzm	0
@@ -74283,7 +71489,6 @@ encoder:
 𤢒	qmzu	0
 𤢧	qmzu	0
 𤣆	qmzu	0
-𪻢	qmzx	0
 狕	qmzy	18800
 脢	qmzy	374000
 𤝕	qmzy	0
@@ -74304,7 +71509,6 @@ encoder:
 脾	qned	6950000
 𦞠	qned	0
 𦞵	qnge	0
-𫇐	qnhs	0
 脾虚	qnik	472000
 䑂	qnio	4960
 臇	qniy	35900
@@ -74344,7 +71548,6 @@ encoder:
 风趣	qobc	8150000
 𦞒	qobd	0
 𦣗	qobg	0
-𪱾	qobk	0
 脸颊	qobu	7120000
 脸	qobv	233000000
 风声	qobx	6320000
@@ -74381,7 +71584,6 @@ encoder:
 𪏍	qoko	0
 风景	qoks	138000000
 风水	qokv	16600000
-𫘆	qokw	0
 膾	qolk	132000
 𦡬	qolz	0
 风箱	qomf	397000
@@ -74408,7 +71610,6 @@ encoder:
 𦙐	qorr	0
 脸色	qory	21000000
 风衣	qosr	3480000
-𫍉	qosr	0
 肣	qosx	71900
 风靡	qotf	7530000
 脸庞	qotg	1990000
@@ -74427,7 +71628,6 @@ encoder:
 风速	qowf	3490000
 风灾	qowu	318000
 风扇	qowy	11200000
-𫇜	qoxb	0
 脸皮	qoxi	5270000
 𦛜	qoxj	0
 𦞛	qoxj	0
@@ -74457,7 +71657,6 @@ encoder:
 狐疑	qprm	709000
 𦜓	qpro	0
 𪃻	qprr	0
-𫇙	qpvv	0
 𦣅	qpxd	0
 𦞿	qpxm	0
 𦙀	qpxs	0
@@ -74471,7 +71670,6 @@ encoder:
 𩒄	qqag	0
 删	qqak	60900000
 𣆑	qqak	0
-𫛽	qqar	0
 𠛹	qqbk	0
 股长	qqch	767000
 䏎	qqda	3460
@@ -74515,7 +71713,6 @@ encoder:
 𠡮	qqym	0
 删除	qqyo	330000000
 胸无	qrag	742000
-𫇰	qrbr	0
 䏺	qrci	3720
 膖	qrcw	34100
 胸花	qren	1240000
@@ -74581,7 +71778,6 @@ encoder:
 胶囊	qsaj	12500000
 猝死	qsar	2650000
 脑壳	qsbw	1180000
-𫇬	qsby	0
 丹青	qscq	2840000
 丹麦	qscr	11600000
 脉搏	qsdf	6700000
@@ -74593,7 +71789,6 @@ encoder:
 𦜟	qsgj	0
 胶布	qsgl	1250000
 丹东	qshk	5820000
-𫇍	qsid	0
 脉虚	qsik	64100
 䐧	qsjl	4070
 𦡣	qsjm	0
@@ -74611,11 +71806,9 @@ encoder:
 䵊	qsko	4000
 𠂄	qskr	0
 臆	qskw	1690000
-𪲆	qskz	0
 狡黠	qslb	2240000
 膪	qslj	43100
 𡵕	qsll	0
-𪲇	qslz	0
 䐮	qsmm	5120
 𦜍	qsmo	0
 𦞎	qsmp	0
@@ -74659,7 +71852,6 @@ encoder:
 𠣝	qsrt	0
 䳮	qsrz	3480
 鴅	qsrz	35900
-𫜣	qsrz	0
 𪚘	qssi	0
 狡诈	qssm	1730000
 狡辩	qsss	1430000
@@ -74668,7 +71860,6 @@ encoder:
 脑浆	qstr	676000
 䐱	qsul	4590
 胶着	qsul	919000
-𪲋	qsur	0
 胶卷	qsuy	2880000
 脉数	qsuz	119000
 脑海	qsvm	13500000
@@ -74681,9 +71872,7 @@ encoder:
 丹寨	qswe	204000
 腋窝	qswj	473000
 腣	qswl	38500
-𪲄	qswr	0
 膀	qsws	2180000
-𫇬	qswy	0
 丹心	qswz	1910000
 𢜑	qswz	0
 丹皮	qsxi	405000
@@ -74708,7 +71897,6 @@ encoder:
 胘	qszz	39800
 褹	qtbq	34200
 𦡻	qtcq	0
-𫇒	qtdm	0
 𦟉	qteb	0
 𦙒	qted	0
 𦟟	qtff	0
@@ -74747,7 +71935,6 @@ encoder:
 𨃗	quji	0
 脱	qujr	82300000
 𦝇	quka	0
-𫇕	qukd	0
 𦞔	qukg	0
 𣎒	quki	0
 𦡮	qukk	0
@@ -74759,7 +71946,6 @@ encoder:
 幐	quli	459000
 𦚿	quli	0
 𦠇	qulk	0
-𪿃	qulk	0
 賸	qulo	942000
 𦠀	qulp	0
 脱手	qumd	1860000
@@ -74775,7 +71961,6 @@ encoder:
 脱贫	quoy	2540000
 脱销	qupk	1020000
 脱钩	qupr	1980000
-𫇝	quqk	0
 脱脂	quqr	1700000
 腾腾	ququ	3460000
 膦	qurm	891000
@@ -74783,14 +71968,12 @@ encoder:
 脱产	qusm	1580000
 脱离	quso	21500000
 𧜜	qusr	0
-𫍉	qusr	0
 䑆	qusx	5940
 𠗲	qutd	0
 胖瘦	qutn	762000
 𦣍	quug	0
 膳	quuj	8900000
 腅	quuo	23500
-𪲈	quuo	0
 脱粒	quus	312000
 滕州	quvn	1600000
 腾空	quwb	2940000
@@ -74820,7 +72003,6 @@ encoder:
 月薪	qves	19400000
 月中	qvjv	8390000
 月光	qvkg	32100000
-𪲊	qvmb	0
 𦡤	qvne	0
 月份	qvno	105000000
 𦟸	qvnr	0
@@ -74953,7 +72135,6 @@ encoder:
 𦙷	qxqy	0
 𦢨	qxrn	0
 胒	qxrr	29900
-𪵮	qxrr	0
 𦞣	qxsi	0
 𢮗	qxsm	0
 凤庆	qxtg	353000
@@ -74983,7 +72164,6 @@ encoder:
 𪖒	qyan	0
 九列	qyar	36900
 猛烈	qyar	11800000
-𫖤	qyax	0
 九万	qyay	1090000
 奿	qyaz	66000
 肥城	qybh	825000
@@ -75005,7 +72185,6 @@ encoder:
 肥西	qyfj	1370000
 猛醒	qyfk	357000
 雑	qyfn	6260000
-𫖤	qyfx	0
 肥大	qygd	3820000
 㐡	qygg	5490
 𦓏	qygl	0
@@ -75022,15 +72201,12 @@ encoder:
 𦚺	qyii	0
 𧓖	qyii	0
 九点	qyij	6010000
-𪜘	qyja	0
 膙	qyji	54100
-𫇞	qyji	0
 猛跌	qyjm	370000
 𠃳	qyjn	0
 𤰙	qyki	0
 𤰚	qyki	0
 𣉑	qykk	0
-𪜕	qykk	0
 肠胃	qykq	5810000
 肥水	qykv	1540000
 犯罪	qylk	80600000
@@ -75043,12 +72219,10 @@ encoder:
 脡	qymb	237000
 九千	qyme	2350000
 肥缺	qyme	254000
-𪜚	qyme	0
 脠	qymi	237000
 䏜	qyms	3490
 𥹛	qymu	0
 服气	qymy	4540000
-𫇣	qymz	0
 胇	qynd	22800
 𦝗	qynd	0
 肥皂	qynh	5570000
@@ -75136,7 +72310,6 @@ encoder:
 厹	qyzs	95200
 肥乡	qyzz	293000
 𦞲	qzai	0
-𫇓	qzbi	0
 腞	qzgq	80300
 𦢍	qzhk	0
 𦠄	qzho	0
@@ -75197,7 +72370,6 @@ encoder:
 鱼网	ralo	2780000
 𩶁	ralo	0
 𩺂	ralo	0
-𫛔	ralo	0
 鱺	ralt	67500
 鱼骨	ralw	621000
 鱼种	ramj	791000
@@ -75222,8 +72394,6 @@ encoder:
 𩸸	raxz	0
 印张	rayc	5020000
 𩶏	rays	0
-𫛎	raza	0
-𫚧	razf	0
 印台	razj	515000
 鱼台	razj	2170000
 印发	razv	11200000
@@ -75254,7 +72424,6 @@ encoder:
 𧏤	rboi	0
 䲋	rbok	3760
 䲅	rbol	3880
-𫛢	rbol	0
 鯪	rbor	89000
 鲮	rbor	304000
 𧏤	rbqi	0
@@ -75268,7 +72437,6 @@ encoder:
 𧏤	rbui	0
 鱚	rbuj	332000
 𩻬	rbup	0
-𫛯	rbup	0
 𠢴	rbuy	0
 𩵘	rbvv	0
 𩵚	rbvv	0
@@ -75279,14 +72447,12 @@ encoder:
 鰪	rbzl	19100
 魱	rbzm	20500
 魼	rbzs	60200
-𫛑	rbzs	0
 𩹀	rcag	0
 𩸮	rcbi	0
 𩽪	rccc	0
 𩾂	rcds	0
 𩽔	rcgd	0
 鱷	rcjj	972000
-𫚠	rcka	0
 䲔	rckk	4200
 鰿	rclo	23500
 𩽗	rcml	0
@@ -75301,9 +72467,7 @@ encoder:
 𩹝	rczy	0
 儿歌	rdaj	6050000
 𩹭	rdbd	0
-𫚦	rdhk	0
 𠑹	rdhx	0
-𫚦	rdkz	0
 𡴸	rdll	0
 儿科	rdmt	6530000
 䱑	rdpd	4370
@@ -75348,7 +72512,6 @@ encoder:
 𩻧	rekf	0
 𩻁	rekg	0
 鰽	rekk	28000
-𫛭	rekk	0
 𩸌	rekm	0
 𩺳	rekm	0
 鱑	reko	22700
@@ -75357,13 +72520,10 @@ encoder:
 𩹞	reld	0
 𩹅	relg	0
 𩺘	relo	0
-𫛃	relz	0
 𢍸	reme	0
 𩸚	remh	0
 𩽭	reml	0
 𩽡	remm	0
-𫚶	remy	0
-𫛈	reni	0
 𩸽	renr	0
 鱯	renx	22700
 鳠	renx	41600
@@ -75377,7 +72537,6 @@ encoder:
 𩷶	resh	0
 𩹩	resl	0
 𩺊	resn	0
-𫚕	revv	0
 䲛	rewl	3670
 𩺌	rewl	0
 𩷚	rewy	0
@@ -75425,7 +72584,6 @@ encoder:
 𩹿	rfrj	0
 䲚	rfrl	3830
 条文	rfso	5650000
-𫚩	rfsq	0
 𩺹	rfsy	0
 𩵦	rfvv	0
 𩻕	rfwr	0
@@ -75457,10 +72615,8 @@ encoder:
 𣀁	rgix	0
 𩹠	rgjk	0
 𩺙	rgjl	0
-𫚘	rgjo	0
 𤑰	rgju	0
 䱳	rgkb	25700
-𫛌	rgkg	0
 𩻻	rgkk	0
 𩸆	rgkz	0
 鮞	rgla	58500
@@ -75483,7 +72639,6 @@ encoder:
 𠨢	rgor	0
 詹	rgos	12400000
 𧩏	rgos	0
-𫚲	rgot	0
 𧫹	rgow	0
 𩻆	rgow	0
 然后	rgpa	381000000
@@ -75496,7 +72651,6 @@ encoder:
 𠨢	rgrr	0
 𧩏	rgrs	0
 危急	rgrx	4940000
-𫚰	rgry	0
 危亡	rgsh	391000
 𢨕	rgsh	0
 𠟧	rgsk	0
@@ -75597,7 +72751,6 @@ encoder:
 𥀓	rhkx	0
 鰋	rhkz	32000
 𡝪	rhkz	0
-𫛨	rhkz	0
 𡑘	rhlb	0
 帋	rhli	62000
 贕	rhll	32800
@@ -75612,7 +72765,6 @@ encoder:
 𢑏	rhmx	0
 卯	rhmy	11400000
 𠨥	rhmy	0
-𫒔	rhmy	0
 𤦨	rhnc	0
 𨾛	rhni	0
 劉	rhpk	27700000
@@ -75624,11 +72776,9 @@ encoder:
 𩵪	rhrd	0
 𣆾	rhrk	0
 𩻛	rhrk	0
-𫏖	rhrl	0
 𣢎	rhro	0
 䲭	rhrz	4850
 𣱒	rhsb	0
-𫚧	rhsf	0
 𩑾	rhsg	0
 𧠟	rhsl	0
 氏族	rhsm	1750000
@@ -75640,7 +72790,6 @@ encoder:
 㤻	rhsw	4380
 𢘴	rhsw	0
 邸	rhsy	10500000
-𫒖	rhsy	0
 𣃃	rhup	0
 𨞌	rhuy	0
 䱌	rhvv	6970
@@ -75668,7 +72817,6 @@ encoder:
 𥁚	rhyl	0
 𩛁	rhyo	0
 𨥫	rhyp	0
-𫛻	rhyr	0
 卵	rhys	42100000
 𤬵	rhys	0
 迎	rhyw	83200000
@@ -75750,7 +72898,6 @@ encoder:
 鲈鱼	rira	763000
 处处	riri	19500000
 外角	rirl	340000
-𫛄	rirl	0
 𩶆	rirr	0
 外贸	rirs	87900000
 外务	riry	1160000
@@ -75783,7 +72930,6 @@ encoder:
 外边	riwy	7100000
 外观	rixl	37500000
 鲈	rixm	1380000
-𫚙	rixm	0
 𩽐	rixo	0
 𩼇	rixu	0
 外加	riyj	15100000
@@ -75791,13 +72937,11 @@ encoder:
 𩽶	rizi	0
 处女	rizm	22900000
 处以	rizo	5480000
-𪥸	rizx	0
 处级	rizy	2380000
 外出	rizz	34700000
 免于	rjad	2390000
 名画	rjak	7710000
 𩺅	rjak	0
-𫚽	rjal	0
 名列	rjar	8580000
 𩶭	rjas	0
 𩶍	rjaz	0
@@ -75809,7 +72953,6 @@ encoder:
 鰐	rjbz	309000
 鳄	rjbz	3780000
 𩹫	rjce	0
-𫛀	rjch	0
 免职	rjcj	2120000
 𩽴	rjcm	0
 各班	rjcu	2360000
@@ -75833,7 +72976,6 @@ encoder:
 䴂	rjgr	4650
 𤟭	rjgs	0
 勨	rjgy	137000
-𪟡	rjgy	0
 象牙	rjhi	14300000
 名医	rjhm	8570000
 各区	rjho	6380000
@@ -75842,7 +72984,6 @@ encoder:
 句号	rjja	3340000
 各国	rjjc	44200000
 鱢	rjjf	21800
-𫛱	rjjf	0
 名贵	rjji	4990000
 𩻂	rjjj	0
 𪛃	rjjj	0
@@ -75859,7 +73000,6 @@ encoder:
 𪛉	rjjz	0
 名师	rjka	17000000
 鱓	rjke	52600
-𪞄	rjke	0
 各省	rjkm	20200000
 名鉴	rjkm	38100
 𡮿	rjkm	0
@@ -75909,8 +73049,6 @@ encoder:
 各处	rjri	4550000
 𣆶	rjrk	0
 𥇅	rjrl	0
-𪾾	rjrl	0
-𪲉	rjrq	0
 㲋	rjrr	4210
 兔	rjrs	47800000
 毚	rjrs	120000
@@ -75921,7 +73059,6 @@ encoder:
 勉	rjry	8080000
 各色	rjry	6800000
 𨞭	rjry	0
-𪞃	rjrz	0
 名言	rjsa	17100000
 𩖌	rjsg	0
 𧇢	rjsi	0
@@ -75988,7 +73125,6 @@ encoder:
 乐于	rkad	8380000
 鯷	rkai	52800
 鳀	rkai	43500
-𫛛	rkal	0
 龟裂	rkar	1150000
 乐平	rkau	1100000
 乐土	rkba	1430000
@@ -76013,7 +73149,6 @@ encoder:
 刨花	rken	250000
 备荒	rkes	206000
 备查	rkfk	2290000
-𫛊	rkfk	0
 备有	rkgq	4040000
 𩶸	rkgr	0
 旨在	rkgv	3110000
@@ -76031,7 +73166,6 @@ encoder:
 乐器	rkjj	28600000
 𩻱	rkjk	0
 𩼉	rkjk	0
-𫚷	rkjl	0
 𩻰	rkjm	0
 𣬔	rkjo	0
 鱧	rkju	364000
@@ -76039,7 +73173,6 @@ encoder:
 鯧	rkka	95900
 鲳	rkka	906000
 𨤰	rkkb	0
-𫓀	rkkb	0
 𩼅	rkkg	0
 𩸛	rkki	0
 乐昌	rkkk	739000
@@ -76047,7 +73180,6 @@ encoder:
 昏暗	rkks	5190000
 亀	rkkz	13100000
 𩸁	rkld	0
-𫚪	rkld	0
 鰛	rklk	29100
 鳁	rklk	32800
 乐山	rkll	6720000
@@ -76055,7 +73187,6 @@ encoder:
 𩹳	rklo	0
 覙	rklr	26900
 𡕳	rklr	0
-𫍣	rklr	0
 𩻠	rkls	0
 备用	rklv	11400000
 鰻	rklx	3780000
@@ -76081,7 +73212,6 @@ encoder:
 鲲	rkrr	781000
 𤉢	rkru	0
 𩹄	rkry	0
-𪟡	rkry	0
 𩿥	rkrz	0
 𪈂	rkrz	0
 乐亭	rksj	861000
@@ -76154,7 +73284,6 @@ encoder:
 负起	rlby	1970000
 触动	rlbz	13500000
 𩺩	rlbz	0
-𫍩	rlbz	0
 𧥄	rlch	0
 解职	rlcj	1130000
 解聘	rlck	1720000
@@ -76190,14 +73319,11 @@ encoder:
 䱀	rlgd	16400
 奂	rlgd	2100000
 奐	rlgd	944000
-𫛖	rlgd	0
 𧣨	rlgh	0
 负面	rlgj	14200000
 𧤮	rlgj	0
 𧣩	rlgl	0
-𫚱	rlgl	0
 触礁	rlgn	635000
-𫍪	rlgn	0
 𩓅	rlgo	0
 负有	rlgq	7180000
 𧰼	rlgq	0
@@ -76213,7 +73339,6 @@ encoder:
 𧤡	rlhm	0
 𧢾	rlhr	0
 𧣒	rlhx	0
-𪩼	rlhx	0
 𧣾	rlih	0
 𧤫	rlio	0
 𧤧	rliq	0
@@ -76235,7 +73360,6 @@ encoder:
 䚩	rljl	3920
 𧤜	rljl	0
 𧤦	rljl	0
-𫍬	rljm	0
 䚭	rljn	3430
 𧣕	rljo	0
 𧤉	rljq	0
@@ -76344,7 +73468,6 @@ encoder:
 觚	rlps	323000
 解释	rlpx	93900000
 角膜	rlqe	2700000
-𫚿	rlqi	0
 解脱	rlqu	11500000
 𧣇	rlqx	0
 触犯	rlqy	5840000
@@ -76363,7 +73486,6 @@ encoder:
 鰴	rlrm	31400
 觴	rlro	1150000
 𠤀	rlro	0
-𫍫	rlro	0
 䚠	rlrr	3900
 𡕫	rlrr	0
 𣬋	rlrr	0
@@ -76377,7 +73499,6 @@ encoder:
 𧣏	rlrt	0
 觾	rlru	21100
 𤊱	rlru	0
-𪹳	rlru	0
 𧥕	rlrw	0
 角色	rlry	66900000
 𠢒	rlry	0
@@ -76502,7 +73623,6 @@ encoder:
 鯯	rmlk	35400
 𩶫	rmlk	0
 𩻳	rmmf	0
-𫚹	rmnd	0
 孵化	rmnr	5330000
 𩽕	rmnx	0
 疑似	rmnz	6920000
@@ -76560,7 +73680,6 @@ encoder:
 鲌	rnka	58400
 𠜼	rnkd	0
 鯾	rnko	39400
-𫛩	rnko	0
 鰁	rnkv	36000
 鳈	rnkv	22900
 𩻖	rnkz	0
@@ -76578,11 +73697,9 @@ encoder:
 兜儿	rnrd	55700
 鯢	rnrd	147000
 鲵	rnrd	350000
-𫛞	rnre	0
 鰷	rnrf	41200
 𦥵	rnrj	0
 欿	rnro	31700
-𫚴	rnrp	0
 魤	rnrr	39800
 𩹻	rnrr	0
 鵮	rnrz	20200
@@ -76595,13 +73712,11 @@ encoder:
 𩺟	rnxm	0
 䱸	rnxs	12000
 𩹹	rnxs	0
-𫚭	rnxx	0
 𩺫	rnym	0
 𩼾	rnzu	0
 𩸵	roai	0
 𩹑	roai	0
 鮯	roaj	28400
-𫛝	roaj	0
 鯩	roal	29900
 欠款	robb	3240000
 𩽸	robg	0
@@ -76613,7 +73728,6 @@ encoder:
 忽而	rogl	1610000
 鯑	rogl	86100
 𤝀	rogs	0
-𫚟	roia	0
 𩸟	roig	0
 𩸍	rojy	0
 忽略	rokr	32800000
@@ -76657,7 +73771,6 @@ encoder:
 鯰	roxw	845000
 鲶	roxw	871000
 魵	royd	91400
-𫛓	royd	0
 𩸂	royw	0
 䱵	royy	4210
 䲝	royy	3960
@@ -76699,7 +73812,6 @@ encoder:
 𠤨	rrae	0
 𣬂	rrae	0
 𣬊	rrae	0
-𪟫	rrag	0
 比武	rrah	5280000
 㔭	rrai	5000
 𠤧	rrai	0
@@ -76730,7 +73842,6 @@ encoder:
 𢺵	rrex	0
 比萨	rrey	4140000
 㯋	rrfg	3660
-𫚵	rrfk	0
 𪀶	rrfr	0
 比配	rrfy	31700
 𣬓	rrge	0
@@ -76773,29 +73884,24 @@ encoder:
 眞	rrlo	6770000
 𠤤	rrlo	0
 𧴦	rrlo	0
-𫛅	rrlx	0
 𨜭	rrly	0
 𠤑	rrma	0
 𠤕	rrma	0
 𩷄	rrmb	0
 毕生	rrmc	3680000
-𫚳	rrmf	0
 穎	rrmg	9300000
 颖	rrmg	18900000
 𩓙	rrmg	0
 比重	rrmk	18700000
-𪵬	rrmm	0
 欵	rrmr	66500
 𠤗	rrmr	0
 𣣅	rrmr	0
 𩺶	rrmr	0
 𪁬	rrmr	0
-𪵎	rrmr	0
 𩻫	rrmu	0
 𥏶	rrmz	0
 比例	rrna	74900000
 䱤	rrnb	4450
-𪟭	rrnc	0
 比值	rrne	1840000
 𡙊	rrng	0
 𩀊	rrnn	0
@@ -76830,12 +73936,10 @@ encoder:
 枈	rrrf	67300
 𨋅	rrrf	0
 𡗬	rrrg	0
-𫗠	rrrg	0
 𧔻	rrri	0
 𣅜	rrrk	0
 觺	rrrl	30800
 𧣅	rrrl	0
-𪵸	rrrl	0
 毞	rrrm	919000
 𢻹	rrrm	0
 𤘤	rrrm	0
@@ -76847,7 +73951,6 @@ encoder:
 魮	rrrr	47100
 𣢋	rrrr	0
 𣬅	rrrr	0
-𫛶	rrrr	0
 𥏑	rrrs	0
 𩶰	rrrs	0
 𩸃	rrrs	0
@@ -76855,7 +73958,6 @@ encoder:
 𩽿	rrrs	0
 𩾅	rrrs	0
 粊	rrru	466000
-𪫷	rrrw	0
 㿫	rrrx	5640
 𤿎	rrrx	0
 𠨒	rrry	0
@@ -76888,18 +73990,15 @@ encoder:
 𠤞	rrxa	0
 䱢	rrxb	3920
 肄	rrxb	801000
-𫇉	rrxb	0
 疑	rrxi	74500000
 𩼨	rrxi	0
 𨽹	rrxk	0
 𨽻	rrxk	0
-𫖚	rrxk	0
 𥏚	rrxl	0
 𥻊	rrxu	0
 比对	rrxv	2810000
 鮑	rrya	2710000
 鲍	rrya	22100000
-𫚞	rryi	0
 鰡	rryk	68800
 𩺜	rryk	0
 𥛤	rryl	0
@@ -76941,19 +74040,16 @@ encoder:
 𩼆	rsbr	0
 𨝋	rsby	0
 𡖮	rsbz	0
-𪠡	rsbz	0
 夆	rsci	605000
 𡕗	rsci	0
 𧋴	rsci	0
 留职	rscj	423000
 㶻	rscu	3800
 逢	rscw	63000000
-𪨃	rsds	0
 㚈	rsed	3830
 𠥾	rsed	0
 頯	rseg	24900
 𡖻	rsel	0
-𪥇	rseq	0
 𡕛	rseu	0
 𤍙	rseu	0
 㩼	rsex	3810
@@ -76961,7 +74057,6 @@ encoder:
 𡖯	rsfj	0
 𦠁	rsfj	0
 𤒗	rsfl	0
-𫛆	rsfp	0
 留校	rsfs	1140000
 𩁼	rsfv	0
 𡖠	rsgb	0
@@ -76990,7 +74085,6 @@ encoder:
 迯	rsiw	92000
 𡖄	rsix	0
 𢼛	rsix	0
-𪥃	rsiz	0
 頟	rsjg	36400
 𠧨	rsji	0
 𡒒	rsji	0
@@ -77025,13 +74119,9 @@ encoder:
 𨚷	rsjy	0
 𨝠	rsjy	0
 𩻗	rsjy	0
-𪟜	rsjy	0
-𫛮	rsjy	0
-𪤽	rsjz	0
 鱣	rska	45900
 鳣	rska	41400
 𩻡	rskb	0
-𪥈	rskb	0
 𡭫	rskd	0
 鱆	rske	68300
 㚌	rskf	4360
@@ -77061,7 +74151,6 @@ encoder:
 𦓟	rslg	0
 𢁙	rsli	0
 𢁟	rsli	0
-𪥀	rsli	0
 𠞚	rslk	0
 𡖕	rsll	0
 𡵁	rsll	0
@@ -77115,7 +74204,6 @@ encoder:
 𡖗	rsob	0
 𤏝	rsob	0
 䱣	rsoe	4660
-𪤽	rsoj	0
 𤚶	rsom	0
 䏑	rsoo	3780
 鮫	rsoo	3300000
@@ -77141,9 +74229,7 @@ encoder:
 𡖾	rsre	0
 䫂	rsrg	3410
 贸然	rsrg	3470000
-𫗳	rsrg	0
 𡖧	rsrh	0
-𪥁	rsri	0
 夠	rsrj	23100000
 𠛫	rsrk	0
 𡖿	rsrl	0
@@ -77166,7 +74252,6 @@ encoder:
 𦠹	rsru	0
 迻	rsrw	82700
 𪚪	rsrw	0
-𪥄	rsrx	0
 卶	rsry	27900
 𡖎	rsry	0
 𡖐	rsry	0
@@ -77201,7 +74286,6 @@ encoder:
 𧯭	rsue	0
 夈	rsuf	318000
 粂	rsuf	169000
-𪥂	rsuf	0
 留美	rsug	2540000
 𠞎	rsuk	0
 𡮫	rsuk	0
@@ -77249,7 +74333,6 @@ encoder:
 䱶	rsxy	3890
 𡖖	rsxy	0
 𡖥	rsxy	0
-𪥅	rsxy	0
 勺子	rsya	3180000
 𡕕	rsya	0
 𡖊	rsyb	0
@@ -77264,7 +74347,6 @@ encoder:
 盌	rsyl	49300
 眢	rsyl	618000
 𧵍	rsyl	0
-𪾼	rsyl	0
 务	rsym	263000000
 𢪸	rsym	0
 𩚴	rsyo	0
@@ -77274,7 +74356,6 @@ encoder:
 鴛	rsyr	357000
 鸳	rsyr	1890000
 𪀈	rsyr	0
-𫛿	rsyr	0
 㼝	rsys	4380
 𡖉	rsys	0
 𤮘	rsys	0
@@ -77295,7 +74376,6 @@ encoder:
 𡚮	rszm	0
 𡚰	rszm	0
 𡛹	rszm	0
-𫚡	rszm	0
 鯍	rszn	17800
 𡗌	rszn	0
 㚊	rszo	4190
@@ -77326,13 +74406,10 @@ encoder:
 𩸅	rtnd	0
 𩽉	rtnx	0
 𩼼	rtob	0
-𫚺	rtoo	0
 冬令	rtow	1210000
 冬瓜	rtps	5040000
 𩼼	rtrb	0
 鳉	rtrd	73500
-𫚮	rtrj	0
-𫛇	rtrl	0
 鯳	rtrs	42600
 冬训	rtsn	395000
 冬装	rttb	5200000
@@ -77347,7 +74424,6 @@ encoder:
 鱅	rtxl	31600
 鳙	rtxl	492000
 冬防	rtys	136000
-𫚢	ruba	0
 䱹	rubi	4850
 䱴	rubk	5130
 䱭	rubr	5200
@@ -77362,7 +74438,6 @@ encoder:
 	rufd	0
 𩺧	ruhb	0
 鮵	rujr	27600
-𫛡	rujr	0
 鲜果	rukf	5100000
 䲕	rukk	3840
 鲜明	rukq	18600000
@@ -77394,14 +74469,12 @@ encoder:
 鳒	ruxk	34300
 𩷼	ruym	0
 䱧	ruyy	4070
-𫛦	ruyy	0
 鮷	ruyz	22400
 鲜红	ruzb	4980000
 鲜嫩	ruzf	1350000
 𩹖	ruzm	0
 𩹦	ruzs	0
 鰦	ruzz	74800
-𫛪	ruzz	0
 多于	rvad	15000000
 多哥	rvaj	1730000
 多万	rvay	23600000
@@ -77481,7 +74554,6 @@ encoder:
 鲢	rwhe	978000
 𩽼	rwhe	0
 𩸘	rwix	0
-𫛁	rwjk	0
 鰰	rwki	215000
 𩼧	rwkl	0
 𪚳	rwlb	0
@@ -77491,18 +74563,13 @@ encoder:
 𩼣	rwlj	0
 𩶱	rwmh	0
 𩽽	rwmh	0
-𫚻	rwmi	0
 𩺬	rwmy	0
 𩺬	rwnx	0
-𫚚	rwoa	0
 鰫	rwoj	34000
 𩽜	rwoj	0
-𫛬	rwoj	0
 𩼶	rwop	0
-𫛲	rwop	0
 𩼵	rwor	0
 𪚺	rwpd	0
-𫚬	rwpd	0
 𩵨	rwqd	0
 魫	rwrd	22400
 𡙟	rwrg	0
@@ -77531,14 +74598,12 @@ encoder:
 𩽾	rwzm	0
 急于	rxad	11800000
 雏形	rxae	3020000
-𫚾	rxae	0
 𣝖	rxaf	0
 𡙝	rxag	0
 𩹍	rxag	0
 邹平	rxau	723000
 䲁	rxbd	4320
 鳚	rxbd	52800
-𫚤	rxbd	0
 鰎	rxby	165000
 急聘	rxck	1890000
 䲎	rxcm	3720
@@ -77554,7 +74619,6 @@ encoder:
 争相	rxfl	4850000
 𩽥	rxfl	0
 争夺	rxgd	20200000
-𫚣	rxgx	0
 𩷃	rxgz	0
 𢎍	rxhb	0
 煞车	rxhe	470000
@@ -77562,7 +74626,6 @@ encoder:
 鮍	rxia	41000
 鲏	rxia	37900
 争战	rxij	607000
-𪻀	rxil	0
 𩶒	rxim	0
 䱬	rxiq	5570
 𩾊	rxiq	0
@@ -77574,7 +74637,6 @@ encoder:
 𩺠	rxjo	0
 争鸣	rxjr	4010000
 𩼎	rxjs	0
-𫛂	rxju	0
 𩺐	rxjy	0
 𩻽	rxka	0
 𩽙	rxka	0
@@ -77593,7 +74655,6 @@ encoder:
 𠹨	rxmi	0
 鱊	rxml	27700
 𡺧	rxml	0
-𫛰	rxml	0
 争先	rxmr	2370000
 煞	rxmu	16300000
 𢞀	rxmw	0
@@ -77606,18 +74667,14 @@ encoder:
 𩻎	rxno	0
 争创	rxoy	2690000
 𠈽	rxqo	0
-𪹰	rxqu	0
 𩸿	rxqx	0
 鲫鱼	rxra	1830000
 𠑾	rxrd	0
-𫛍	rxri	0
-𫚛	rxrr	0
 𤍹	rxru	0
 𠜧	rxry	0
 𩿿	rxrz	0
 鰠	rxsi	30300
 鳋	rxsi	59200
-𪭔	rxsj	0
 争端	rxsl	4770000
 争论	rxso	16700000
 急诊	rxso	5020000
@@ -77635,11 +74692,9 @@ encoder:
 急流	rxvs	1390000
 急速	rxwf	16400000
 鯞	rxwl	31100
-𫛧	rxwl	0
 急迫	rxwn	1730000
 𪂺	rxwr	0
 鮼	rxwx	19500
-𪬥	rxwy	0
 急	rxwz	149000000
 急骤	rxxc	466000
 急剧	rxxe	8470000
@@ -77649,7 +74704,6 @@ encoder:
 皱眉	rxxl	6350000
 鰕	rxxx	118000
 𩸯	rxxx	0
-𫛫	rxxx	0
 𩷐	rxyj	0
 争办	rxyo	112000
 𢏻	rxyo	0
@@ -77714,7 +74768,6 @@ encoder:
 𪅞	rygr	0
 𠣥	rygs	0
 𠣮	rygu	0
-𫚜	ryhd	0
 包车	ryhe	1970000
 𠣹	ryhr	0
 䰾	ryia	4780
@@ -77775,10 +74828,8 @@ encoder:
 郇	ryky	582000
 𠡪	ryky	0
 𢏔	ryky	0
-𪾂	ryky	0
 匎	rykz	48300
 鸳鸯	rylg	7440000
-𫚯	rylg	0
 㬟	rylk	3730
 鯭	rylk	98500
 𣍐	rylk	0
@@ -77807,7 +74858,6 @@ encoder:
 务川	rynd	173000
 鮄	rynd	24800
 𩷺	rynd	0
-𫛘	rynd	0
 𦫖	rynk	0
 𠅱	rynr	0
 匑	ryny	24000
@@ -77815,12 +74865,10 @@ encoder:
 勽	ryod	24400
 勿	ryod	215000000
 𠓨	ryod	0
-𫛐	ryod	0
 𨍂	ryof	0
 䝆	ryog	4360
 𩑮	ryog	0
 𠤈	ryoi	0
-𪵗	ryoi	0
 𠯳	ryoj	0
 㫚	ryok	3690
 刎	ryok	578000
@@ -77900,11 +74948,9 @@ encoder:
 怨恨	ryux	9210000
 𠤆	ryvb	0
 𩵌	ryvv	0
-𫒦	ryvv	0
 色泽	ryvx	15000000
 色达	rywg	306000
 务必	rywm	25100000
-𪯨	rywm	0
 包袱	rywn	13000000
 包容	rywo	6070000
 务农	rywr	1240000
@@ -77953,14 +74999,12 @@ encoder:
 皺	ryzx	6480000
 鄒	ryzy	1970000
 𨝁	ryzy	0
-𪦂	ryzy	0
 𠣎	ryzz	0
 𠣖	ryzz	0
 烏	rzaa	13500000
 𩾝	rzae	0
 䴌	rzag	4130
 𪃆	rzag	0
-𫗧	rzag	0
 𣦑	rzai	0
 𩺉	rzai	0
 𪁯	rzai	0
@@ -77978,7 +75022,6 @@ encoder:
 𡷊	rzal	0
 𩿐	rzal	0
 𠂶	rzam	0
-𫖝	rzan	0
 歍	rzar	41700
 𤑎	rzar	0
 邬	rzay	1860000
@@ -77998,7 +75041,6 @@ encoder:
 鷌	rzcu	25500
 䳖	rzcz	3370
 勾搭	rzde	1080000
-𫜙	rzeb	0
 鶀	rzec	25400
 𩿵	rzej	0
 𪂯	rzej	0
@@ -78018,7 +75060,6 @@ encoder:
 鯵	rzgp	1560000
 鲹	rzgp	43700
 䱲	rzgq	5760
-𫛾	rzgq	0
 𩿁	rzgs	0
 𩹧	rzgu	0
 𪈫	rzgu	0
@@ -78035,7 +75076,6 @@ encoder:
 𪆧	rzhz	0
 𣦘	rzii	0
 𩽵	rzii	0
-𫛹	rzij	0
 𪇷	rzis	0
 䳹	rzix	3980
 𪆳	rziy	0
@@ -78046,9 +75086,7 @@ encoder:
 𪈩	rzjn	0
 䳅	rzjo	3590
 𩸠	rzjq	0
-𫜂	rzjq	0
 䴋	rzjr	3780
-𫝋	rzjr	0
 𪇊	rzjs	0
 𪆖	rzju	0
 郺	rzjy	21700
@@ -78067,7 +75105,6 @@ encoder:
 𩿼	rzki	0
 𪀋	rzki	0
 𪀌	rzki	0
-𫚼	rzki	0
 𪈒	rzkl	0
 𪃐	rzkm	0
 𩶚	rzko	0
@@ -78137,7 +75174,6 @@ encoder:
 𠝷	rzoy	0
 𩿉	rzoy	0
 鱲	rzoz	166000
-𫛳	rzoz	0
 乌金	rzpa	371000
 鷈	rzpi	28900
 凫	rzqd	840000
@@ -78179,7 +75215,6 @@ encoder:
 𪄝	rzrz	0
 𪄞	rzrz	0
 𪅝	rzrz	0
-𫛷	rzrz	0
 𣁓	rzso	0
 䙚	rzsr	5720
 袅	rzsr	996000
@@ -78201,12 +75236,10 @@ encoder:
 𪀤	rzvb	0
 𪇨	rzvf	0
 乌海	rzvm	1800000
-𫛋	rzvr	0
 䰲	rzvv	5940
 𪂋	rzwl	0
 𪇍	rzwl	0
 鴥	rzwo	38400
-𫜩	rzwo	0
 鴕	rzwr	77300
 鸵	rzwr	400000
 𪂊	rzwr	0
@@ -78215,11 +75248,9 @@ encoder:
 𪀴	rzxb	0
 𪆫	rzxf	0
 鴃	rzxg	157000
-𫜤	rzxg	0
 鵦	rzxk	21600
 𪅟	rzxl	0
 䳧	rzxm	3820
-𫝀	rzxm	0
 𪆭	rzxn	0
 䳁	rzxs	3620
 𩷅	rzxs	0
@@ -78231,7 +75262,6 @@ encoder:
 鷻	rzym	27500
 𩾖	rzym	0
 𩾜	rzym	0
-𫜎	rzyp	0
 𪇷	rzys	0
 𪈙	rzys	0
 𩿴	rzyt	0
@@ -78337,7 +75367,6 @@ encoder:
 评剧	saxe	465000
 誱	saxi	21800
 证书	saxy	72500000
-𫍺	saxz	0
 订费	sayn	25100
 𧧀	says	0
 订婚	sazr	2790000
@@ -78372,7 +75401,6 @@ encoder:
 𧫘	sbjr	0
 𧬇	sbju	0
 讲师	sbka	16700000
-𫎢	sbkv	0
 讲堂	sbkw	6600000
 𧥛	sbld	0
 讀	sbll	75600000
@@ -78422,7 +75450,6 @@ encoder:
 讲座	sbto	27400000
 䛭	sbub	3300
 譆	sbuj	231000
-𫎶	sbuj	0
 语料	sbut	151000
 语法	sbvb	27900000
 语汇	sbvh	541000
@@ -78453,7 +75480,6 @@ encoder:
 𧜍	sbzr	0
 詓	sbzs	151000
 𧥼	sbzs	0
-𫎗	sbzs	0
 请于	scad	4930000
 主干	scae	5480000
 𧩻	scag	0
@@ -78483,7 +75509,6 @@ encoder:
 𩒊	scgo	0
 主顾	scgy	591000
 主轴	schk	1840000
-𪜌	schm	0
 𧏼	scii	0
 𧬼	scjc	0
 讍	scjj	21600
@@ -78555,7 +75580,6 @@ encoder:
 𧩶	scyg	0
 主力	scym	36100000
 謸	scym	96400
-𫎰	scym	0
 主办	scyo	122000000
 主婚	sczr	408000
 主编	sczw	57500000
@@ -78607,8 +75631,6 @@ encoder:
 读本	sefa	4580000
 辣	sefj	69900000
 𨐤	sefl	0
-𫑖	sefl	0
-𫑕	sefy	0
 𧬔	segf	0
 𩕺	segg	0
 諾	segj	18400000
@@ -78690,7 +75712,6 @@ encoder:
 𧭝	serb	0
 䜦	serk	3430
 𧭽	sers	0
-𫎈	sers	0
 䜩	seru	17300
 讌	seru	229000
 	seru	0
@@ -78715,19 +75736,16 @@ encoder:
 辬	sess	25000
 辯	sess	2300000
 𢣑	sesw	0
-𪭗	sesw	0
 读	setg	266000000
 𠦑	sets	0
 谨慎	seue	43700000
 辨	seus	15300000
-𪭗	seuw	0
 𨐩	seux	0
 计数	seuz	8780000
 读数	seuz	1170000
 𥆳	sevl	0
 㵷	sevs	5310
 𢌮	sevv	0
-𫍭	sevv	0
 读写	sewa	21300000
 谋害	sewc	794000
 𧫚	sewl	0
@@ -78752,11 +75770,9 @@ encoder:
 𧮚	sezi	0
 𨐎	sezm	0
 𨐮	sezo	0
-𫑘	sezo	0
 𨐑	sezr	0
 辫	sezs	2410000
 辮	sezs	517000
-𫑗	sezw	0
 新型	sfae	55800000
 新政	sfai	7360000
 新款	sfbb	31200000
@@ -78780,7 +75796,6 @@ encoder:
 新药	sfez	22000000
 新村	sffd	13600000
 辣椒	sffi	14200000
-𫎄	sffq	0
 𧝺	sffr	0
 新奇	sfga	13800000
 譳	sfgl	22100
@@ -78891,7 +75906,6 @@ encoder:
 䜍	sgkk	3650
 𧩚	sgkv	0
 䛳	sgkz	3390
-𫎦	sgkz	0
 䛔	sgla	3560
 𧦞	sgli	0
 𧭡	sglz	0
@@ -78924,12 +75938,10 @@ encoder:
 𠅒	shaf	0
 諴	shaj	99000
 讴歌	shaj	1040000
-𫎪	shaj	0
 𧫳	shak	0
 試	shbi	48700000
 誙	shbi	22800
 试	shbi	407000000
-𪲌	shbl	0
 𧪖	shbo	0
 𡑤	shbq	0
 誆	shca	89200
@@ -78948,7 +75960,6 @@ encoder:
 𨏩	shfq	0
 试样	shfu	904000
 𨛌	shfy	0
-𫎝	shgr	0
 諓	shhm	34000
 訝	shia	1650000
 讶	shia	4070000
@@ -78958,22 +75969,18 @@ encoder:
 试点	shij	39800000
 蠃	shiq	701000
 𧥯	shis	0
-𫍼	shji	0
 謳	shjj	1190000
 𠅽	shjk	0
 𠅳	shjl	0
-𪭊	shjl	0
 𠅻	shjq	0
 试图	shjr	27800000
 𧭻	shjs	0
 䜗	shjw	3470
 𧭶	shjz	0
 试题	shka	35900000
-𪦘	shkg	0
 𤰡	shki	0
 朚	shkq	70700
 𦣖	shkq	0
-𪲍	shkz	0
 𧦏	shld	0
 㠵	shli	7670
 𥁃	shlk	0
@@ -78993,7 +76000,6 @@ encoder:
 𠅼	shmo	0
 𢻬	shmo	0
 𧩼	shmo	0
-𫎱	shmo	0
 𥢵	shmq	0
 𦏞	shmt	0
 试管	shmw	2570000
@@ -79047,7 +76053,6 @@ encoder:
 詎	shxa	150000
 讵	shxa	366000
 𧩆	shxb	0
-𫎅	shxb	0
 试验	shxo	85000000
 𦫋	shxo	0
 𡳴	shxq	0
@@ -79104,12 +76109,10 @@ encoder:
 𧨳	sike	0
 𧬟	sike	0
 譃	siku	111000
-𪜣	sikv	0
 𧭜	sikw	0
 諔	sikx	32500
 让贤	sikx	367000
 謯	silc	30300
-𫎴	silc	0
 𪚑	sili	0
 站岗	sill	1050000
 𡾩	sill	0
@@ -79148,7 +76151,6 @@ encoder:
 𪚥	siss	0
 站立	sisu	8700000
 𪚛	site	0
-𫎏	siuh	0
 𧥞	sivv	0
 让它	siwr	16900000
 𢤲	siwz	0
@@ -79221,10 +76223,8 @@ encoder:
 諤	sjbz	187000
 谔	sjbz	545000
 颤动	sjbz	6430000
-𪜠	sjbz	0
 諿	sjce	28400
 部长	sjch	38700000
-𫎉	sjch	0
 就职	sjcj	9400000
 襄理	sjck	148000
 讝	sjcm	21100
@@ -79277,7 +76277,6 @@ encoder:
 𩀻	sjgn	0
 豪爽	sjgo	3280000
 享有	sjgq	35600000
-𪵳	sjgq	0
 鷲	sjgr	2710000
 鹫	sjgr	1610000
 𪆩	sjgr	0
@@ -79289,12 +76288,10 @@ encoder:
 识破	sjgx	3320000
 高雄	sjgz	59300000
 就医	sjhm	11800000
-𪯫	sjhm	0
 高雅	sjhn	11800000
 误区	sjho	15400000
 𣄵	sjhr	0
 𢀮	sjhx	0
-𪩻	sjhx	0
 𩫨	sjhy	0
 㝄	sjhz	4380
 𧓂	sjii	0
@@ -79323,17 +76320,14 @@ encoder:
 𩫏	sjje	0
 譟	sjjf	133000
 髞	sjjf	42800
-𪳊	sjjf	0
 𠅧	sjjg	0
 高喊	sjjh	3470000
-𪜦	sjjh	0
 高贵	sjji	16700000
 𩫗	sjji	0
 𧬌	sjjl	0
 𩫣	sjjl	0
 稟	sjjm	1700000
 高呼	sjjm	3410000
-𫗐	sjjm	0
 敲响	sjjn	3670000
 膏	sjjq	17100000
 𩫘	sjjq	0
@@ -79355,7 +76349,6 @@ encoder:
 亶	sjka	639000
 竞日	sjka	19300
 𠆞	sjka	0
-𪧎	sjkb	0
 𡬱	sjkd	0
 䯬	sjke	3330
 亸	sjke	312000
@@ -79363,7 +76356,6 @@ encoder:
 譂	sjke	72000
 𡅄	sjke	0
 𩫜	sjke	0
-𫙻	sjke	0
 亮光	sjkg	6190000
 就	sjkg	1720000000
 𡰔	sjkg	0
@@ -79412,7 +76404,6 @@ encoder:
 𩫍	sjlm	0
 𩫙	sjln	0
 𧪼	sjlo	0
-𫎤	sjlo	0
 毃	sjlq	39200
 𩪿	sjlq	0
 歊	sjlr	41400
@@ -79425,7 +76416,6 @@ encoder:
 𩫋	sjlx	0
 䯩	sjly	3390
 鄗	sjly	54800
-𫙹	sjly	0
 高县	sjlz	818000
 墪	sjmb	57600
 高等	sjmb	57200000
@@ -79568,7 +76558,6 @@ encoder:
 熟	sjsu	80000000
 𤍨	sjsu	0
 𤒆	sjsu	0
-𪺙	sjsu	0
 识记	sjsy	494000
 𩫄	sjte	0
 京广	sjtg	1770000
@@ -79586,7 +76575,6 @@ encoder:
 高烧	sjuh	3310000
 哀悼	sjui	4960000
 高爆	sjuk	379000
-𪯵	sjum	0
 敦煌	sjun	6750000
 部首	sjun	2830000
 𩁛	sjun	0
@@ -79667,7 +76655,6 @@ encoder:
 襄阳	sjyk	2820000
 高阳	sjyk	1270000
 𧧸	sjyk	0
-𪜧	sjyk	0
 𥂣	sjyl	0
 敦	sjym	13700000
 𣮢	sjym	0
@@ -79683,7 +76670,6 @@ encoder:
 𤮩	sjys	0
 熟习	sjyt	488000
 烹	sjyu	6040000
-𪹥	sjyu	0
 譴	sjyw	1150000
 谴	sjyw	509000
 𢚟	sjyw	0
@@ -79785,7 +76771,6 @@ encoder:
 讄	skkk	21700
 𣉣	skkk	0
 亰	skko	371000
-𪨏	skko	0
 竟是	skkv	14600000
 意思	skkw	104000000
 课堂	skkw	45400000
@@ -79812,7 +76797,6 @@ encoder:
 章程	skmj	19900000
 课程	skmj	67400000
 𩡑	skmk	0
-𫍽	skml	0
 永年	skmm	1980000
 童年	skmm	19000000
 音符	skmn	12200000
@@ -79837,7 +76821,6 @@ encoder:
 课余	skom	2860000
 䛺	skon	3340
 脔	skoo	174000
-𪢗	skoo	0
 謖	skor	89400
 谡	skor	599000
 䛕	skos	3470
@@ -79927,7 +76910,6 @@ encoder:
 童心	skwz	5220000
 諰	skwz	43700
 𠅤	skwz	0
-𫎫	skwz	0
 永登	skxa	437000
 竟敢	skxc	3440000
 𧩍	skxg	0
@@ -79983,7 +76965,6 @@ encoder:
 端面	slgj	779000
 諯	slgl	33400
 𧪪	slgl	0
-𫎬	slgl	0
 𧭬	slgn	0
 𧬳	slgu	0
 调转	slhb	982000
@@ -80000,7 +76981,6 @@ encoder:
 𥂬	sljl	0
 譞	sljr	39000
 𧭴	sljr	0
-𫎸	sljr	0
 𧪚	slju	0
 调唆	sljz	38000
 褱	slkr	35100
@@ -80109,10 +77089,8 @@ encoder:
 产权	smfx	60600000
 放大	smgd	41400000
 訞	smgd	181000
-𫎕	smgd	0
 颜面	smgj	2900000
 许愿	smgn	17900000
-𫎟	smgn	0
 放在	smgv	116000000
 旋转	smhb	44700000
 託	smhd	8790000
@@ -80137,7 +77115,6 @@ encoder:
 话别	smjy	500000
 产量	smka	33400000
 諥	smkb	47100
-𫎮	smkb	0
 誗	smkd	25500
 许昌	smkk	5350000
 放映	smkl	14900000
@@ -80215,7 +77192,6 @@ encoder:
 旅店	smti	3760000
 𧪝	smtr	0
 𧦝	smua	0
-𫎙	smua	0
 放羊	smuc	1100000
 放慢	smuk	4870000
 放养	smun	1220000
@@ -80240,7 +77216,6 @@ encoder:
 𧫸	smxi	0
 诈骗	smxw	11700000
 诱骗	smxw	1570000
-𫎁	smxw	0
 旗子	smya	1130000
 訖	smyd	286000
 讫	smyd	1080000
@@ -80248,7 +77223,6 @@ encoder:
 𧥷	smyd	87
 𧨮	smye	0
 𧦧	smyi	0
-𫎚	smyi	0
 施加	smyj	5610000
 𧭀	smyk	0
 誘	smym	15100000
@@ -80318,7 +77292,6 @@ encoder:
 讹传	snnb	248000
 齐集	snnf	1890000
 𧮓	snni	0
-𪜥	snni	0
 𠅯	snno	0
 𠆠	snnu	0
 亦会	snob	1530000
@@ -80337,7 +77310,6 @@ encoder:
 変	snor	60900000
 𧫝	snor	0
 𪁂	snor	0
-𫎵	snor	0
 䛜	snos	3310
 训令	snow	186000
 迹	snow	14400000
@@ -80385,7 +77357,6 @@ encoder:
 𧩨	snxm	0
 謏	snxs	56800
 謢	snxs	646000
-𫎭	snxs	0
 谁也	snyi	17500000
 𧦭	snyi	0
 𧥰	snym	0
@@ -80398,7 +77369,6 @@ encoder:
 交融	soaj	7530000
 詥	soaj	73600
 认可	soaj	34000000
-𪯽	soaj	0
 𣦮	soak	0
 論	soal	48300000
 𧨦	soal	0
@@ -80443,13 +77413,10 @@ encoder:
 𩓉	soeg	0
 𠲩	soej	0
 𡮇	soek	0
-𫁕	soek	0
 文献	soel	67800000
 认真	soel	107000000
 㲞	soem	4290
 𨿼	soen	0
-𪟿	soeo	0
-𪯿	soeo	0
 离散	soeq	2610000
 㐮	soer	6890
 㰵	soer	4900
@@ -80500,7 +77467,6 @@ encoder:
 𢒶	sojg	0
 讑	sojl	23200
 𧭆	sojl	0
-𪰃	sojl	0
 文史	sojo	11800000
 𠓬	sojo	0
 䘱	sojr	4660
@@ -80518,7 +77484,6 @@ encoder:
 刘	sokd	390000000
 𣁌	soke	0
 效果	sokf	223000000
-𪞿	sokg	0
 交由	soki	4280000
 文昌	sokk	5580000
 交界	soko	6150000
@@ -80537,7 +77502,6 @@ encoder:
 𣁘	solj	0
 譮	solk	205000
 认罪	solk	3430000
-𪯼	solk	0
 文山	soll	8110000
 斖	soll	36100
 𡵡	soll	0
@@ -80555,7 +77519,6 @@ encoder:
 𣁄	somb	0
 交手	somd	4560000
 六千	some	5180000
-𪞺	some	0
 𣓰	somf	0
 𧧶	somf	0
 文告	somj	1290000
@@ -80574,7 +77537,6 @@ encoder:
 交付	sond	16800000
 斉	sond	2190000
 齐	sond	123000000
-𪯹	sond	0
 交集	sonf	4280000
 文体	sonf	20400000
 文集	sonf	86000000
@@ -80582,7 +77544,6 @@ encoder:
 𣠛	sonf	0
 𥗱	song	0
 交代	sonh	18900000
-𪜤	sonh	0
 交售	sonj	272000
 剂	sonk	57400000
 剤	sonk	26000000
@@ -80598,7 +77559,6 @@ encoder:
 效仿	sons	3910000
 𢥗	sonw	0
 﨎	sonx	31500
-𪰂	sonx	0
 认命	sooa	1920000
 交待	soob	7420000
 𧨀	soob	0
@@ -80642,7 +77602,6 @@ encoder:
 文采	sopf	4500000
 顏	sopg	12900000
 𠷗	sopj	0
-𪵱	sopq	0
 交锋	sopr	6450000
 𪃛	sopr	0
 诊所	sopv	12000000
@@ -80656,7 +77615,6 @@ encoder:
 六月	soqv	39900000
 论处	sori	785000
 郊外	sori	8910000
-𪡑	sori	0
 𠞬	sork	0
 离解	sorl	130000
 𩘍	sorq	0
@@ -80682,9 +77640,7 @@ encoder:
 论调	sosl	2100000
 义诊	soso	2200000
 论文	soso	163000000
-𪯻	soso	0
 𡖍	sosr	0
-𫌯	sosr	0
 𣁕	soss	0
 交谈	sosu	23200000
 离谱	sosu	4470000
@@ -80693,7 +77649,6 @@ encoder:
 斏	sosx	21500
 訡	sosx	17800
 𣂂	sote	0
-𪞾	sotr	0
 效应	sotv	31000000
 诊疗	soty	5430000
 交差	soub	2730000
@@ -80731,7 +77686,6 @@ encoder:
 交通	sowx	309000000
 𪓖	sowx	0
 文字	sowy	364000000
-𪰁	sowy	0
 六安	sowz	3960000
 忞	sowz	136000
 文安	sowz	647000
@@ -80757,7 +77711,6 @@ encoder:
 交际	soyb	8230000
 㐎	soyd	4540
 訜	soyd	81700
-𫎖	soyd	0
 离异	soye	6100000
 交加	soyj	5180000
 效力	soym	12900000
@@ -80771,7 +77724,6 @@ encoder:
 𦑋	soyy	0
 𧬈	soyy	0
 𩕝	sozg	0
-𪞽	sozg	0
 㐫	sozi	4660
 㓙	sozi	3910
 訩	sozi	23900
@@ -80826,7 +77778,6 @@ encoder:
 𢒲	spii	0
 譒	spki	31900
 𧭕	spll	0
-𫎒	spls	0
 謟	spnb	31900
 谣传	spnb	1180000
 䜠	sppl	7950
@@ -80837,13 +77788,11 @@ encoder:
 诉说	spsv	10400000
 诉状	sptg	1500000
 𧝢	spur	0
-𫍻	spvv	0
 䛵	spwx	3410
 䛀	spxs	4150
 譌	spyu	267000
 𩑁	spyu	0
 謑	spzg	52100
-𫍸	spzm	0
 𧩒	spzy	0
 𧫈	sqaj	0
 𧩠	sqan	0
@@ -80851,7 +77800,6 @@ encoder:
 望都	sqby	1180000
 𠅪	sqcc	0
 訉	sqda	79800
-𪜡	sqda	0
 讽刺	sqfl	9380000
 设想	sqfl	14500000
 望奎	sqgb	226000
@@ -80994,7 +77942,6 @@ encoder:
 衣料	srut	5320000
 𢽯	srvm	0
 衣襟	srwf	2860000
-𪬊	srwz	0
 諍	srxb	244000
 诌	srxb	534000
 诤	srxb	1020000
@@ -81005,7 +77952,6 @@ encoder:
 𧪭	sryk	0
 𧩷	sryw	0
 䛄	sryy	3380
-𫎛	sryy	0
 𧪛	srza	0
 𧦷	srzo	0
 𧝾	srzr	0
@@ -81014,7 +77960,6 @@ encoder:
 𧭺	ssae	0
 𠆖	ssaj	0
 该项	ssbg	2910000
-𪤢	ssbs	0
 议长	ssch	1340000
 议事	ssdj	27700000
 辩护	ssdw	6310000
@@ -81032,7 +77977,6 @@ encoder:
 譠	sska	1040000
 议题	sska	5740000
 𧬤	sskb	0
-𫎷	sskb	0
 𧫱	sske	0
 𧫾	sskg	0
 識	sskh	14300000
@@ -81061,7 +78005,6 @@ encoder:
 𧧣	ssoz	0
 𧫢	ssqc	0
 𧦑	ssqd	0
-𫍶	ssrh	0
 谅解	ssrl	24800000
 辩解	ssrl	4220000
 䜞	ssrn	3860
@@ -81081,7 +78024,6 @@ encoder:
 謪	ssul	27600
 謫	ssul	237000
 谪	ssul	861000
-𫎎	ssux	0
 誩	ssvv	41700
 𧨟	ssvv	0
 諪	sswa	121000
@@ -81121,7 +78063,6 @@ encoder:
 𧪠	stma	0
 𧧉	stmh	0
 𧮠	stmk	0
-𫎌	stnn	0
 𧨱	stra	0
 𧜫	strh	0
 𧋲	stri	0
@@ -81139,7 +78080,6 @@ encoder:
 𧫨	stzl	0
 𧜍	stzr	0
 立于	suad	3640000
-𫂒	suad	0
 𥫉	suae	0
 谈天	suag	2640000
 竒	suaj	319000
@@ -81148,7 +78088,6 @@ encoder:
 𥪼	suaj	0
 𨶼	suaj	0
 𩐥	suaj	0
-𪸝	suaj	0
 𥩬	suak	0
 𩐡	suak	0
 韴	sual	25700
@@ -81162,7 +78101,6 @@ encoder:
 𥩳	subd	0
 𥩸	subd	0
 𥪸	subd	0
-𫂗	subd	0
 立项	subg	5860000
 𥪯	subg	0
 𩕉	subg	0
@@ -81178,14 +78116,12 @@ encoder:
 赣	subl	17800000
 𩐵	subl	0
 𩑅	subl	0
-𫏧	subl	0
 氃	subm	28100
 𥪤	subm	0
 𤗔	subn	0
 𥪢	subo	0
 𥪹	subq	0
 䴀	subr	16200
-𫜋	subr	0
 𥩺	subu	0
 立志	subw	8710000
 勭	suby	1140000
@@ -81206,14 +78142,12 @@ encoder:
 𥪏	sucx	0
 𥪳	sucx	0
 𥩩	sueb	0
-𫗞	sueb	0
 𥪓	suec	0
 竍	sued	37500
 𧫵	suee	0
 𩐷	suef	0
 𩕆	sueg	0
 𥩪	suej	0
-𫂖	suej	0
 䇎	suek	3750
 商朝	suek	729000
 商南	suel	305000
@@ -81223,7 +78157,6 @@ encoder:
 𩐠	sueo	0
 彰	suep	16500000
 𪅂	suer	0
-𫝈	suer	0
 遧	suew	32400
 𢥺	suew	0
 攱	suex	243000
@@ -81292,11 +78225,9 @@ encoder:
 商战	suij	2920000
 站	suij	2410000000
 𠶷	suij	0
-𫂕	suij	0
 谦虚	suik	13300000
 竬	suil	23700
 𥫇	suil	0
-𫗜	suil	0
 𢡃	suiw	0
 㪗	suix	3930
 𢾑	suix	0
@@ -81306,7 +78237,6 @@ encoder:
 帝国	sujc	47700000
 𢨅	sujc	0
 䫓	sujg	3580
-𪥡	sujg	0
 𢧂	sujh	0
 䇍	suji	3690
 立足	suji	20400000
@@ -81322,8 +78252,6 @@ encoder:
 𥫀	sujl	0
 𧷞	sujl	0
 敨	sujm	80100
-𪯲	sujm	0
-𫂘	sujm	0
 𨿦	sujn	0
 旁听	sujp	4610000
 𤬃	sujp	0
@@ -81349,7 +78277,6 @@ encoder:
 辨别	sujy	9120000
 部	sujy	966000000
 郶	sujy	19600
-𫂟	sujz	0
 商量	suka	32000000
 䪦	sukb	3650
 童	sukb	55200000
@@ -81377,12 +78304,9 @@ encoder:
 𩐲	sukl	0
 竗	sukm	23000
 𢾚	sukm	0
-𪶉	sukm	0
 商界	suko	9830000
-𫗝	suko	0
 𣂺	sukp	0
 𩐙	sukp	0
-𫗟	sukp	0
 䇌	sukq	3770
 𩐯	sukq	0
 歆	sukr	3530000
@@ -81405,14 +78329,12 @@ encoder:
 䪧	suky	3520
 謭	suky	25500
 谫	suky	97700
-𪟢	suky	0
 竜	sukz	13300000
 𡔕	sulb	0
 𥩢	sulc	0
 商	suld	677000000
 啇	suld	96900
 𠹧	suld	0
-𪫋	sule	0
 䫕	sulg	3610
 端	sulg	128000000
 韺	sulg	80800
@@ -81427,8 +78349,6 @@ encoder:
 𧷮	sull	0
 敵	sulm	20300000
 𣯵	sulm	0
-𪯩	sulm	0
-𪯭	sulm	0
 𥪞	sulo	0
 𥪧	sulo	0
 商贩	sulp	5030000
@@ -81449,7 +78369,6 @@ encoder:
 𢥮	sulw	0
 𢥿	sulw	0
 𥫒	sulw	0
-𪬼	sulw	0
 𠢗	suly	0
 𢁆	suly	0
 𨝗	suly	0
@@ -81465,7 +78384,6 @@ encoder:
 𥪺	sumh	0
 𥫃	sumh	0
 𣄬	sumi	0
-𫂟	sumj	0
 剷	sumk	257000
 𩡕	sumk	0
 竵	suml	136000
@@ -81474,8 +78392,6 @@ encoder:
 𥫔	suml	0
 𧗛	suml	0
 𧗜	suml	0
-𪱬	suml	0
-𪿯	suml	0
 産	summ	34200000
 谈笑	summ	3910000
 彦	sump	11800000
@@ -81539,19 +78455,15 @@ encoder:
 商船	supq	2500000
 遃	supw	19100
 𢣪	supw	0
-𪭋	supw	0
 㜪	supz	4230
 𡣎	supz	0
-𫂐	suqa	0
 竌	suqd	20800
 𥩕	suqd	0
 𩔍	suqg	0
 颯	suqi	804000
 𧪈	suqk	0
-𪟏	suqk	0
 𥃚	suql	0
 飒	suqo	506000
-𪭙	suqw	0
 竐	suqx	18400
 𥩘	sura	0
 𡎿	surb	0
@@ -81561,22 +78473,17 @@ encoder:
 𡙴	surg	0
 𤇯	surh	0
 𩑂	suri	0
-𪭂	suri	0
-𫂎	suri	0
 竘	surj	180000
 𠹪	surj	0
 𥩮	surj	0
 𩐝	surj	0
 详解	surl	14100000
 𧶜	surl	0
-𫂓	surl	0
 𤙺	surm	0
 𥪴	surm	0
 𩐨	surm	0
-𫂛	surm	0
 𣢦	suro	0
 𥪔	suro	0
-𫂜	suro	0
 䇋	surr	3710
 𥪫	surr	0
 𪅑	surr	0
@@ -81597,7 +78504,6 @@ encoder:
 鴗	surz	43000
 𥩞	surz	0
 𥪥	surz	0
-𫂑	surz	0
 旁证	susa	601000
 辨证	susa	5340000
 𢤴	susb	0
@@ -81628,7 +78534,6 @@ encoder:
 𧟛	susr	0
 𪆿	susr	0
 商议	suss	5970000
-𫂚	suss	0
 商谈	susu	4390000
 竝	susu	203000
 详谈	susu	1630000
@@ -81642,7 +78547,6 @@ encoder:
 𣂅	sute	0
 𣂆	sute	0
 𣂉	sute	0
-𫗚	sute	0
 𩑈	sutg	0
 商店	suti	96800000
 𥪑	sutm	0
@@ -81689,7 +78593,6 @@ encoder:
 谦逊	suwy	1690000
 𥩾	suwy	0
 𧪶	suwy	0
-𫂝	suwy	0
 立案	suwz	11000000
 谈心	suwz	5070000
 𥿿	suwz	0
@@ -81727,41 +78630,29 @@ encoder:
 甋	suys	26700
 𩐛	suys	0
 𩐶	suys	0
-𫂔	suys	0
 䇃	suyy	3930
 翊	suyy	3200000
 譾	suyy	28800
 𦒍	suyy	0
-𫂙	suyy	0
-𫆞	suyy	0
-𫎺	suyy	0
 𥪲	suyz	0
 㡣	suzc	36300
-𫗛	suze	0
 𩐱	suzf	0
-𫐸	suzf	0
 𥪦	suzg	0
-𪥤	suzg	0
 𦁋	suzh	0
 𥩭	suzj	0
-𪡷	suzj	0
 详细	suzk	407000000
 𥪋	suzk	0
-𪾋	suzk	0
 𥉩	suzl	0
 𥪄	suzl	0
 𥫎	suzl	0
 妾	suzm	6730000
 竢	suzm	156000
 𣯡	suzm	0
-𫎨	suzm	0
-𫎯	suzm	0
 𥩲	suzo	0
 𥪧	suzo	0
 𩐰	suzo	0
 𧪜	suzq	0
 立约	suzr	192000
-𫂏	suzs	0
 𢠀	suzw	0
 韷	suzz	22600
 𥩚	suzz	0
@@ -81783,7 +78674,6 @@ encoder:
 率领	svow	9680000
 说服	svqy	16300000
 誂	svrd	159000
-𫎠	svrd	0
 说谎	svse	2920000
 说话	svsm	77300000
 说法	svvb	56600000
@@ -81819,7 +78709,6 @@ encoder:
 谉	swki	25200
 𧭟	swkm	0
 𧭈	swla	0
-𫎹	swla	0
 誼	swlc	3400000
 谊	swlc	5730000
 𧨏	swlc	0
@@ -81843,7 +78732,6 @@ encoder:
 𧬵	swoe	0
 𧨾	swof	0
 𧮈	swoj	0
-𫎂	swoj	0
 𧮎	swos	0
 𧩮	swox	0
 𧬯	swoy	0
@@ -81852,10 +78740,7 @@ encoder:
 𧭂	swrb	0
 訦	swrd	38800
 𧨾	swrf	0
-𫎡	swrh	0
-𫎃	swrn	0
 詑	swrr	502000
-𫎜	swrr	0
 𧭠	swru	0
 䛷	swry	3290
 谜语	swsb	7030000
@@ -81871,15 +78756,12 @@ encoder:
 這	swvv	166000000
 𧬪	swwf	0
 𧮘	swwf	0
-𫎇	swxl	0
 𧨠	swxs	0
 𧭋	swxs	0
 𧧕	swya	0
 诧异	swye	7050000
 謆	swyy	38700
-𫎳	swyy	0
 䛪	swyz	3410
-𫎍	swzl	0
 𧧼	swzm	0
 变形	sxae	16500000
 𦫍	sxae	0
@@ -81898,14 +78780,12 @@ encoder:
 𧮕	sxcu	0
 变现	sxcv	3640000
 变换	sxdr	15300000
-𪬓	sxdw	0
 䚼	sxed	3360
 变革	sxee	16200000
 䛯	sxej	3400
 变故	sxej	3110000
 䛝	sxel	3470
 良莠	sxem	329000
-𫒯	sxeq	0
 变卖	sxex	1780000
 良药	sxez	3460000
 译本	sxfa	1920000
@@ -81916,7 +78796,6 @@ encoder:
 𧫞	sxfv	0
 訣	sxgd	1760000
 诀	sxgd	5240000
-𫒭	sxge	0
 良辰	sxgh	2800000
 变态	sxgs	24100000
 译码	sxgx	518000
@@ -81924,7 +78803,6 @@ encoder:
 詖	sxia	49200
 诐	sxia	49000
 变频	sxik	17700000
-𫎊	sxil	0
 㐧	sxim	4640
 諝	sxiq	38700
 谞	sxiq	55500
@@ -81944,9 +78822,7 @@ encoder:
 誦	sxld	1270000
 诵	sxld	5190000
 𧧱	sxll	0
-𫍾	sxly	0
 朗县	sxlz	126000
-𫎀	sxmf	0
 变种	sxmj	8060000
 良种	sxmj	6580000
 譎	sxml	251000
@@ -81964,7 +78840,6 @@ encoder:
 㮾	sxqf	3920
 𧫫	sxqq	0
 𧩴	sxrf	0
-𫎓	sxri	0
 译名	sxrj	8510000
 讇	sxrn	20200
 欴	sxro	125000
@@ -81973,8 +78848,6 @@ encoder:
 变色	sxry	7560000
 𪁜	sxrz	0
 良言	sxsa	1710000
-𫍴	sxsa	0
-𫍴	sxsb	0
 朗读	sxse	10500000
 謘	sxse	56300
 诵读	sxse	1740000
@@ -81991,7 +78864,6 @@ encoder:
 变为	sxuv	14100000
 变法	sxvb	1800000
 郎溪	sxvp	503000
-𪜋	sxvv	0
 诀窍	sxwb	5590000
 变速	sxwf	9310000
 变迁	sxwm	7200000
@@ -82023,13 +78895,10 @@ encoder:
 良缘	sxzz	5010000
 誳	sxzz	38900
 𧬲	sxzz	0
-𫎩	sxzz	0
 方形	syae	5340000
-𪰐	syag	0
 㫌	syai	4470
 方正	syai	16200000
 𣄍	syai	0
-𪰕	syai	0
 㫊	syaj	3950
 旑	syaj	38900
 旖	syaj	2970000
@@ -82056,9 +78925,7 @@ encoder:
 𪗅	sybx	0
 旔	syby	22200
 䶒	sybz	3770
-𪰓	sych	0
 𪗈	sycr	0
-𪯴	sycz	0
 记事	sydj	21900000
 方才	sydm	7420000
 𣄃	syec	0
@@ -82067,10 +78934,8 @@ encoder:
 记载	syeh	18300000
 譔	syeo	70000
 𣄗	syeo	0
-𫎑	syeo	0
 𣄄	syep	0
 𣄨	syep	0
-𪰝	syeu	0
 旚	syfb	24400
 𣄔	syfb	0
 𣄎	syfd	0
@@ -82090,16 +78955,13 @@ encoder:
 䛉	syhd	3360
 𣄞	syhk	0
 𣄟	syia	0
-𫎔	syia	0
 𣄒	syib	0
-𪰞	syib	0
 𠅄	syid	0
 䗠	syii	3730
 譅	syii	68500
 𧖊	syii	0
 𪚎	syii	0
 𣄅	syij	0
-𪰎	syij	0
 词频	syik	247000
 𢄲	syil	0
 㫍	syim	3980
@@ -82115,7 +78977,6 @@ encoder:
 方圆	syjj	7350000
 𣃫	syjl	0
 𧬂	syjl	0
-𪰘	syjl	0
 𣃴	syjo	0
 𣃷	syjo	0
 弯路	syjr	3230000
@@ -82130,9 +78991,7 @@ encoder:
 𩐓	syka	0
 𣄛	sykb	0
 𣄢	sykb	0
-𪰟	sykc	0
 𠛍	sykd	0
-𪰚	syke	0
 𣄙	sykg	0
 旘	sykh	24600
 𣄞	sykh	0
@@ -82154,14 +79013,12 @@ encoder:
 𣃰	sylo	0
 𪗑	sylr	0
 𪗒	sylr	0
-𪰗	sylx	0
 誔	symb	288000
 𡌼	symb	0
 孪生	symc	2190000
 诞生	symc	55800000
 旗	syme	66600000
 𣃬	syme	0
-𫎐	syme	0
 𣄉	symf	0
 𧧇	symf	0
 𠅑	symg	0
@@ -82171,13 +79028,11 @@ encoder:
 诞	symi	4750000
 𧌱	symi	0
 𧐈	symi	0
-𪯮	symi	0
 方程	symj	4030000
 𣃥	symk	0
 𣃧	symk	0
 𣃵	symk	0
 𣃻	symk	0
-𪟔	symk	0
 斾	syml	137000
 𢄧	syml	0
 𣄘	syml	0
@@ -82188,8 +79043,6 @@ encoder:
 𣄓	symm	0
 𩀥	symn	0
 𩙴	symn	0
-𪰒	symn	0
-𫍿	symn	0
 放	symo	653000000
 𩜢	symo	0
 旂	symp	1390000
@@ -82201,9 +79054,7 @@ encoder:
 𣃮	symr	0
 𩺯	symr	0
 訯	syms	19600
-𪬝	symw	0
 旇	symx	477000
-𪰍	symx	0
 施	symy	126000000
 斿	symy	1320000
 𡥮	symy	0
@@ -82220,7 +79071,6 @@ encoder:
 齋	synk	4690000
 齍	synl	30700
 齎	synl	193000
-𪰜	synl	0
 𪗉	synm	0
 记仇	synq	735000
 𦠃	synq	0
@@ -82236,8 +79086,6 @@ encoder:
 䶒	synz	3770
 𣄀	syoc	0
 㫃	syod	8890
-𪯷	syoe	0
-𪰛	syoe	0
 𣃘	syoi	0
 𣃺	syoj	0
 㫆	syok	3550
@@ -82252,7 +79100,6 @@ encoder:
 𣄝	syoo	0
 𦠕	syoo	0
 𪗌	syoo	0
-𪰙	syoo	0
 謬	syop	751000
 谬	syop	2260000
 𧬶	syop	0
@@ -82262,8 +79109,6 @@ encoder:
 𣄪	syou	0
 旍	syow	146000
 𣃠	syow	0
-𪟓	syoy	0
-𪰌	sypd	0
 方针	sype	23600000
 𩕇	sypg	0
 旙	sypk	29000
@@ -82283,10 +79128,8 @@ encoder:
 𦦏	syrn	0
 𣃦	syro	0
 𩝦	syro	0
-𪵋	syro	0
 膂	syrq	155000
 𣃽	syrr	0
-𪬝	syrw	0
 鴋	syrz	36000
 𣃿	syrz	0
 方言	sysa	10500000
@@ -82299,7 +79142,6 @@ encoder:
 䜧	sysi	3590
 譅	sysi	68500
 𣄕	sysk	0
-𪰖	sysn	0
 谬论	syso	1400000
 𣁅	syso	0
 𣃚	sysq	0
@@ -82316,7 +79158,6 @@ encoder:
 乻	syty	43700
 𣃶	syty	0
 方差	syub	1020000
-𪰑	syuc	0
 旞	syug	26100
 词类	syug	308000
 𣄚	syug	0
@@ -82330,7 +79171,6 @@ encoder:
 旐	syvr	69500
 𧥟	syvv	0
 𧦫	syvv	0
-𫒝	syvv	0
 㫎	sywf	3740
 记述	sywf	2610000
 𣄈	sywf	0
@@ -82338,7 +79178,6 @@ encoder:
 𣄁	sywx	0
 方案	sywz	199000000
 誋	sywz	103000
-𫎥	sywz	0
 旔	syxb	22200
 旋	syxi	23800000
 𣃣	syxi	0
@@ -82346,7 +79185,6 @@ encoder:
 记录	syxk	300000000
 旎	syxr	5590000
 讔	syxw	34000
-𪰔	syxw	0
 𠆜	syxz	0
 𪗍	syxz	0
 𣃗	syyd	0
@@ -82386,7 +79224,6 @@ encoder:
 𩓗	szeg	0
 育苗	szek	2680000
 𠔚	szeo	0
-𫇹	szer	0
 刻薄	szev	2650000
 𢻉	szex	0
 罋	szez	23900
@@ -82418,7 +79255,6 @@ encoder:
 袬	szjr	31500
 䜈	szkf	4050
 𤰸	szki	0
-𫌄	szki	0
 𡄚	szkl	0
 𡅟	szkl	0
 玅	szkm	110000
@@ -82437,7 +79273,6 @@ encoder:
 誒	szma	254000
 诶	szma	8600000
 畜生	szmc	3850000
-𪞺	szme	0
 𤣧	szmi	0
 育种	szmj	4940000
 充血	szml	3930000
@@ -82487,7 +79322,6 @@ encoder:
 𠛳	szoy	0
 𧭞	szoz	0
 𠘺	szqd	0
-𪟈	szqk	0
 𣣎	szqr	0
 𠂅	szqs	0
 逳	szqw	30900
@@ -82495,10 +79329,8 @@ encoder:
 充	szrd	82000000
 𠅵	szrd	0
 𩒘	szrg	0
-𫇖	szri	0
 𩩇	szrl	0
 𪁇	szrr	0
-𫇲	szrr	0
 育雏	szrx	328000
 𠡌	szry	0
 𠡜	szry	0
@@ -82516,7 +79348,6 @@ encoder:
 率	szve	325000000
 𧧈	szvv	0
 牽	szwm	9280000
-𪻖	szwm	0
 充裕	szwo	4210000
 夣	szwr	93700
 充实	szwt	17200000
@@ -82526,7 +79357,6 @@ encoder:
 詜	szxs	18600
 𧪅	szxw	0
 辫子	szya	5790000
-𫎘	szyo	0
 甕	szys	1500000
 𠜨	szys	0
 𤭕	szys	0
@@ -82539,7 +79369,6 @@ encoder:
 詘	szzi	40900
 诎	szzi	268000
 𨏯	szzj	0
-𪞇	szzj	0
 畜	szzk	17200000
 𠛑	szzk	0
 𠾃	szzl	0
@@ -82576,7 +79405,6 @@ encoder:
 病号	taja	454000
 𤺡	tajb	0
 病因	tajd	5930000
-𪾣	tajl	0
 𣪪	tajq	0
 痘	taju	15900000
 㾘	tako	4810
@@ -82594,7 +79422,6 @@ encoder:
 症侯	tanx	121000
 病愈	taoa	650000
 病人	taod	28700000
-𪾟	taog	0
 𤶮	taoh	0
 𤻞	taoo	0
 㽴	taos	4690
@@ -82603,7 +79430,6 @@ encoder:
 病危	targ	1950000
 㾐	tark	5890
 𤷋	tarm	0
-𪾕	tars	0
 病变	tasx	5780000
 病畜	tasz	120000
 病症	tata	5830000
@@ -82643,7 +79469,6 @@ encoder:
 壮大	tbgd	19800000
 装有	tbgq	5500000
 装车	tbhe	2080000
-𪾥	tbhz	0
 庄园	tbjb	6360000
 㿒	tbjd	5080
 凌晨	tbkg	29200000
@@ -82661,7 +79486,6 @@ encoder:
 装入	tbod	3690000
 装饰	tbom	36400000
 𤷖	tbor	0
-𪾤	tbow	0
 装船	tbpq	947000
 𤻆	tbrg	0
 装备	tbrk	76000000
@@ -82737,13 +79561,9 @@ encoder:
 𠘓	tdam	0
 𠗍	tdan	0
 𠖸	tdar	0
-𪞩	tdar	0
 㓕	tdau	4080
-𪞚	tdax	0
-𪞤	tdbb	0
 𠗭	tdbd	0
 𤸟	tdbd	0
-𪞯	tdbg	0
 冮	tdbi	1020000
 凋	tdbj	3080000
 𠸆	tdbj	0
@@ -82763,7 +79583,6 @@ encoder:
 𠙖	tdcq	0
 𪅯	tdcr	0
 馮	tdcu	4480000
-𪞬	tdcu	0
 憑	tdcw	8570000
 𨝭	tdcy	0
 㓖	tdeb	4250
@@ -82779,7 +79598,6 @@ encoder:
 𠗘	tdeo	0
 凘	tdep	48800
 𣁰	tdep	0
-𪰄	tdep	0
 𠙥	tdeq	0
 𣃜	tdes	0
 慿	tdew	76200
@@ -82800,21 +79618,15 @@ encoder:
 𤈀	tdfu	0
 头	tdgd	340000000
 𣂇	tdgk	0
-𪟇	tdgk	0
 𠗇	tdgu	0
 𠗊	tdhb	0
 㭍	tdhf	4250
 冴	tdhi	901000
 冻	tdhk	36900000
-𪞫	tdhn	0
-𪞠	tdhy	0
-𪞥	tdih	0
 𠘦	tdil	0
-𪞥	tdir	0
 𠖱	tdis	0
 凛	tdjb	10500000
 𠗃	tdjd	0
-𪨅	tdjd	0
 楶	tdjf	41300
 𣓫	tdjf	0
 𣙤	tdjf	0
@@ -82826,7 +79638,6 @@ encoder:
 凜	tdjm	1250000
 𠘡	tdjm	0
 𣯃	tdjm	0
-𪞭	tdjm	0
 𠗓	tdjq	0
 㖍	tdjr	4050
 况	tdjr	12500000
@@ -82842,13 +79653,10 @@ encoder:
 𠘁	tdjy	0
 𠘐	tdka	0
 𠗔	tdkb	0
-𪞮	tdke	0
 𠘊	tdkg	0
 𠖹	tdki	0
-𪞝	tdki	0
 𠘌	tdkk	0
 𠘔	tdkm	0
-𪞨	tdkq	0
 𠘠	tdkr	0
 𠗹	tdku	0
 冰	tdkv	132000000
@@ -82865,9 +79673,7 @@ encoder:
 𠘎	tdlk	0
 凟	tdll	28400
 凗	tdln	30200
-𪞙	tdlo	0
 闭眼	tdlx	2290000
-𫒩	tdly	0
 𠘅	tdlz	0
 𠗝	tdmb	0
 𡍼	tdmb	0
@@ -82884,17 +79690,14 @@ encoder:
 㓔	tdnd	4150
 凖	tdne	365000
 𠦥	tdne	0
-𪳺	tdnf	0
 准	tdni	141000000
 𠗯	tdnk	0
-𪞞	tdnk	0
 𠘇	tdnp	0
 𤌞	tdnu	0
 㕠	tdnx	4030
 闭合	tdoa	2130000
 㓐	tdob	4810
 闭会	tdob	536000
-𪞣	tdob	0
 㓌	tdoc	4100
 𠗎	tdoc	0
 𠗚	tdoe	0
@@ -82914,7 +79717,6 @@ encoder:
 𠗕	tdor	0
 㓒	tdou	4300
 冷	tdow	150000000
-𪞰	tdow	0
 飡	tdox	53100
 𠖲	tdoy	0
 凇	tdoz	759000
@@ -82923,13 +79725,11 @@ encoder:
 𠘖	tdpl	0
 凈	tdpx	2110000
 𠖵	tdqb	0
-𪞘	tdqd	0
 𩇟	tdql	0
 𠘒	tdqp	0
 垐	tdrb	61600
 𣁻	tdrd	0
 栥	tdrf	80200
-𪲠	tdrf	0
 𣂌	tdri	0
 𧊒	tdri	0
 咨	tdrj	17900000
@@ -82970,11 +79770,9 @@ encoder:
 𠘤	tdsk	0
 闭市	tdsl	181000
 凕	tdso	28200
-𪞛	tdso	0
 𠗩	tdss	0
 𤷟	tdsu	0
 𠗋	tdsw	0
-𪞚	tdsx	0
 𣁾	tdte	0
 𠘛	tdtg	0
 冸	tdub	39400
@@ -82983,21 +79781,14 @@ encoder:
 𣁿	tdvr	0
 𠗈	tdvs	0
 𤶩	tdvs	0
-𪞪	tdwa	0
-𪞧	tdwb	0
 𠗞	tdwd	0
 闭塞	tdwe	2020000
-𪲼	tdwf	0
-𪞱	tdwg	0
 𠗬	tdwl	0
 𠗵	tdws	0
 㓎	tdwx	4070
-𪞢	tdwy	0
 𠖶	tdwz	0
 冿	tdxb	199000
 𠗻	tdxb	0
-𪞟	tdxb	0
-𪞲	tdxc	0
 𠘣	tdxd	0
 决	tdxg	61300000
 凝	tdxi	29700000
@@ -83008,8 +79799,6 @@ encoder:
 𣳆	tdxk	0
 𠘄	tdxm	0
 冹	tdxs	55700
-𪞜	tdxs	0
-𪞦	tdxw	0
 𠗱	tdxx	0
 𠗷	tdxy	0
 凄	tdxz	22000000
@@ -83086,7 +79875,6 @@ encoder:
 𤼚	tezi	0
 𤺔	tezl	0
 𤻜	tezl	0
-𪾡	tezl	0
 𤹖	tfae	0
 麾下	tfai	1970000
 磨灭	tfau	4240000
@@ -83169,7 +79957,6 @@ encoder:
 磨练	tfzh	4280000
 麻绳	tfzj	690000
 麻纱	tfzk	330000
-𪾠	tfzm	0
 麻纺	tfzs	361000
 㡰	tgad	5930
 𢊢	tgad	0
@@ -83180,11 +79967,9 @@ encoder:
 头顶	tgag	11700000
 庑	tgag	554000
 𢉶	tgag	0
-𪪮	tgag	0
 庁	tgai	7380000
 𢇗	tgai	0
 𢉴	tgai	0
-𪪣	tgai	0
 㢊	tgaj	3460
 㢌	tgaj	3890
 㾨	tgaj	5030
@@ -83192,8 +79977,6 @@ encoder:
 𢉔	tgak	0
 𢊮	tgal	0
 𪎯	tgal	0
-𪪡	tgal	0
-𪽲	tgam	0
 𢈷	tgan	0
 𢋛	tgan	0
 𢈮	tgao	0
@@ -83203,7 +79986,6 @@ encoder:
 𢌖	tgaw	0
 𢇱	tgaz	0
 庤	tgbd	823000
-𫝜	tgbj	0
 𤷈	tgbk	0
 𢉜	tgbm	0
 𢈩	tgbo	0
@@ -83232,11 +80014,8 @@ encoder:
 㢅	tgce	3860
 𢌊	tgce	0
 广丰	tgci	1020000
-𪪿	tgci	0
-𪪯	tgcj	0
 廭	tgcl	22800
 𢊷	tgcl	0
-𪪸	tgcl	0
 𢉋	tgcq	0
 𢉑	tgcq	0
 𢉿	tgcu	0
@@ -83246,7 +80025,6 @@ encoder:
 𢊾	tgdl	0
 广播	tgdp	66900000
 𤹘	tgds	0
-𪪵	tgds	0
 焤	tgdu	23000
 𢜆	tgdw	0
 𢇾	tgeb	0
@@ -83283,7 +80061,6 @@ encoder:
 𢈧	tgex	0
 𢉎	tgex	0
 𢻘	tgex	0
-𪪫	tgex	0
 𢇸	tgez	0
 𢈊	tgez	0
 𢉮	tgez	0
@@ -83370,7 +80147,6 @@ encoder:
 𢊹	tggl	0
 庞	tggm	20200000
 庬	tggm	44400
-𪪦	tggn	0
 𢈓	tggq	0
 𢇟	tggr	0
 状态	tggs	303000000
@@ -83381,7 +80157,6 @@ encoder:
 𢉏	tggx	0
 𢈌	tggy	0
 𨟖	tggy	0
-𪪩	tggy	0
 庢	tghb	1470000
 库	tghe	622000000
 𢈽	tghh	0
@@ -83392,25 +80167,20 @@ encoder:
 㡲	tghm	4530
 廐	tghr	58700
 𢇙	tghs	0
-𪪥	tghs	0
 庉	tghz	63900
 𧍽	tgib	0
 𧑢	tgib	0
 𢈶	tgih	0
-𪪰	tgih	0
 蠯	tgii	23700
 𢊚	tgii	0
 𢌆	tgii	0
 店	tgij	604000000
-𪪨	tgij	0
 𢈨	tgik	0
 㢒	tgil	3850
 𢉠	tgil	0
 𢊐	tgio	0
 庛	tgir	461000
-𪪻	tgir	0
 𢉍	tgiu	0
-𪪴	tgiw	0
 头颅	tgix	4670000
 𢇮	tgix	0
 𢈂	tgix	0
@@ -83419,7 +80189,6 @@ encoder:
 𣀫	tgix	0
 𣀯	tgix	0
 𪎘	tgix	0
-𪪤	tgix	0
 𢋄	tgiy	0
 𤶐	tgiy	0
 𢉓	tgiz	0
@@ -83444,7 +80213,6 @@ encoder:
 𢋔	tgjj	0
 𢋢	tgjj	0
 𢋾	tgjj	0
-𪪳	tgjj	0
 𢈴	tgjk	0
 𢉨	tgjk	0
 㢗	tgjl	4130
@@ -83463,22 +80231,17 @@ encoder:
 𢋖	tgjs	0
 㢄	tgju	4210
 𤉽	tgju	0
-𪪽	tgju	0
-𫎾	tgju	0
 𢇵	tgjx	0
 𢈞	tgjx	0
 廍	tgjy	57400
 鄌	tgjy	42600
 𢌓	tgjy	0
-𪪭	tgjy	0
-𪪲	tgjy	0
 𢉈	tgjz	0
 㡺	tgka	3910
 𢋃	tgka	0
 𢌁	tgka	0
 𢌐	tgka	0
 𩐕	tgka	0
-𪪹	tgka	0
 㢆	tgkb	4090
 𢋂	tgkb	0
 䨾	tgkc	3900
@@ -83562,7 +80325,6 @@ encoder:
 𢈃	tglr	0
 𢈥	tglr	0
 𢊿	tglr	0
-𪪱	tglr	0
 廲	tglt	51500
 头骨	tglw	2470000
 廰	tglw	183000
@@ -83717,7 +80479,6 @@ encoder:
 㢖	tgpk	3640
 廞	tgpr	40300
 𢈕	tgpr	0
-𫝌	tgpr	0
 𢈅	tgps	0
 𢇥	tgqe	0
 㢏	tgqk	3770
@@ -83738,7 +80499,6 @@ encoder:
 𠝇	tgrk	0
 𠝡	tgrk	0
 𢋡	tgrk	0
-𫝝	tgrk	0
 广角	tgrl	9800000
 𪎬	tgrl	0
 㢝	tgrm	3630
@@ -83761,7 +80521,6 @@ encoder:
 𣩇	tgrr	0
 𪈾	tgrr	0
 𪎠	tgrr	0
-𪥉	tgrr	0
 㡱	tgrs	6700
 底	tgrs	123000000
 𢉕	tgrs	0
@@ -83772,7 +80531,6 @@ encoder:
 庖	tgry	1860000
 𢋽	tgry	0
 𪎛	tgry	0
-𫒫	tgry	0
 𢇼	tgrz	0
 𩾦	tgrz	0
 𪇵	tgrz	0
@@ -83786,7 +80544,6 @@ encoder:
 𢉩	tgsk	0
 𤸙	tgsl	0
 广义	tgso	4090000
-𪪢	tgso	0
 庡	tgsr	1650000
 𢊭	tgsr	0
 𢌀	tgsr	0
@@ -83822,8 +80579,6 @@ encoder:
 䗪	tgui	3630
 𤺗	tguk	0
 𧷫	tgul	0
-𪪶	tgul	0
-𪪺	tgul	0
 㫂	tgup	5570
 鷓	tgur	161000
 鹧	tgur	894000
@@ -83880,16 +80635,13 @@ encoder:
 𢇳	tgxi	0
 𢈻	tgxi	0
 𥀱	tgxi	0
-𪪼	tgxi	0
 唐	tgxj	113000000
 𢈪	tgxj	0
 𨇭	tgxj	0
-𪪧	tgxj	0
 剫	tgxk	63500
 劆	tgxk	60400
 康	tgxk	155000000
 𢊺	tgxk	0
-𪪷	tgxk	0
 庸	tgxl	18700000
 𢊟	tgxl	0
 𢾅	tgxm	0
@@ -83901,7 +80653,6 @@ encoder:
 𢉄	tgxr	0
 𣤤	tgxr	0
 𪃒	tgxr	0
-𫝁	tgxr	0
 废	tgxs	31900000
 庹	tgxs	2160000
 𢊤	tgxs	0
@@ -83911,7 +80662,6 @@ encoder:
 𥹺	tgxu	0
 𢈸	tgxw	0
 廊	tgxy	31900000
-𪪬	tgxy	0
 𢊨	tgxz	0
 痞子	tgya	7660000
 邝	tgya	1240000
@@ -83958,7 +80708,6 @@ encoder:
 𢋘	tgzn	0
 𢌈	tgzn	0
 𪎣	tgzn	0
-𪪪	tgzo	0
 𢈋	tgzq	0
 𢇰	tgzr	0
 𤺤	tgzr	0
@@ -84099,7 +80848,6 @@ encoder:
 䉾	tiru	3840
 𢘠	tirw	0
 邶	tiry	281000
-𪜝	tiry	0
 装	tisr	459000000
 闽北	titr	584000
 𤮪	tiue	0
@@ -84112,7 +80860,6 @@ encoder:
 𤼁	tiwl	0
 𥦚	tiwq	0
 㾎	tixa	4550
-𪾛	tixm	0
 𠬧	tixs	0
 𠭼	tixx	0
 㼱	tiys	5410
@@ -84207,7 +80954,6 @@ encoder:
 冰箱	tkmf	25200000
 𤹊	tkmi	0
 㾪	tkml	4910
-𪾧	tkmo	0
 𤹾	tkmz	0
 冰川	tknd	4200000
 𤻵	tknh	0
@@ -84243,7 +80989,6 @@ encoder:
 间断	tkzu	7990000
 𤻗	tkzu	0
 闬	tlae	47900
-𫕲	tlae	0
 阕	tlag	3020000
 𨸉	tlaj	0
 阓	tlal	39000
@@ -84253,7 +80998,6 @@ encoder:
 阇	tlbm	262000
 𤻂	tlbu	0
 闱	tlby	775000
-𫕵	tlby	0
 闫	tlcd	9250000
 闻	tlce	82000000
 㿂	tlcm	7320
@@ -84275,7 +81019,6 @@ encoder:
 闼	tlgw	870000
 闳	tlgz	445000
 𨸅	tlhb	0
-𫕷	tlhm	0
 门口	tlja	47000000
 阈	tlja	1230000
 阃	tljf	656000
@@ -84291,7 +81034,6 @@ encoder:
 阐	tlke	971000
 闸	tlki	14400000
 阊	tlkk	854000
-𫕰	tlkl	0
 𡭜	tlko	0
 𨸇	tlko	0
 瘝	tlkv	210000
@@ -84310,11 +81052,8 @@ encoder:
 癭	tllz	62500
 门生	tlmc	1070000
 𨸃	tlmh	0
-𫕸	tlnf	0
 阀	tlnh	23100000
-𫕶	tlni	0
 𤼒	tlnl	0
-𫕴	tlno	0
 阋	tlnr	483000
 𨸋	tlnu	0
 䦷	tlob	16200
@@ -84328,7 +81067,6 @@ encoder:
 𤶨	tlrr	0
 䦶	tlrx	14900
 	tlrx	0
-𫕭	tlsb	0
 𨸁	tlsh	0
 门市	tlsl	8380000
 闹	tlsl	43300000
@@ -84338,7 +81076,6 @@ encoder:
 闶	tlsq	364000
 阆	tlsx	611000
 𨸂	tlsy	0
-𫕬	tlte	0
 门将	tltr	4010000
 门廊	tlts	414000
 门灯	tlua	155000
@@ -84360,9 +81097,7 @@ encoder:
 𨸄	tlxo	0
 𨸀	tlya	0
 门巴	tlyi	246000
-𫕮	tlyw	0
 阘	tlyy	33400
-𫕳	tlze	0
 阖	tlzl	2000000
 𨷿	tlzm	0
 㿚	tlzn	5740
@@ -84482,7 +81217,6 @@ encoder:
 𤹆	tnxs	0
 𤹑	tnxw	0
 𤵩	tnyi	0
-𪾖	tnym	0
 瘦弱	tnyt	3420000
 癙	tnzd	71900
 𤼞	tnzo	0
@@ -84654,7 +81388,6 @@ encoder:
 奖励	trga	58500000
 瓷砖	trgb	6000000
 北大	trgd	33100000
-𪟬	trgi	0
 背面	trgj	11100000
 将有	trgq	26300000
 姿态	trgs	17600000
@@ -84985,7 +81718,6 @@ encoder:
 𤺫	twww	0
 㾼	twxo	5730
 𤶒	twym	0
-𪾞	twym	0
 疲于	txad	818000
 𪊑	txae	0
 𪋋	txae	0
@@ -85054,7 +81786,6 @@ encoder:
 康熙	txhy	12200000
 决战	txij	17300000
 麔	txij	24100
-𫝔	txik	0
 𪋮	txio	0
 𤸀	txiq	0
 𢿇	txix	0
@@ -85168,7 +81899,6 @@ encoder:
 𤻿	txrf	0
 𪊘	txrh	0
 𪊲	txrj	0
-𫝓	txrj	0
 康乐	txrk	6320000
 疲惫	txrk	16800000
 𪊨	txrk	0
@@ -85178,7 +81908,6 @@ encoder:
 㿕	txrn	5240
 麡	txrn	36900
 𪊖	txro	0
-𫝒	txro	0
 痆	txrr	29000
 麀	txrr	47300
 𪊕	txrr	0
@@ -85216,7 +81945,6 @@ encoder:
 麋	txuf	403000
 闯关	txug	3910000
 𧲊	txug	0
-𫌜	txui	0
 𣋴	txuk	0
 序性	txum	474000
 麃	txuo	44900
@@ -85260,7 +81988,6 @@ encoder:
 䴥	txyj	7940
 𢉻	txyj	0
 𤶹	txyj	0
-𫝑	txym	0
 癈	txyq	837000
 㼾	txys	5250
 𪊍	txyy	0
@@ -85286,11 +82013,9 @@ encoder:
 𤵤	tyhd	0
 𤸅	tyhk	0
 疤	tyia	5660000
-𪾜	tyik	0
 庭园	tyjb	1430000
 𤻾	tyke	0
 𤷪	tylk	0
-𪾦	tylz	0
 疗程	tymj	3630000
 㽺	tyms	5110
 疿	tynd	25600
@@ -85301,7 +82026,6 @@ encoder:
 瘸	tyoo	2740000
 瘳	tyop	307000
 𤺟	tyou	0
-𪾢	typs	0
 𤺼	typy	0
 𤺹	tyro	0
 疗效	tyso	15200000
@@ -85382,7 +82106,6 @@ encoder:
 𠁝	uaaj	0
 𠔺	uaaj	0
 𢥳	uaaj	0
-𪞏	uaaj	0
 𠁔	uaaz	0
 兰	uabd	153000000
 灯塔	uabe	2240000
@@ -85392,19 +82115,13 @@ encoder:
 忓	uaed	1790000
 頩	uaeg	149000
 𠛼	uaek	0
-𫘼	uaek	0
 𢼶	uaem	0
-𪱸	uaeq	0
-𫘿	uaeq	0
 鵧	uaer	26100
-𫜮	uaer	0
 𣁊	uaes	0
 㤣	uaew	5290
 迸	uaew	3260000
 㔙	uaey	4040
 郱	uaey	41900
-𪳟	uafj	0
-𫊍	uafk	0
 𩠳	uafn	0
 关	uagd	93600000
 𦍍	uagd	0
@@ -85420,21 +82137,18 @@ encoder:
 郑	uagy	72000000
 𨚜	uagy	0
 𢗄	uaid	0
-𫈚	uaid	0
 𢠟	uaig	0
 怔	uaii	8350000
 𣀚	uaim	0
 𩠰	uaim	0
 𧈁	uaio	0
 𢝒	uaiq	0
-𪬛	uaiw	0
 㪠	uaix	4120
 𢼩	uaix	0
 𩠮	uaix	0
 𢗙	uaiz	0
 馘	uaja	262000
 𩠲	uaja	0
-𫘻	uajf	0
 愊	uajk	43000
 𩉕	uajk	0
 𩫐	uajl	0
@@ -85446,10 +82160,8 @@ encoder:
 𡐂	uakb	0
 𥚘	uakb	0
 㮍	uakf	3970
-𪳋	uakf	0
 灯光	uakg	21600000
 𢞹	uakg	0
-𪥠	uakg	0
 𨂝	uakj	0
 普	uakk	177000000
 𣹅	uakk	0
@@ -85478,7 +82190,6 @@ encoder:
 䚊	uall	3620
 怲	ualo	40800
 灯具	ualo	25400000
-𪪘	ualo	0
 鷁	ualr	82400
 鹢	ualr	54200
 𣣼	ualr	0
@@ -85489,7 +82200,6 @@ encoder:
 𩢁	uamc	0
 灯笼	uamg	8790000
 𩑿	uamg	0
-𫘺	uamu	0
 𠬵	uamx	0
 𩠓	uamy	0
 𩠱	uamy	0
@@ -85499,12 +82209,10 @@ encoder:
 𩖐	uang	0
 𢟟	uanh	0
 𩠛	uanh	0
-𪬅	uank	0
 首	uanl	2560000000
 𩠔	uanm	0
 𢆣	uanr	0
 道	uanw	619000000
-𪬧	uanw	0
 𠡼	uany	0
 𪕼	uanz	0
 𠧆	uaoe	0
@@ -85522,7 +82230,6 @@ encoder:
 𩠕	uaos	0
 𢝑	uaow	0
 𣕙	uaoz	0
-𪠮	uapx	0
 塑	uaqb	98200000
 𢍥	uaqe	0
 槊	uaqf	794000
@@ -85536,7 +82243,6 @@ encoder:
 蠲	uari	870000
 𩠘	uari	0
 㤡	uark	4790
-𪬫	uarm	0
 𠬌	uarr	0
 𡕸	uarr	0
 𡖼	uarr	0
@@ -85556,7 +82262,6 @@ encoder:
 𦥈	uawh	0
 噵	uawj	332000
 𩠱	uawn	0
-𫘽	uawq	0
 懮	uawr	825000
 𠭳	uaxb	0
 𢆗	uaxe	0
@@ -85575,7 +82280,6 @@ encoder:
 𢜂	uaxw	0
 悽	uaxz	1500000
 𩠧	uayj	0
-𫘾	uaym	0
 剙	uayo	572000
 剏	uays	60400
 瓶	uays	61400000
@@ -85588,7 +82292,6 @@ encoder:
 𦑦	uayy	0
 𦒂	uayy	0
 𦒟	uayy	0
-𫆘	uayy	0
 𡙛	uazg	0
 𩒋	uazg	0
 𩒕	uazg	0
@@ -85597,7 +82300,6 @@ encoder:
 屰	uazi	44900
 𠧦	uazi	0
 𤲸	uazk	0
-𪟆	uazk	0
 𦥭	uazn	0
 𦥾	uazn	0
 𨿄	uazn	0
@@ -85621,7 +82323,6 @@ encoder:
 半天	ubag	28000000
 𢞄	ubaj	0
 半百	uban	685000
-𪬄	ubaz	0
 兰考	ubba	459000
 憢	ubbg	41400
 䄅	ubbk	5830
@@ -85664,7 +82365,6 @@ encoder:
 恒量	ubka	114000
 判	ubkd	41200000
 𤱵	ubki	0
-𪟹	ubkl	0
 恒星	ubkm	3700000
 半晌	ubkn	10300000
 𩴏	ubkn	0
@@ -85742,13 +82442,11 @@ encoder:
 恒温	ubvk	4990000
 兰州	ubvn	27000000
 兰溪	ubvp	1910000
-𪫵	ubvv	0
 半空	ubwb	6490000
 恒定	ubwd	1890000
 懛	ubwh	53900
 差遣	ubwj	935000
 差额	ubwr	4110000
-𪟻	ubws	0
 半边	ubwy	2560000
 𠢁	ubwy	0
 𢘤	ubwz	0
@@ -85773,7 +82471,6 @@ encoder:
 巻	ubyy	47300000
 𠡶	ubyy	0
 弮	ubyz	571000
-𪬬	ubzk	0
 㥺	ubzl	4360
 𡛤	ubzm	0
 𢗝	ubzm	0
@@ -85784,7 +82481,6 @@ encoder:
 㤼	ubzy	4710
 勬	ubzy	1810000
 恸	ubzy	845000
-𪬏	ubzy	0
 	ucaa	0
 	ucaa	0
 𦍌	ucaa	0
@@ -85792,7 +82488,6 @@ encoder:
 精干	ucae	2320000
 𨷑	ucae	0
 䍪	ucaf	3640
-𫆁	ucai	0
 羬	ucaj	81800
 𠻁	ucaj	0
 𦎛	ucaj	0
@@ -85837,21 +82532,18 @@ encoder:
 羮	ucco	119000
 𢟩	uccx	0
 情操	ucdj	4080000
-𫆈	ucdj	0
 㤽	ucds	4890
 精挑	ucdv	2470000
 情报	ucdy	42400000
 𠵊	ucej	0
 𦍩	ucej	0
 𦎠	ucej	0
-𫆓	ucej	0
 𦏒	ucek	0
 𩼫	ucek	0
 𩽫	ucek	0
 精英	ucel	71800000
 羵	ucel	23800
 𦎽	ucel	0
-𫆉	ucel	0
 䍻	uceo	3440
 𪅠	ucer	0
 𢻐	ucex	0
@@ -85865,7 +82557,6 @@ encoder:
 𦎏	ucfj	0
 䍶	ucfk	4050
 𨌅	ucfk	0
-𫆌	ucfx	0
 美	ucgd	712000000
 𦍸	ucgd	0
 𦏌	ucgg	0
@@ -85905,9 +82596,7 @@ encoder:
 䍺	uciw	3790
 㪨	ucix	4200
 𢼝	ucix	0
-𫆑	ucix	0
 𦎘	ucja	0
-𪭅	ucjc	0
 䍰	ucjd	4000
 𦏟	ucjd	0
 𦏛	ucjf	0
@@ -85933,8 +82622,6 @@ encoder:
 鄯	ucjy	913000
 羶	ucka	435000
 𦏄	ucka	0
-𫆃	ucka	0
-𫆏	ucka	0
 𦎐	uckb	0
 𦏆	uckb	0
 𦏏	uckk	0
@@ -85952,11 +82639,8 @@ encoder:
 𦎹	uckz	0
 𦍻	ucld	0
 精典	ucle	7140000
-𪥧	uclg	0
-𫆂	uclg	0
 盖	uclk	83600000
 𥃙	uclk	0
-𫆋	uclk	0
 𦏢	ucll	0
 㥽	uclo	3810
 羊肉	uclo	7640000
@@ -86019,7 +82703,6 @@ encoder:
 𦏂	ucqj	0
 羭	ucqk	159000
 𦎿	ucqq	0
-𫆍	ucqq	0
 羖	ucqx	93000
 羌	ucrd	3140000
 𦎆	ucrd	0
@@ -86028,7 +82711,6 @@ encoder:
 䍼	ucrk	3630
 𠒤	ucrk	0
 𦍴	ucrk	0
-𫗀	ucrk	0
 𦎈	ucrl	0
 𦎥	ucrn	0
 𦎪	ucro	0
@@ -86038,12 +82720,10 @@ encoder:
 𡗍	ucrr	0
 𦎄	ucrr	0
 𦎵	ucrr	0
-𪵖	ucrr	0
 羑	ucrs	114000
 羝	ucrs	197000
 𦍑	ucrs	0
 𦏇	ucrs	0
-𫆇	ucrs	0
 䍵	ucrx	3680
 𦍨	ucry	0
 𦫧	ucry	0
@@ -86064,7 +82744,6 @@ encoder:
 精良	ucsx	12100000
 羪	ucsx	29800
 養	ucsx	23300000
-𫒧	ucsy	0
 㕗	ucsz	4220
 精装	uctb	26100000
 𣁵	ucte	0
@@ -86072,7 +82751,6 @@ encoder:
 羡	uctr	8930000
 精度	uctv	19000000
 𩱋	ucua	0
-𫆅	ucuc	0
 䫞	ucug	3490
 情怀	ucug	16800000
 精美	ucug	64300000
@@ -86122,7 +82800,6 @@ encoder:
 羊群	ucxj	1880000
 𦎌	ucxj	0
 𩁥	ucxn	0
-𫆆	ucxo	0
 𢛏	ucxs	0
 𦍱	ucxs	0
 精灵	ucxu	68300000
@@ -86134,10 +82811,8 @@ encoder:
 𦍛	ucxz	0
 精子	ucya	6520000
 𢝛	ucyg	0
-𫆄	ucyh	0
 羓	ucyi	30700
 𦍔	ucyi	0
-𫆊	ucyj	0
 劷	ucym	120000
 慠	ucym	55500
 精力	ucym	37800000
@@ -86150,11 +82825,9 @@ encoder:
 𦎞	ucyz	0
 情绪	uczb	21800000
 𦎉	uczb	0
-𫆒	uczf	0
 精练	uczh	1020000
 羊绒	uczh	6550000
 羲	uczh	3340000
-𫆀	uczi	0
 精细	uczk	14900000
 姜	uczm	39300000
 𦎓	uczn	0
@@ -86175,12 +82848,10 @@ encoder:
 兽	udaj	86800000
 䶏	udan	3710
 𪗲	udax	0
-𪱳	udax	0
 𣍎	udbr	0
 𦍎	udck	0
 𠟃	uddk	0
 鷷	uddr	27800
-𫝊	uddr	0
 遵	uddw	32200000
 冁	udeh	35000
 𢧐	udeh	0
@@ -86223,9 +82894,6 @@ encoder:
 𧔭	udii	0
 䤋	udja	3810
 𣚱	udjf	0
-𪞎	udjj	0
-𫝥	udjk	0
-𪫚	udjl	0
 兌	udjr	2700000
 兑	udjr	10500000
 𡈤	udjr	0
@@ -86265,7 +82933,6 @@ encoder:
 𤿫	udrx	0
 䒏	udry	3960
 𢛺	udry	0
-𪱳	udsx	0
 㤹	udvs	12600
 𧷭	udwa	0
 帰	udwl	6970000
@@ -86324,7 +82991,6 @@ encoder:
 糟蹋	uejk	8430000
 𢢩	uejm	0
 懽	uejn	83600
-𪬷	uejn	0
 𢚛	uejr	0
 𢡇	uejs	0
 懴	ueka	31500
@@ -86394,7 +83060,6 @@ encoder:
 煤油	uevk	2150000
 愤激	uevn	223000
 糊涂	uevo	15700000
-𪬖	uewa	0
 并进	uewb	1490000
 㦅	uewl	3890
 懵	uewl	3640000
@@ -86441,10 +83106,8 @@ encoder:
 𥹕	ufax	0
 粝	ufay	223000
 𥸯	ufay	0
-𫃴	ufay	0
 𥹬	ufaz	0
 𥺒	ufaz	0
-𫃹	ufaz	0
 𥹩	ufbd	0
 𥻣	ufbd	0
 𥻵	ufbd	0
@@ -86463,7 +83126,6 @@ encoder:
 𥼹	ufbq	0
 粩	ufbr	196000
 𥹳	ufbr	0
-𫃻	ufbr	0
 𥺁	ufbs	0
 𥼯	ufbu	0
 𥼶	ufbu	0
@@ -86471,20 +83133,17 @@ encoder:
 𥺃	ufbw	0
 𥼳	ufbw	0
 𥺄	ufby	0
-𫄇	ufby	0
 𥹓	ufbz	0
 𥺭	ufbz	0
 𥺼	ufbz	0
 𥺅	ufcd	0
 𥹢	ufce	0
 粻	ufch	890000
-𫃧	ufci	0
 𥹯	ufck	0
 精	ufcl	0
 𥼃	ufcl	0
 𥼲	ufcm	0
 精	ufcq	220000000
-𫃳	ufcx	0
 𥺈	ufdp	0
 愽	ufds	122000
 慱	ufds	47800
@@ -86496,7 +83155,6 @@ encoder:
 籵	ufed	608000
 𥻔	ufee	0
 𥽒	ufef	0
-𫃽	ufeh	0
 䊀	ufej	5420
 𥺨	ufej	0
 米黄	ufek	1270000
@@ -86514,7 +83172,6 @@ encoder:
 𥸳	ufex	0
 糂	ufez	124000
 𥹑	ufez	0
-𫄃	ufez	0
 𥻸	uffa	0
 㦗	uffb	3780
 䊇	uffb	4010
@@ -86523,7 +83180,6 @@ encoder:
 䊜	uffd	3840
 糐	uffd	26600
 糰	uffd	2240000
-𫃿	ufff	0
 糯	uffg	3730000
 𥽢	uffg	0
 𥽨	uffg	0
@@ -86539,7 +83195,6 @@ encoder:
 𥽥	uffn	0
 𥺚	uffp	0
 𥼔	uffp	0
-𪺉	uffp	0
 䊛	uffq	3490
 𢟼	uffr	0
 𥽰	uffu	0
@@ -86565,8 +83220,6 @@ encoder:
 𥽙	ufgs	0
 𥽉	ufgu	0
 𥹨	ufhb	0
-𫃮	ufhg	0
-𫃩	ufhl	0
 𥼘	ufho	0
 𥽘	ufhs	0
 𥺫	ufhu	0
@@ -86577,7 +83230,6 @@ encoder:
 𥻀	ufij	0
 糌	ufik	340000
 𥹴	ufik	0
-𫃬	ufik	0
 糈	ufiq	69500
 𥺾	ufiq	0
 𣀰	ufix	0
@@ -86586,19 +83238,15 @@ encoder:
 𥼐	ufjb	0
 𥺆	ufjc	0
 𥻯	ufjc	0
-𫃸	ufjc	0
 䊭	ufjd	3840
-𫃯	ufjd	0
 𥼾	ufjf	0
 尊贵	ufji	9940000
 糨	ufji	84100
-𫃶	ufjj	0
 糆	ufjk	23600
 𥻃	ufjk	0
 𥻅	ufjk	0
 𥼽	ufjk	0
 𥽯	ufjk	0
-𫄀	ufjk	0
 𥻥	ufjl	0
 𥻱	ufjl	0
 𥼱	ufjl	0
@@ -86631,7 +83279,6 @@ encoder:
 糎	ufkb	79600
 糧	ufkb	7500000
 𥻝	ufkb	0
-𫓂	ufkb	0
 𥺘	ufkc	0
 䊤	ufke	4060
 憛	ufke	70400
@@ -86643,14 +83290,12 @@ encoder:
 糢	ufkg	292000
 畨	ufki	311000
 粙	ufki	784000
-𫃫	ufki	0
 粬	ufkk	387000
 糟	ufkk	14200000
 𢥱	ufkk	0
 𥼦	ufkk	0
 𥽾	ufkk	0
 䊑	ufkl	3990
-𪭚	ufkl	0
 粆	ufkm	30500
 𥻠	ufkm	0
 𥽩	ufkm	0
@@ -86666,7 +83311,6 @@ encoder:
 𥼜	ufku	0
 𥼞	ufku	0
 𥽑	ufku	0
-𪺎	ufku	0
 𥻏	ufkw	0
 𥽜	ufkw	0
 𥹥	ufkx	0
@@ -86689,7 +83333,6 @@ encoder:
 籼	ufll	565000
 𢢻	ufll	0
 𥼇	ufll	0
-𪿈	ufll	0
 𥼂	ufln	0
 𥹘	uflo	0
 𥺎	uflo	0
@@ -86737,7 +83380,6 @@ encoder:
 𥸼	ufms	0
 𥻾	ufms	0
 𥼕	ufms	0
-𫝕	ufmt	0
 䉿	ufmu	3890
 𥼄	ufmu	0
 𥼨	ufmu	0
@@ -86774,13 +83416,11 @@ encoder:
 𩏶	ufnu	0
 𩏷	ufnu	0
 𩏸	ufnu	0
-𫄈	ufnu	0
 𥸺	ufnx	0
 𥻬	ufnx	0
 𥻎	ufob	0
 𥸪	ufod	0
 粹	ufoe	8720000
-𫃨	ufoe	0
 𥻹	ufof	0
 𥼪	ufok	0
 𥺌	ufom	0
@@ -86798,17 +83438,14 @@ encoder:
 糭	ufor	33500
 𥺙	ufor	0
 𥽁	ufor	0
-𫄉	ufou	0
 𥹕	ufow	0
 𥼸	ufow	0
 粉	ufoy	142000000
 𥺯	ufoy	0
 𢛒	ufoz	0
-𪭎	ufpb	0
 䉼	ufpd	4030
 慚	ufpd	336000
 𥹽	ufpd	0
-𫃼	ufpe	0
 䊩	ufpk	3800
 䊝	ufpw	3670
 𢣥	ufpw	0
@@ -86834,7 +83471,6 @@ encoder:
 𥽴	ufrj	0
 糣	ufrk	18700
 𥺢	ufrk	0
-𫃭	ufrk	0
 懒	ufrl	63800000
 懶	ufrl	9730000
 𥼓	ufrl	0
@@ -86866,7 +83502,6 @@ encoder:
 𥽫	ufru	0
 𥸾	ufry	0
 𥺹	ufry	0
-𫄇	ufry	0
 𥻤	ufrz	0
 𥻼	ufrz	0
 𪀿	ufrz	0
@@ -86894,7 +83529,6 @@ encoder:
 𥹎	ufub	0
 𥹿	ufub	0
 𥽞	ufub	0
-𫃨	ufue	0
 憟	ufuf	238000
 𥹫	ufuf	0
 懒惰	ufug	1560000
@@ -86912,11 +83546,8 @@ encoder:
 𥽎	ufux	0
 䊎	ufuy	3800
 𥺀	ufuy	0
-𫄅	ufuy	0
 𥺇	ufuz	0
 米酒	ufvf	4100000
-𫃲	ufvs	0
-𪫶	ufvv	0
 懒汉	ufvx	764000
 米汤	ufvy	517000
 𥹍	ufwa	0
@@ -86926,7 +83557,6 @@ encoder:
 糘	ufwg	56200
 糄	ufwl	20300
 𥺥	ufwl	0
-𫄄	ufwl	0
 粐	ufwm	191000
 𥹅	ufwm	0
 𥹈	ufwr	0
@@ -86936,13 +83566,11 @@ encoder:
 𥻮	ufws	0
 𥺑	ufwx	0
 𥹸	ufwy	0
-𫄂	ufwy	0
 憓	ufwz	105000
 𢘻	ufwz	0
 𢝴	ufwz	0
 𥹀	ufwz	0
 𥻨	ufwz	0
-𫃱	ufwz	0
 䊕	ufxb	3650
 𥹧	ufxb	0
 粈	ufxe	1120000
@@ -86957,7 +83585,6 @@ encoder:
 糠	ufxk	3540000
 𥼴	ufxk	0
 𥻡	ufxl	0
-𫃾	ufxl	0
 䊊	ufxm	4950
 糇	ufxm	181000
 𥺶	ufxm	0
@@ -86972,21 +83599,17 @@ encoder:
 𥽆	ufxu	0
 𥽣	ufxu	0
 𥺴	ufxw	0
-𫄁	ufxw	0
 𥽊	ufxy	0
-𫄇	ufxy	0
 籽	ufya	12100000
 𩱸	ufya	0
 㐘	ufyd	4510
 籸	ufye	35800
 𦧾	ufye	0
-𪫌	ufye	0
 𡙢	ufyg	0
 𩔫	ufyg	0
 粌	ufyi	565000
 粑	ufyi	1370000
 𧏟	ufyi	0
-𫃥	ufyi	0
 𥹙	ufyj	0
 𥺸	ufyk	0
 𥺬	ufyl	0
@@ -87013,7 +83636,6 @@ encoder:
 𥼁	ufze	0
 𥻈	ufzf	0
 𥽗	ufzf	0
-𫐶	ufzf	0
 纇	ufzg	256000
 颣	ufzg	34000
 𥻺	ufzg	0
@@ -87038,8 +83660,6 @@ encoder:
 𥼗	ufzt	0
 𥺇	ufzu	0
 𥼮	ufzu	0
-𫃵	ufzw	0
-𫄆	ufzw	0
 𥸴	ufzy	0
 𥹱	ufzy	0
 糍	ufzz	620000
@@ -87052,7 +83672,6 @@ encoder:
 㥓	ugaj	4060
 美丽	ugal	146000000
 𢛄	ugbb	0
-𪫽	ugbi	0
 怀来	ugbk	799000
 㦋	ugbm	4030
 惰	ugbq	2200000
@@ -87164,7 +83783,6 @@ encoder:
 美观	ugxl	17000000
 怀柔	ugxx	5700000
 怀孕	ugym	56200000
-𪫸	ugym	0
 𦑑	ugyy	0
 恞	ugyz	37700
 关台	ugzj	33000
@@ -87208,13 +83826,11 @@ encoder:
 炼钢	uhpl	1900000
 炼铁	uhpm	1080000
 憯	uhrk	77200
-𪫿	uhrs	0
 惬意	uhsk	6440000
 烧烤	uhub	9460000
 烧瓶	uhue	270000
 惭愧	uhun	8220000
 烧火	uhuo	704000
-𪬆	uhuo	0
 炼油	uhvk	7550000
 慳	uhxb	1140000
 𢤞	uhxl	0
@@ -87228,7 +83844,6 @@ encoder:
 懅	uigq	315000
 𢟧	uijo	0
 𢛈	uijw	0
-𪬤	uijw	0
 𢤯	uika	0
 悼	uike	3020000
 烛光	uikg	4100000
@@ -87245,7 +83860,6 @@ encoder:
 𢟶	uios	0
 粘膜	uiqe	4740000
 𢟡	uirl	0
-𪭇	uirl	0
 粘剂	uisn	305000
 悼词	uisy	551000
 丫头	uitg	17700000
@@ -87290,7 +83904,6 @@ encoder:
 烟叶	ujje	1960000
 懆	ujjf	429000
 𢠮	ujjk	0
-𪭈	ujjl	0
 总师	ujka	163000
 总量	ujka	20400000
 烟尘	ujkb	2710000
@@ -87392,7 +84005,6 @@ encoder:
 𢤗	ukjl	0
 𢢪	ukju	0
 𢢳	ukkb	0
-𪬿	ukkb	0
 愰	ukkg	1190000
 憹	ukkg	52800
 单显	ukkk	67900
@@ -87404,7 +84016,6 @@ encoder:
 𢠵	uklm	0
 𢢔	ukls	0
 慢	uklx	90600000
-𪬹	ukly	0
 㥥	uklz	4870
 单县	uklz	536000
 惺	ukmc	1430000
@@ -87413,7 +84024,6 @@ encoder:
 单程	ukmj	2070000
 单利	ukmk	154000
 𢜫	ukml	0
-𪬣	ukml	0
 𢚕	ukms	0
 单传	uknb	348000
 单身	uknc	41200000
@@ -87476,7 +84086,6 @@ encoder:
 普安	ukwz	392000
 悭	ukxb	528000
 单骑	ukxg	2960000
-𪬸	ukxl	0
 炒买	ukxt	157000
 单子	ukya	3380000
 普及	ukym	46800000
@@ -87520,7 +84129,6 @@ encoder:
 𢚭	ulkv	0
 𢢥	ulkw	0
 懼	ulln	2100000
-𪭟	ulln	0
 𢠼	ullo	0
 着眼	ullx	13500000
 盖县	ullz	67400
@@ -87576,7 +84184,6 @@ encoder:
 曾经	ulzx	124000000
 𢤝	umaj	0
 炸死	umar	2190000
-𪬗	umaz	0
 𢡩	umbd	0
 炸坝	umbl	21700
 𢣤	umbu	0
@@ -87597,13 +84204,11 @@ encoder:
 㤭	umgn	5250
 性感	umha	97000000
 𢖲	umhd	0
-𪭒	umhm	0
 怍	umid	979000
 𢠑	umjj	0
 憍	umjl	201000
 慥	umjw	148000
 性别	umjy	145000000
-𪬦	umka	0
 𢝆	umkb	0
 悧	umkd	675000
 愎	umkr	441000
@@ -87626,17 +84231,14 @@ encoder:
 性腺	umqn	939000
 炸鱼	umra	306000
 𢝤	umra	0
-𪬮	umrb	0
 𢙝	umrd	0
 㦧	umrk	3900
 㦫	umrl	3710
 慯	umro	262000
 性急	umrx	1720000
-𪬺	umsj	0
 性状	umtg	2940000
 拳头	umtg	11800000
 𢟊	umtr	0
-𪬘	umtr	0
 性情	umuc	11200000
 忏悔	umum	4800000
 愀	umuo	806000
@@ -87658,7 +84260,6 @@ encoder:
 养殖	unar	41800000
 熄灭	unau	5240000
 惟一	unav	14300000
-𪬗	unaz	0
 𢝘	unbi	0
 惟恐	unbq	2010000
 惶恐	unbq	4040000
@@ -87774,7 +84375,6 @@ encoder:
 煶	uoai	341000
 𤌗	uoai	0
 𤐔	uoai	0
-𪹯	uoai	0
 恰	uoaj	17000000
 炣	uoaj	33200
 烚	uoaj	143000
@@ -87783,13 +84383,10 @@ encoder:
 𤏃	uoaj	0
 𤏉	uoaj	0
 𤏧	uoaj	0
-𪹙	uoaj	0
-𪺥	uoaj	0
 𤉴	uoak	0
 㷍	uoal	4150
 惀	uoal	489000
 𤏳	uoal	0
-𪺲	uoal	0
 𤊪	uoao	0
 𤇊	uoau	0
 𤏘	uoaw	0
@@ -87814,12 +84411,10 @@ encoder:
 灴	uobi	398000
 𢘐	uobi	0
 𤈄	uobj	0
-𪹢	uobj	0
 㶹	uobk	4650
 烜	uobk	304000
 煊	uobk	902000
 𤇋	uobk	0
-𪸽	uobk	0
 熕	uobl	37900
 𤉑	uobl	0
 𤒠	uobl	0
@@ -87833,12 +84428,8 @@ encoder:
 𤊳	uobq	0
 𤌃	uobq	0
 𤐢	uobq	0
-𪹭	uobq	0
-𪺜	uobq	0
 烷	uobr	8150000
-𪸵	uobr	0
 𤆧	uobs	0
-𪹖	uobs	0
 㷵	uobu	4500
 燡	uobu	28600
 燵	uobu	46100
@@ -87847,11 +84438,8 @@ encoder:
 𤒋	uobu	0
 𤓂	uobu	0
 𤓦	uobu	0
-𪺅	uobu	0
 𤈷	uobv	0
-𪬑	uobv	0
 𤌷	uobw	0
-𪺒	uobw	0
 𤊫	uobx	0
 㷲	uoby	3830
 炜	uoby	5590000
@@ -87864,13 +84452,10 @@ encoder:
 𤉁	uobz	0
 𤑼	uobz	0
 𤒫	uobz	0
-𪸶	uobz	0
-𪸼	uobz	0
 㷯	uocb	4380
 𤊡	uocb	0
 㸎	uocc	5010
 𤆜	uocd	0
-𪹊	uoce	0
 𤊴	uocg	0
 㷃	uoch	3820
 𤊞	uoch	0
@@ -87878,7 +84463,6 @@ encoder:
 𤈞	uock	0
 𤑈	uocm	0
 煅	uocq	1240000
-𪸿	uocs	0
 𤌬	uocu	0
 𤌰	uocu	0
 熢	uocw	35500
@@ -87919,7 +84503,6 @@ encoder:
 焟	uoek	34100
 𤋙	uoek	0
 𤍬	uoek	0
-𪹺	uoek	0
 煵	uoel	35300
 燌	uoel	23100
 𤊧	uoel	0
@@ -87932,19 +84515,16 @@ encoder:
 𤈝	uoeo	0
 𤌱	uoeo	0
 𤒩	uoeo	0
-𪹞	uoeo	0
 燍	uoep	27000
 火警	uoer	1510000
 爙	uoer	23000
 𤓢	uoer	0
-𪺟	uoer	0
 𤊊	uoes	0
 㷻	uoeu	4190
 熫	uoeu	37500
 𤌰	uoeu	0
 𤎫	uoeu	0
 𢻑	uoex	0
-𪯝	uoex	0
 火药	uoez	2140000
 煁	uoez	333000
 熎	uoez	24300
@@ -88004,7 +84584,6 @@ encoder:
 𤌕	uogj	0
 𤎐	uogj	0
 𨆜	uogj	0
-𪸾	uogj	0
 𤒳	uogk	0
 悕	uogl	693000
 烯	uogl	18900000
@@ -88022,13 +84601,11 @@ encoder:
 粉碎	uogs	12000000
 𤋀	uogs	0
 𤓊	uogs	0
-𪺱	uogs	0
 烣	uogu	49700
 𤌢	uogu	0
 𤏵	uogu	0
 𤒁	uogu	0
 𤒺	uogu	0
-𪹮	uogu	0
 燧	uogw	811000
 煖	uogx	636000
 𤇉	uogy	0
@@ -88044,16 +84621,12 @@ encoder:
 𤈪	uohe	0
 烧	uohg	64500000
 𤇽	uohg	0
-𪹛	uohh	0
 𤆹	uohi	0
-𪹚	uohi	0
-𪹑	uohj	0
 𤐒	uohl	0
 𤇦	uohm	0
 𤋖	uohm	0
 炬	uohx	3970000
 𤆻	uohy	0
-𪹉	uohy	0
 炖	uohz	6370000
 爞	uoia	150000
 益虫	uoia	380000
@@ -88062,15 +84635,11 @@ encoder:
 𤋛	uoig	0
 爞	uoii	150000
 𤎠	uoii	0
-𪸸	uoii	0
 炶	uoij	422000
 煔	uoij	32000
 㷔	uoik	3980
 焔	uoik	1050000
-𪺋	uoik	0
 𤋺	uoil	0
-𪹲	uoil	0
-𪺛	uoil	0
 𤑉	uoio	0
 火柴	uoir	8480000
 𤍲	uoiw	0
@@ -88083,7 +84652,6 @@ encoder:
 𤎍	uoja	0
 燷	uojb	21800
 𤎌	uojb	0
-𪺫	uojb	0
 𤒌	uojc	0
 烟	uojd	96800000
 燖	uojd	39100
@@ -88127,7 +84695,6 @@ encoder:
 𤓀	uojl	0
 𤓝	uojl	0
 𪛑	uojl	0
-𪹌	uojl	0
 煒	uojm	1710000
 燣	uojm	25200
 𤒢	uojm	0
@@ -88135,7 +84702,6 @@ encoder:
 炽	uojo	4450000
 𤈆	uojo	0
 𤌜	uojo	0
-𪹀	uojo	0
 焆	uojq	41400
 煳	uojq	113000
 𤍦	uojq	0
@@ -88152,7 +84718,6 @@ encoder:
 𤏈	uoju	0
 𤐆	uoju	0
 𧺄	uoju	0
-𪹸	uoju	0
 煾	uojw	37300
 𤐉	uojw	0
 𤇆	uojx	0
@@ -88164,7 +84729,6 @@ encoder:
 𨚊	uojy	0
 𨞴	uojy	0
 𨟏	uojy	0
-𪹁	uojy	0
 𤉈	uojz	0
 㷥	uoka	4470
 懺	uoka	1420000
@@ -88201,10 +84765,8 @@ encoder:
 𤏏	uokg	0
 𤒚	uokg	0
 𩖋	uokg	0
-𪹓	uokg	0
 煨	uokh	1770000
 熾	uokh	1750000
-𪹝	uokh	0
 炠	uoki	29000
 畑	uoki	9920000
 㷮	uokk	4100
@@ -88216,7 +84778,6 @@ encoder:
 𤐀	uokk	0
 𤒬	uokk	0
 𤓗	uokk	0
-𪹻	uokk	0
 煴	uokl	56900
 爐	uokl	6660000
 𤉆	uokl	0
@@ -88228,7 +84789,6 @@ encoder:
 𤎤	uokm	0
 熦	uokn	25800
 熿	uoko	29500
-𪹐	uoko	0
 焇	uokq	25800
 焨	uokq	20100
 煟	uokq	701000
@@ -88240,7 +84800,6 @@ encoder:
 𤋟	uokr	0
 𤐚	uokr	0
 煜	uoks	5230000
-𪹡	uoks	0
 㸁	uoku	6680
 𤍅	uoku	0
 𤐄	uoku	0
@@ -88276,9 +84835,7 @@ encoder:
 焵	uold	277000
 焹	uold	50100
 𤆳	uold	0
-𪹬	uold	0
 燺	uolf	24800
-𪴯	uolf	0
 炴	uolg	2070000
 焕	uolg	5320000
 煐	uolg	445000
@@ -88295,7 +84852,6 @@ encoder:
 灿	uoll	6520000
 爦	uoll	24800
 𤋫	uoll	0
-𪺩	uoll	0
 𤏮	uolm	0
 𤏰	uolm	0
 熣	uoln	37300
@@ -88309,17 +84865,13 @@ encoder:
 𤌭	uolo	0
 𤑍	uolo	0
 𤑣	uolo	0
-𪹒	uolo	0
-𪹟	uolp	0
 䙺	uolr	3670
 𤋬	uolr	0
 𤓇	uolr	0
-𪺊	uolr	0
 𤍉	uols	0
 𤓧	uolt	0
 熥	uolw	41400
 𤐾	uolw	0
-𪺭	uolw	0
 熳	uolx	198000
 𤈬	uolx	0
 㷒	uolz	3800
@@ -88339,7 +84891,6 @@ encoder:
 秌	uomf	32200
 𤌴	uomf	0
 𤏆	uomf	0
-𪹍	uomf	0
 𤌡	uomg	0
 𤒟	uomg	0
 𩕶	uomg	0
@@ -88368,7 +84919,6 @@ encoder:
 𤊿	uomn	0
 炇	uomo	20200
 𣃌	uomp	0
-𪸲	uomq	0
 烍	uomr	27600
 熪	uomr	28300
 𤆣	uoms	0
@@ -88389,8 +84939,6 @@ encoder:
 𤑓	uomy	0
 𤑲	uomy	0
 𨞧	uomy	0
-𪸳	uomy	0
-𪸹	uomy	0
 烸	uomz	74500
 𤉦	uomz	0
 𤍃	uomz	0
@@ -88406,15 +84954,11 @@ encoder:
 𤆑	uond	0
 焷	uone	35300
 烌	uonf	25300
-𪺗	uonf	0
-𪹣	uonh	0
 火候	uoni	2740000
 焳	uoni	21000
 𤈍	uonj	0
 𤌋	uonj	0
 𤍀	uonj	0
-𪹕	uonj	0
-𪹼	uonj	0
 㷧	uonk	4390
 𤇢	uonk	0
 𤏚	uonn	0
@@ -88445,7 +84989,6 @@ encoder:
 𤑥	uooc	0
 焠	uooe	111000
 𢙋	uooe	0
-𪺨	uooe	0
 𤉾	uoof	0
 㷜	uoog	3800
 𤋋	uoog	0
@@ -88455,7 +84998,6 @@ encoder:
 𢠰	uooi	0
 焀	uooj	32300
 熔	uooj	7380000
-𪬐	uooj	0
 爆	uook	108000000
 𢡽	uook	0
 𤎳	uook	0
@@ -88469,7 +85011,6 @@ encoder:
 𧶦	uool	0
 𤐲	uoom	0
 𤒦	uoom	0
-𪺀	uoom	0
 炌	uoon	26800
 𤊍	uoon	0
 𤋽	uoon	0
@@ -88492,18 +85033,15 @@ encoder:
 𤆢	uoor	0
 𤊥	uoor	0
 𤎑	uoor	0
-𪺰	uoor	0
 㤊	uoos	5390
 𤐐	uoos	0
 𤉪	uoot	0
 𤏟	uoou	0
 𤒾	uoou	0
-𪺤	uoou	0
 炩	uoow	577000
 燯	uoow	27000
 𢝦	uoow	0
 𤋶	uoow	0
-𪹫	uoow	0
 炝	uooy	594000
 𤆶	uooy	0
 𤊈	uooy	0
@@ -88518,7 +85056,6 @@ encoder:
 熖	uopn	34000
 𤓁	uopn	0
 𤉒	uopq	0
-𪺁	uopq	0
 焮	uopr	79000
 𤋻	uopr	0
 炿	uops	28100
@@ -88528,22 +85065,17 @@ encoder:
 𢥒	uopw	0
 𤎕	uopw	0
 炍	uopx	51300
-𪹤	uopx	0
 烐	uopy	26600
 烰	uopy	26100
-𪹔	uopz	0
 𤇒	uoqa	0
 𤇛	uoqa	0
 𤊚	uoqb	0
 𤎞	uoqb	0
 𤆘	uoqd	0
-𪺣	uoqf	0
 煈	uoqi	177000
 㷙	uoqk	3630
 愉	uoqk	5710000
-𪹱	uoqk	0
 𤐟	uoql	0
-𪺚	uoqm	0
 𤑍	uoqo	0
 焩	uoqq	17600
 𤎒	uoqs	0
@@ -88552,9 +85084,6 @@ encoder:
 𤆥	uorb	0
 𤎆	uorb	0
 𤏯	uorb	0
-𪹜	uorb	0
-𪺍	uorb	0
-𪺦	uorb	0
 㷨	uorc	6460
 烽	uorc	5800000
 熢	uorc	35500
@@ -88567,7 +85096,6 @@ encoder:
 燭	uori	3690000
 爥	uori	28500
 益处	uori	4520000
-𪹃	uori	0
 烙	uorj	5020000
 㶷	uork	4190
 烁	uork	3440000
@@ -88576,7 +85104,6 @@ encoder:
 𤈎	uork	0
 𤈘	uork	0
 𤑟	uork	0
-𪹂	uork	0
 㸊	uorl	5330
 𤓎	uorl	0
 𧣌	uorl	0
@@ -88597,7 +85124,6 @@ encoder:
 煬	uoro	175000
 𤆞	uoro	0
 爩	uorp	29200
-𪹵	uorp	0
 𤊷	uorq	0
 㶴	uorr	5190
 焜	uorr	1250000
@@ -88628,7 +85154,6 @@ encoder:
 焥	uory	23200
 𤊵	uory	0
 𦫟	uory	0
-𪹠	uory	0
 䲴	uorz	6360
 煼	uorz	94000
 熓	uorz	21800
@@ -88643,7 +85168,6 @@ encoder:
 焙	uosj	3680000
 䪯	uosk	3290
 𤋾	uosk	0
-𪹄	uosk	0
 𤐎	uosl	0
 𤐛	uosl	0
 燩	uosm	26000
@@ -88655,7 +85179,6 @@ encoder:
 烿	uosp	26900
 炕	uosq	3300000
 𤒀	uosq	0
-𪺌	uosq	0
 褮	uosr	23100
 𧚵	uosr	0
 烬	uost	810000
@@ -88673,7 +85196,6 @@ encoder:
 炓	uote	36600
 𣂈	uote	0
 𤉜	uotf	0
-𪺄	uotf	0
 爌	uotg	102000
 粉状	uotg	1790000
 𤆓	uotg	0
@@ -88691,7 +85213,6 @@ encoder:
 𤑆	uoub	0
 𤒲	uoub	0
 𥚡	uoub	0
-𪺴	uoub	0
 烊	uouc	325000
 羚羊	uouc	3930000
 怜惜	uoue	3070000
@@ -88712,9 +85233,6 @@ encoder:
 𤏢	uoug	0
 𤓔	uoug	0
 𩖖	uoug	0
-𪥫	uoug	0
-𪹶	uoug	0
-𪺢	uoug	0
 㸍	uouh	6340
 火炬	uouh	7010000
 火烧	uouh	8250000
@@ -88728,7 +85246,6 @@ encoder:
 覢	uoul	25300
 𤏲	uoul	0
 𤑦	uoul	0
-𪺏	uoul	0
 㲜	uoum	4090
 㲭	uoum	3760
 㷣	uoum	4160
@@ -88739,7 +85256,6 @@ encoder:
 炎	uouo	78100000
 炏	uouo	60800
 𨧿	uoup	0
-𪺓	uoup	0
 飊	uouq	62400
 𤈺	uouq	0
 𤎒	uouq	0
@@ -88790,7 +85306,6 @@ encoder:
 焢	uowb	113000
 禜	uowb	88000
 𤉳	uowb	0
-𪹷	uowb	0
 瑩	uowc	4930000
 𤑚	uowc	0
 𦖽	uowc	0
@@ -88808,7 +85323,6 @@ encoder:
 𤌫	uowg	0
 𤐶	uowg	0
 𤐽	uowh	0
-𪹎	uowh	0
 螢	uowi	26300000
 㽦	uowk	8190
 滎	uowk	439000
@@ -88830,7 +85344,6 @@ encoder:
 𤯵	uowm	0
 𤌍	uown	0
 𤏥	uown	0
-𪸺	uowo	0
 鎣	uowp	78100
 𤬐	uowp	0
 焭	uowq	26100
@@ -88848,8 +85361,6 @@ encoder:
 𤋩	uows	0
 𤍩	uows	0
 𤓋	uows	0
-𪺂	uows	0
-𪺆	uows	0
 火灾	uowu	8830000
 熒	uowu	936000
 𤐥	uowu	0
@@ -88878,7 +85389,6 @@ encoder:
 𤈠	uoxb	0
 𤏑	uoxb	0
 𤏫	uoxb	0
-𪹇	uoxb	0
 爝	uoxd	108000
 𤓣	uoxd	0
 𤓭	uoxd	0
@@ -88894,8 +85404,6 @@ encoder:
 㶦	uoxi	4230
 𢜢	uoxi	0
 𤊂	uoxi	0
-𪹆	uoxi	0
-𪺝	uoxi	0
 㤷	uoxj	7710
 愴	uoxj	203000
 焐	uoxj	908000
@@ -88911,13 +85419,9 @@ encoder:
 煝	uoxl	63700
 熥	uoxl	41400
 粉刷	uoxl	1960000
-𪺐	uoxl	0
 𤈦	uoxm	0
-𪹴	uoxm	0
 熽	uoxn	28600
 𤑳	uoxn	0
-𪺈	uoxn	0
-𪺘	uoxn	0
 焿	uoxo	109000
 熌	uoxo	57000
 爘	uoxo	23400
@@ -88943,8 +85447,6 @@ encoder:
 㸅	uoxy	5450
 𤍎	uoxy	0
 𨛂	uoxy	0
-𪺬	uoxy	0
-𪺮	uoxy	0
 㤋	uoyd	4000
 灱	uoyd	545000
 㷀	uoye	4690
@@ -88958,21 +85460,17 @@ encoder:
 炤	uoyj	338000
 焗	uoyj	1880000
 𤐵	uoyj	0
-𪹗	uoyj	0
-𪹘	uoyj	0
 熘	uoyk	448000
 益阳	uoyk	5060000
 燲	uoyl	22100
 𢞂	uoyl	0
 𢠈	uoyl	0
-𪹧	uoyl	0
 㷪	uoym	4540
 燉	uoym	1730000
 𠠽	uoym	0
 𤆈	uoym	0
 𤍗	uoym	0
 𤐃	uoym	0
-𪹾	uoym	0
 炥	uoyn	24400
 熠	uoyn	945000
 燿	uoyn	913000
@@ -88989,7 +85487,6 @@ encoder:
 𤬬	uoys	0
 𤭰	uoys	0
 𤮶	uoys	0
-𪸴	uoys	0
 爋	uoyu	24500
 𤎶	uoyu	0
 𤏂	uoyu	0
@@ -89012,11 +85509,8 @@ encoder:
 𤍪	uoyy	0
 𤒻	uoyy	0
 𦒪	uoyy	0
-𪹏	uoyy	0
-𪺡	uoyy	0
 𤆺	uoyz	0
 𤏦	uoyz	0
-𪹅	uoyz	0
 粉红	uozb	24500000
 𡓧	uozb	0
 煠	uozf	102000
@@ -89044,19 +85538,15 @@ encoder:
 𤇱	uozl	0
 𤎽	uozl	0
 𤐩	uozl	0
-𪺇	uozl	0
 㶼	uozm	7200
 𤓩	uozm	0
 𤐣	uozn	0
 𤑺	uozn	0
 𤓓	uozn	0
-𪺯	uozn	0
 烗	uozo	24100
 焴	uozq	31700
-𪺃	uozq	0
 恱	uozr	36600
 𢚔	uozr	0
-𪸻	uozr	0
 忪	uozs	469000
 𤎄	uozu	0
 𤐴	uozu	0
@@ -89268,7 +85758,6 @@ encoder:
 粮棉	usfn	434000
 惊奇	usga	11800000
 𢟰	usgq	0
-𪬳	usgs	0
 惊厥	usgu	1520000
 忙碌	usgx	20600000
 𢡠	ushk	0
@@ -89277,7 +85766,6 @@ encoder:
 惊吓	usja	7860000
 懔	usjb	605000
 𢥢	usjc	0
-𪭐	usji	0
 㥫	usjk	4080
 惊	usjk	131000000
 𢞟	usjl	0
@@ -89350,7 +85838,6 @@ encoder:
 㥬	usws	4450
 𢚚	uswz	0
 𢣸	usxj	0
-𪭏	usxk	0
 悢	usxo	817000
 𢠯	usxq	0
 惊骇	usxs	2130000
@@ -89435,15 +85922,12 @@ encoder:
 㦈	uulk	3930
 憎	uulk	4130000
 𢣂	uumh	0
-𪭕	uumy	0
 善待	uuob	6130000
-𪬯	uuol	0
 善后	uupa	4560000
 憐	uurm	1720000
 𢣶	uurm	0
 善意	uusk	11200000
 𢟣	uusk	0
-𪭞	uuss	0
 善良	uusx	28800000
 懩	uusx	41800
 炎症	uuta	7880000
@@ -89460,11 +85944,9 @@ encoder:
 𢣙	uuwc	0
 𢤨	uuwi	0
 憦	uuwy	26700
-𪬴	uuwz	0
 慊	uuxk	327000
 𢛗	uuym	0
 𢤻	uuym	0
-𪭝	uuyr	0
 惓	uuyy	117000
 悌	uuyz	1170000
 㥪	uuzm	4470
@@ -89474,7 +85956,6 @@ encoder:
 为辅	uvhf	2830000
 为止	uvii	80900000
 为此	uvir	43700000
-𪬰	uvjq	0
 为题	uvka	2400000
 𢟗	uvkb	0
 为时	uvkd	3970000
@@ -89508,7 +85989,6 @@ encoder:
 悾	uwbi	643000
 悰	uwbk	513000
 愃	uwbk	86600
-𪬒	uwbr	0
 𢥼	uwbw	0
 煽动	uwbz	18500000
 𢞐	uwcj	0
@@ -89522,14 +86002,11 @@ encoder:
 恽	uwhe	701000
 熔点	uwij	1320000
 𢠠	uwix	0
-𪭛	uwjg	0
 𢠲	uwjk	0
 𢞏	uwjn	0
 𢣐	uwkl	0
-𪬽	uwko	0
 𢠭	uwkx	0
 懧	uwla	45600
-𪬚	uwlc	0
 惼	uwld	27000
 𢣄	uwlj	0
 㦥	uwlw	26200
@@ -89546,8 +86023,6 @@ encoder:
 㤾	uwof	4530
 愹	uwoj	19200
 𢢈	uwot	0
-𪭑	uwpk	0
-𪬱	uwpo	0
 炉膛	uwqk	609000
 𢣼	uwrb	0
 㦀	uwrc	5110
@@ -89585,9 +86060,7 @@ encoder:
 𢟔	uwxo	0
 炉子	uwya	1790000
 𢛙	uwyz	0
-𪬉	uwzm	0
 熔断	uwzu	1100000
-𪬨	uxae	0
 𢜽	uxag	0
 𢘶	uxbd	0
 𢠢	uxbd	0
@@ -89638,13 +86111,11 @@ encoder:
 快件	uxnm	2650000
 㦦	uxnr	4450
 𢘧	uxod	0
-𪬭	uxod	0
 𢚌	uxoo	0
 快艇	uxpy	2180000
 㥡	uxrf	4250
 快乐	uxrk	224000000
 怩	uxrr	239000
-𪭄	uxrx	0
 慅	uxsi	31200
 歉意	uxsk	12600000
 怪话	uxsm	243000
@@ -89709,7 +86180,6 @@ encoder:
 𢡉	uysi	0
 劵商	uysu	29100
 𢚴	uysw	0
-𪬵	uyti	0
 𢢊	uyug	0
 𢤸	uyug	0
 卷烟	uyuj	5130000
@@ -89772,7 +86242,6 @@ encoder:
 惨重	uzmk	4580000
 慈利	uzmk	340000
 数年	uzmm	20400000
-𪭍	uzmz	0
 惯例	uzna	9960000
 数值	uzne	12900000
 惨白	uznk	608000
@@ -89793,7 +86262,6 @@ encoder:
 塑胶	uzqs	16400000
 数月	uzqv	4870000
 惯犯	uzqy	507000
-𪫻	uzrd	0
 𢟒	uzrr	0
 数论	uzso	455000
 惨状	uztg	3750000
@@ -89850,21 +86318,18 @@ encoder:
 𤃈	vaer	0
 举世	vaev	5470000
 河槽	vafe	113000
-𪸍	vaff	0
 举杯	vafg	2920000
 河西	vafj	13700000
 河套	vagc	774000
 𣵞	vagj	0
 兴奋	vagk	48500000
 𣸸	vagk	0
-𪶱	vagm	0
 㴿	vago	5710
 𣲘	vagr	0
 添	vagu	42700000
 𣵍	vagx	0
 兴致	vahm	15500000
 兴盛	vahy	3080000
-𪶌	vaid	0
 举止	vaii	7030000
 泟	vaii	103000
 河口	vaja	5810000
@@ -89880,10 +86345,8 @@ encoder:
 𣽐	vakl	0
 浭	vako	63200
 河畔	vaku	11000000
-𪷑	vaku	0
 汗水	vakv	10900000
 河水	vakv	7240000
-𪷒	vakw	0
 举贤	vakx	278000
 𣶣	vakz	0
 𣶩	vakz	0
@@ -89969,7 +86432,6 @@ encoder:
 澆	vbbg	1970000
 𣼤	vbbg	0
 江城	vbbh	3790000
-𪴞	vbbk	0
 𤃋	vbbl	0
 法规	vbbo	449000000
 𣽟	vbbr	0
@@ -90015,7 +86477,6 @@ encoder:
 涞	vbkv	1130000
 涞水	vbkv	278000
 潜水	vbkv	22200000
-𪶾	vbkw	0
 𣷻	vbla	0
 㴂	vblb	5660
 𣷻	vblb	0
@@ -90024,7 +86485,6 @@ encoder:
 𣵨	vbld	0
 法典	vble	2350000
 江岸	vblg	3100000
-𪷲	vblh	0
 法则	vblk	14000000
 江山	vbll	16700000
 瀆	vbll	566000
@@ -90062,11 +86522,9 @@ encoder:
 𤄁	vbqi	0
 㳩	vbqs	4290
 𣼳	vbqs	0
-𪸘	vbqu	0
 𤃲	vbqz	0
 沅	vbrd	3600000
 法条	vbrf	721000
-𪶳	vbri	0
 𣹡	vbrk	0
 𣳩	vbro	0
 㳣	vbrr	4720
@@ -90129,7 +86587,6 @@ encoder:
 法案	vbwz	8230000
 潜心	vbwz	3480000
 𣽏	vbwz	0
-𪫱	vbxb	0
 浯	vbxj	774000
 𤃀	vbxk	0
 𣳏	vbxs	0
@@ -90137,9 +86594,7 @@ encoder:
 涍	vbya	41400
 江陵	vbyb	2090000
 沅陵	vbyb	523000
-𪶜	vbyi	0
 𤀺	vbyj	0
-𪸎	vbyl	0
 江孜	vbym	400000
 漖	vbym	195000
 潜力	vbym	37100000
@@ -90221,8 +86676,6 @@ encoder:
 清盘	vcpl	409000
 淸	vcqa	1360000
 㵾	vcql	4070
-𪷱	vcql	0
-𪸧	vcqm	0
 清脆	vcqr	7050000
 𣷴	vcrh	0
 𣿛	vcrj	0
@@ -90266,7 +86719,6 @@ encoder:
 滶	vcym	38700
 清除	vcyo	296000000
 潔	vcyz	14400000
-𪷁	vczj	0
 清剿	vczk	721000
 灩	vczl	609000
 𡝝	vczm	0
@@ -90297,7 +86749,6 @@ encoder:
 㳺	vdmy	5020
 州	vdnd	99300000
 举	vdob	75100000
-𫀋	vdog	0
 挙	vdom	726000
 誉	vdos	25400000
 浙	vdpd	90800000
@@ -90305,8 +86756,6 @@ encoder:
 鼡	vdqb	139000
 𩖟	vdqi	0
 𧇳	vdri	0
-𪷤	vdsp	0
-𪷀	vdue	0
 浙江	vdvb	226000000
 浗	vdvs	873000
 栄	vdwf	7970000
@@ -90321,10 +86770,8 @@ encoder:
 労	vdwy	5720000
 学	vdwy	406000000
 𣻧	vdxw	0
-𪶲	vdyj	0
 敩	vdym	128000
 澣	veae	90100
-𪶻	veae	0
 满天	veag	8450000
 濛	veag	1480000
 𣿮	veag	0
@@ -90343,7 +86790,6 @@ encoder:
 𤅼	vebr	0
 𤅽	vebr	0
 𣶽	vebz	0
-𪸙	vebz	0
 渎职	vecj	1960000
 𣽇	vecx	0
 灌救	vedv	55700
@@ -90360,20 +86806,17 @@ encoder:
 瀻	veeo	338000
 潮	veeq	47500000
 𣿯	veex	0
-𪷶	veez	0
 灌木	vefa	4780000
 𣽡	vefd	0
 泄露	vefj	13400000
 𣺋	vefj	0
 灡	vefl	374000
 𣸃	vefs	0
-𪸞	vefw	0
 𤅠	vegc	0
 𣸽	vege	0
 渃	vegj	63200
 满面	vegj	10800000
 濗	vegl	18900
-𪸄	vegx	0
 𤂘	vehh	0
 𣸻	vehm	0
 洪雅	vehn	450000
@@ -90388,7 +86831,6 @@ encoder:
 漌	vejc	19400
 𣾑	vejc	0
 𤃂	vejd	0
-𪷖	vejd	0
 𣼑	vejf	0
 𣾓	vejh	0
 满足	veji	118000000
@@ -90580,7 +87022,6 @@ encoder:
 𤄓	vexg	0
 濸	vexj	73800
 𤃦	vexk	0
-𪸂	vexl	0
 瀟	vexn	503000
 汥	vexs	49100
 潮阳	veyk	1800000
@@ -90593,7 +87034,6 @@ encoder:
 渫	vezf	264000
 𤄶	vezf	0
 㶓	vezh	4680
-𪭬	vezh	0
 港台	vezj	41100000
 𣹓	vezj	0
 𣺾	vezj	0
@@ -90608,8 +87048,6 @@ encoder:
 𣺕	vfae	0
 𣸑	vfaf	0
 𣾐	vfaj	0
-𪸗	vfal	0
-𪷓	vfan	0
 𣻔	vfau	0
 溎	vfbb	52300
 㵱	vfbd	5820
@@ -90679,13 +87117,11 @@ encoder:
 𣿙	vfll	0
 𣿊	vflm	0
 𣿦	vflo	0
-𪷯	vfme	0
 𤃏	vfmg	0
 𧗉	vfml	0
 漂移	vfmr	3210000
 𣿋	vfmu	0
 𣸯	vfmy	0
-𪜛	vfmy	0
 沐川	vfnd	289000
 淅川	vfnd	376000
 瀖	vfni	26900
@@ -90699,14 +87135,12 @@ encoder:
 𤂭	vfoe	0
 漆	vfok	27500000
 𣿀	vfok	0
-𪸏	vfok	0
 淶	vfoo	705000
 𤂉	vfoo	0
 𤅷	vfoo	0
 𤀍	vfop	0
 𪅍	vfor	0
 𤅒	vfou	0
-𪭃	vfou	0
 澪	vfow	1530000
 𤅫	vfow	0
 淞	vfoz	4510000
@@ -90774,7 +87208,6 @@ encoder:
 𤄐	vfyk	0
 𪆟	vfyr	0
 𪆵	vfyr	0
-𪷎	vfyy	0
 𤄿	vfzf	0
 㜑	vfzm	4360
 㴗	vfzm	3880
@@ -90786,10 +87219,7 @@ encoder:
 𣳙	vgae	0
 渏	vgaj	63900
 𤂾	vgak	0
-𪶕	vgay	0
-𪶐	vgaz	0
 涯	vgbb	9770000
-𪶽	vgbb	0
 𣳇	vgbi	0
 㴎	vgbk	4580
 㵔	vgbm	6040
@@ -90819,7 +87249,6 @@ encoder:
 湹	vgkb	126000
 潦	vgkk	1340000
 𣿳	vgku	0
-𪷰	vgku	0
 沥水	vgkv	263000
 𣵟	vgkv	0
 𣸼	vgkv	0
@@ -90837,7 +87266,6 @@ encoder:
 𤃉	vgmw	0
 𣶐	vgmy	0
 𣽂	vgnd	0
-𪷏	vgni	0
 源	vgnk	268000000
 源泉	vgnk	10900000
 源自	vgnl	9420000
@@ -90857,10 +87285,8 @@ encoder:
 𧚚	vgsr	0
 源头	vgtg	10500000
 涿鹿	vgtx	453000
-𪸁	vgtx	0
 𣷟	vgub	0
 𤄊	vgub	0
-𪷳	vgud	0
 𣸷	vguk	0
 𣽄	vguk	0
 洃	vguo	126000
@@ -90888,7 +87314,6 @@ encoder:
 𣸵	vhaz	0
 汇款	vhbb	65700000
 𣿷	vhbb	0
-𪶛	vhbd	0
 涇	vhbi	293000
 𣸂	vhbo	0
 汇聚	vhcx	10400000
@@ -90915,8 +87340,6 @@ encoder:
 灊	vhjl	425000
 澸	vhjw	25000
 𣽦	vhjz	0
-𪷐	vhkc	0
-𪶰	vhkd	0
 浅显	vhkk	1830000
 浇水	vhkv	2980000
 𣹐	vhkz	0
@@ -90933,7 +87356,6 @@ encoder:
 柒佰	vhna	62800
 汇集	vhnf	12800000
 滙	vhni	580000
-𪷴	vhni	0
 柒仟	vhnm	51100
 𣾀	vhnn	0
 汇价	vhno	1770000
@@ -90945,11 +87367,8 @@ encoder:
 沤	vhos	943000
 𣶠	vhou	0
 浇铸	vhpc	702000
-𫇄	vhpc	0
 渐	vhpd	26800000
-𫘞	vhpo	0
 𣲪	vhrd	0
-𪸨	vhri	0
 潛	vhrk	4730000
 𤁭	vhrl	0
 𤂯	vhrl	0
@@ -90975,11 +87394,9 @@ encoder:
 渠	vhxf	9080000
 𤂐	vhxl	0
 𣶔	vhxn	0
-𪸐	vhxz	0
 沏	vhyd	2030000
 𤀠	vhyu	0
 𤏁	vhyu	0
-𪸌	vhyw	0
 𣶕	vhzc	0
 㵴	vhzh	12800
 沌	vhzi	1540000
@@ -91030,7 +87447,6 @@ encoder:
 濾	vikw	3290000
 𤄦	vikw	0
 淑	vikx	16400000
-𪷷	viky	0
 𤂡	vikz	0
 𣻐	vilc	0
 𣴯	vili	0
@@ -91053,7 +87469,6 @@ encoder:
 𤃒	viol	0
 𤃯	viop	0
 𤁊	vios	0
-𪶞	vios	0
 滮	vipd	54100
 𣾅	vipk	0
 𣾥	vipy	0
@@ -91062,7 +87477,6 @@ encoder:
 𣻶	virb	0
 濒危	virg	4030000
 涉外	viri	8300000
-𪸅	viro	0
 泚	virr	285000
 𤃫	virr	0
 𣿤	virs	0
@@ -91076,7 +87490,6 @@ encoder:
 㵃	viwr	4640
 涉案	viwz	4890000
 滤	viwz	17700000
-𪶖	vixa	0
 𣵕	vixi	0
 泸	vixm	2490000
 𣲏	vixs	0
@@ -91157,16 +87570,13 @@ encoder:
 溃烂	vjuu	2060000
 涡流	vjvs	1090000
 泅渡	vjvt	260000
-𪶵	vjwm	0
 溃退	vjwx	311000
 𣲷	vjxs	0
 𣳚	vjxs	0
 𣳲	vjya	0
 𣴵	vjya	0
 浥	vjyi	261000
-𪶧	vjyk	0
 𣳧	vjzd	0
-𪸆	vjzi	0
 𣹺	vjzk	0
 𣷢	vjzq	0
 淂	vkad	665000
@@ -91189,7 +87599,6 @@ encoder:
 溡	vkbd	725000
 𣻞	vkbd	0
 𣵀	vkbi	0
-𪷠	vkbj	0
 濐	vkbm	211000
 油井	vkbn	901000
 灙	vkbu	136000
@@ -91206,7 +87615,6 @@ encoder:
 滥捕	vkdf	105000
 混排	vkdk	546000
 𣼬	vkdp	0
-𪶨	vkds	0
 渴求	vkdv	1780000
 滭	vkeb	29100
 𤀾	vkee	0
@@ -91247,7 +87655,6 @@ encoder:
 𣽠	vkix	0
 沙哑	vkja	1300000
 漟	vkjb	92400
-𪸬	vkjd	0
 漫骂	vkjj	8940000
 澋	vkjk	34200
 澢	vkjk	32600
@@ -91261,7 +87668,6 @@ encoder:
 䣉	vkjy	3270
 消暑	vkkb	2870000
 灅	vkkb	52100
-𪷵	vkkb	0
 浀	vkkd	132000
 滉	vkkg	424000
 濃	vkkg	18400000
@@ -91322,7 +87728,6 @@ encoder:
 乷	vkmy	83800
 油气	vkmy	4320000
 湿气	vkmy	1040000
-𪟞	vkmy	0
 娑	vkmz	3830000
 混乱	vkmz	33300000
 𦀟	vkmz	0
@@ -91343,7 +87748,6 @@ encoder:
 璗	vkoc	42600
 混入	vkod	4290000
 滥杀	vkof	803000
-𪴙	vkof	0
 𧑘	vkoi	0
 𣽞	vkoj	0
 瀑	vkok	5340000
@@ -91386,7 +87790,6 @@ encoder:
 消音	vksk	2160000
 沙市	vksl	744000
 渂	vkso	27600
-𪷹	vkso	0
 渴望	vksq	34200000
 裟	vksr	916000
 漫谈	vksu	5930000
@@ -91433,7 +87836,6 @@ encoder:
 沙滩	vkvx	14700000
 沙害	vkwc	46100
 消逝	vkwd	5670000
-𪸃	vkwg	0
 温室	vkwh	5860000
 消遣	vkwj	6880000
 沙迦	vkwy	262000
@@ -91443,14 +87845,12 @@ encoder:
 油层	vkxb	216000
 𣼦	vkxb	0
 𣼫	vkxi	0
-𪷧	vkxl	0
 𣴉	vkxs	0
 温柔	vkxx	49100000
 沙子	vkya	4780000
 消弭	vkyc	713000
 𤃑	vkyg	0
 𣸬	vkyj	0
-𪶤	vkym	0
 消费	vkyn	151000000
 消除	vkyo	39800000
 消防	vkys	38000000
@@ -91469,7 +87869,6 @@ encoder:
 𣺝	vkzz	0
 𤂽	vkzz	0
 𣵼	vlae	0
-𪶴	vlae	0
 𣿄	vlak	0
 𣼍	vlal	0
 漄	vlbb	94400
@@ -91477,7 +87876,6 @@ encoder:
 𣳷	vlbd	0
 淍	vlbj	47500
 濖	vlbm	21900
-𪷥	vlbm	0
 𤅵	vlbq	0
 𣵘	vlbr	0
 潶	vlbu	522000
@@ -91546,7 +87944,6 @@ encoder:
 滑县	vllz	489000
 瀴	vllz	58200
 滑稽	vlmg	16300000
-𪷂	vlmi	0
 𣽋	vlmj	0
 测算	vlml	8340000
 𣺐	vlmo	0
@@ -91582,13 +87979,11 @@ encoder:
 潉	vlrr	52100
 𤁣	vlrr	0
 𤄧	vlrs	0
-𪶶	vlrs	0
 湍急	vlrx	1140000
 𪂔	vlrz	0
 𪆸	vlrz	0
 测评	vlsa	21300000
 𣷪	vlsc	0
-𪷕	vlse	0
 测试	vlsh	321000000
 𤀆	vlss	0
 涔	vlsx	2070000
@@ -91667,8 +88062,6 @@ encoder:
 海西	vmfj	1340000
 𣽤	vmfl	0
 海霞	vmfx	415000
-𪣧	vmgb	0
-𪶫	vmgb	0
 𤅲	vmgc	0
 沃	vmgd	59500000
 浩大	vmgd	3950000
@@ -91722,10 +88115,8 @@ encoder:
 湩	vmkb	84500
 浰	vmkd	44700
 㶘	vmke	4000
-𪷇	vmke	0
 𣼖	vmkf	0
 浩淼	vmkk	702000
-𪷼	vmkm	0
 洙	vmko	2140000
 潲	vmkq	121000
 𣸪	vmkr	0
@@ -91739,7 +88130,6 @@ encoder:
 海岸	vmlg	24700000
 潈	vmlg	144000
 潨	vmlg	92600
-𪶘	vmli	0
 洫	vmlk	206000
 淛	vmlk	46000
 汽缸	vmme	1760000
@@ -91748,7 +88138,6 @@ encoder:
 潨	vmmk	92600
 活血	vmml	3350000
 𣾽	vmmm	0
-𪷙	vmmo	0
 𤅏	vmms	0
 𤅃	vmmx	0
 瀿	vmmz	46500
@@ -91762,14 +88151,12 @@ encoder:
 泆	vmod	491000
 潻	vmok	472000
 𤂱	vmok	0
-𪸒	vmom	0
 澨	vmoo	44600
 洗钱	vmph	1890000
 洗盘	vmpl	1210000
 汽船	vmpq	727000
 海豹	vmpr	2380000
 𣵸	vmqd	0
-𪶏	vmqd	0
 海豚	vmqg	10700000
 瀩	vmqg	31000
 洗脸	vmqo	6680000
@@ -91783,7 +88170,6 @@ encoder:
 活象	vmrj	419000
 濳	vmrk	55300
 灒	vmrl	494000
-𪸡	vmrl	0
 㵲	vmrm	8680
 漡	vmro	32400
 鍌	vmrp	1670000
@@ -91870,7 +88256,6 @@ encoder:
 激烈	vnar	47000000
 澚	vnaz	26300
 𤀀	vnaz	0
-𪶸	vnbb	0
 𣲚	vnbd	0
 𣽎	vnbe	0
 湼	vnbi	86000
@@ -91915,11 +88300,9 @@ encoder:
 湟中	vnjv	214000
 𣶜	vnjz	0
 𣵤	vnka	0
-𪷇	vnke	0
 激光	vnkg	34800000
 𤃗	vnkl	0
 𣸇	vnko	0
-𪵀	vnkq	0
 激昂	vnkr	2780000
 濮	vnku	4580000
 𤂛	vnku	0
@@ -91942,16 +88325,12 @@ encoder:
 㵿	vnnn	4340
 激化	vnnr	3780000
 㳛	vnod	3800
-𪶟	vnod	0
 𤀈	vnog	0
 𤅛	vnog	0
-𪶷	vnog	0
 灚	vnol	538000
 𤃘	vnol	0
-𪷆	vnom	0
 𣾄	vnoo	0
 𣼺	vnor	0
-𪷄	vnor	0
 𣳦	vnos	0
 𤄚	vnou	0
 㶅	vnoy	21500
@@ -91961,7 +88340,6 @@ encoder:
 𣴟	vnrd	0
 滌	vnrf	962000
 𣺢	vnrf	0
-𪾍	vnrk	0
 𣺅	vnro	0
 𣺫	vnrp	0
 滫	vnrq	40700
@@ -91979,7 +88357,6 @@ encoder:
 淮北	vntr	5190000
 𣵲	vnub	0
 激情	vnuc	40300000
-𪷈	vnuc	0
 𤃙	vnue	0
 渊	vnuf	17400000
 澳	vnug	63800000
@@ -92013,7 +88390,6 @@ encoder:
 洽	voaj	21400000
 淪	voal	1580000
 𣹘	vobd	0
-𪶩	vobk	0
 𣺺	vobo	0
 𣹶	vobr	0
 浍	vobz	722000
@@ -92136,12 +88512,10 @@ encoder:
 沧	voyy	19300000
 滃	voyy	1400000
 潝	voyy	37400
-𪷅	voyy	0
 汹	vozi	321000
 𣳸	vozr	0
 㳂	vozs	5950
 洉	vpaj	113000
-𪸠	vpaj	0
 𣺧	vpal	0
 渓	vpbo	1590000
 浮动	vpbz	8460000
@@ -92160,7 +88534,6 @@ encoder:
 鸂	vpgr	57900
 湲	vpgx	857000
 淫威	vpha	887000
-𪸟	vphh	0
 㴲	vpih	6080
 浮点	vpij	2610000
 㴞	vpik	4360
@@ -92183,11 +88556,8 @@ encoder:
 淫秽	vpml	44800000
 派系	vpmz	5940000
 滔	vpnb	2490000
-𪷘	vpnk	0
 𤂚	vpnr	0
-𪸪	vpoj	0
 派往	vpos	1610000
-𪸚	vpow	0
 𣹊	vppd	0
 𤁩	vppl	0
 派兵	vppo	2150000
@@ -92199,7 +88569,6 @@ encoder:
 瀊	vpql	37100
 𤅪	vprd	0
 派	vprh	409000000
-𪡨	vprj	0
 𣾠	vpro	0
 𤅥	vprx	0
 浮记	vpsy	3590
@@ -92258,13 +88627,10 @@ encoder:
 𣻽	vqhb	0
 染成	vqhv	1930000
 𣶴	vqji	0
-𪷨	vqjr	0
 𤂲	vqko	0
 沿岸	vqlg	5640000
 盕	vqlk	17400
 沿用	vqlv	4680000
-𪷃	vqmo	0
-𪷻	vqne	0
 㵻	vqnx	4000
 沿街	vqob	2230000
 㶀	vqop	4930
@@ -92272,17 +88638,14 @@ encoder:
 沿儿	vqrd	85700
 㴯	vqrk	4460
 𣶘	vqrr	0
-𪷸	vqrr	0
 染色	vqry	6210000
 𣑱	vqsf	0
 浵	vqsp	66500
-𪟝	vqsy	0
 染病	vqta	1110000
 𣹸	vqub	0
 𥹦	vquf	0
 㴨	vqug	5020
 沿着	vqul	15300000
-𪶪	vquo	0
 染料	vqut	9540000
 𤂵	vquz	0
 沿江	vqvb	3880000
@@ -92294,15 +88657,11 @@ encoder:
 汍	vqya	82000
 淝	vqyi	1050000
 𤅂	vqyl	0
-𪟝	vqym	0
 𣳜	vqyy	0
 沿线	vqzh	9260000
 𥁼	vral	0
 湰	vram	408000
 𣹯	vraz	0
-𪸣	vrbg	0
-𪸮	vrbg	0
-𪶔	vrbi	0
 𣽃	vrbj	0
 漈	vrbk	238000
 兆赫	vrbn	357000
@@ -92327,7 +88686,6 @@ encoder:
 涤棉	vrfn	710000
 頫	vrgo	164000
 𣻳	vrgo	0
-𫗲	vrgo	0
 𤀴	vrgq	0
 𤃽	vrgq	0
 洈	vrgy	103000
@@ -92336,7 +88694,6 @@ encoder:
 𣳢	vrid	0
 𣵥	vrik	0
 潒	vrjg	137000
-𪸭	vrjk	0
 𩁧	vrjn	0
 浼	vrjr	3060000
 𤀧	vrjr	0
@@ -92361,11 +88718,9 @@ encoder:
 渔利	vrmk	648000
 𣶌	vrmo	0
 𣼋	vrmr	0
-𪷣	vrmr	0
 泖	vrmy	243000
 淘气	vrmy	10900000
 𤄏	vrmz	0
-𪸩	vrmz	0
 淊	vrnb	41200
 洛川	vrnd	370000
 𨾾	vrni	0
@@ -92373,13 +88728,11 @@ encoder:
 𣽌	vrnr	0
 兆位	vrns	270000
 沕	vrod	66700
-𪡐	vroj	0
 㳷	vrok	4590
 𣸄	vrok	0
 𣹒	vrok	0
 澹	vros	2310000
 𣲢	vros	0
-𪷗	vrot	0
 𣶾	vrou	0
 淴	vrow	53900
 洶	vroz	258000
@@ -92397,11 +88750,9 @@ encoder:
 鴵	vrrz	21000
 𣺥	vrrz	0
 𥁼	vrsl	0
-𪷺	vrsu	0
 𠡑	vrsy	0
 汮	vrtd	25700
 泈	vrtd	22800
-𪿀	vrtl	0
 㶍	vruc	4040
 淗	vruf	29000
 洛美	vrug	301000
@@ -92416,7 +88767,6 @@ encoder:
 洛宁	vrwa	245000
 𣸢	vrwm	0
 沟通	vrwx	61800000
-𪸢	vrwx	0
 浄	vrxb	1330000
 𤁒	vrxi	0
 𤂰	vrxk	0
@@ -92493,7 +88843,6 @@ encoder:
 汶上	vsiv	321000
 𤅝	vsiy	0
 游园	vsjb	1690000
-𪸈	vsjb	0
 𤄲	vsjc	0
 𣹾	vsje	0
 𤁘	vsji	0
@@ -92504,7 +88853,6 @@ encoder:
 㗟	vsjr	3560
 渷	vsjr	122000
 滾	vsjr	12400000
-𪷊	vsjr	0
 涥	vsjy	27900
 淳	vsjy	12700000
 𤅻	vsjy	0
@@ -92590,14 +88938,10 @@ encoder:
 游行	vsoi	12800000
 滧	vsom	27800
 洨	vsoo	1260000
-𪷽	vsop	0
 𣺓	vsor	0
 𤅭	vsor	0
-𪸉	vsor	0
-𪷞	vsos	0
 淤	vsot	3300000
 𣻒	vsow	0
-𪷋	vsoy	0
 𤄰	vspg	0
 注销	vspk	19200000
 滚翻	vspk	98200
@@ -92686,8 +89030,6 @@ encoder:
 滂	vsws	660000
 流通	vswx	60600000
 淳安	vswz	1080000
-𪤐	vsxb	0
-𪶮	vsxd	0
 游戏	vsxh	598000000
 漩	vsxi	1140000
 浪	vsxo	53400000
@@ -92699,7 +89041,6 @@ encoder:
 𤅀	vsyg	0
 𤅗	vsyg	0
 游民	vsyh	22800000
-𪸔	vsyj	0
 济阳	vsyk	754000
 浏阳	vsyk	2620000
 潡	vsym	698000
@@ -92732,9 +89073,7 @@ encoder:
 泫	vszz	862000
 流出	vszz	20000000
 𣴔	vtae	0
-𪸥	vtbx	0
 灋	vtbz	84700
-𪸖	vteb	0
 㳆	vted	3900
 𣳝	vted	0
 㵂	vteu	5600
@@ -92753,20 +89092,16 @@ encoder:
 𤃢	vtjm	0
 𣼟	vtkv	0
 𣴿	vtmb	0
-𪷝	vtmb	0
 𣳥	vtmh	0
 㶐	vtnw	4060
 瀍	vtob	175000
-𪷚	vtob	0
 𤄟	vtoj	0
 渡船	vtpq	1390000
 澬	vtrl	77800
 𣳩	vtro	0
 𣼀	vtrp	0
-𪷟	vtrq	0
 𣷳	vtrs	0
 润色	vtry	841000
-𪸫	vtub	0
 𤃱	vtuf	0
 瀌	vtuo	32600
 濂	vtux	3180000
@@ -92775,7 +89110,6 @@ encoder:
 润滑	vtvl	8960000
 澜沧	vtvo	419000
 渡过	vtwd	5180000
-𪸜	vtwr	0
 溏	vtxj	3760000
 漮	vtxk	37100
 滽	vtxl	27700
@@ -92784,7 +89118,6 @@ encoder:
 𣿕	vtzu	0
 㳕	vubd	3940
 溠	vubi	115000
-𪷉	vubk	0
 滋长	vuch	1310000
 𤀡	vucx	0
 滋扰	vudg	378000
@@ -92820,7 +89153,6 @@ encoder:
 淡水	vukv	21900000
 漛	vukv	18600
 𣻌	vukv	0
-𪷫	vuky	0
 潧	vulk	1080000
 洋县	vulz	354000
 𣹌	vumf	0
@@ -92860,7 +89192,6 @@ encoder:
 𣷇	vuuo	0
 𣺸	vuuo	0
 𤄂	vuuu	0
-𪸦	vuux	0
 㴴	vuuz	9130
 淡漠	vuve	2920000
 洋浦	vuvf	491000
@@ -92873,7 +89204,6 @@ encoder:
 渊深	vuvw	143000
 渊远	vuwb	179000
 𣿩	vuwb	0
-𪸓	vuwb	0
 瀅	vuwc	967000
 濚	vuwf	130000
 㶈	vuwi	4000
@@ -93001,11 +89331,9 @@ encoder:
 深切	vwhy	6060000
 滱	vwix	35100
 𣵈	vwiz	0
-𪷾	vwji	0
 㴦	vwjj	5180
 浑圆	vwjj	1480000
 演唱	vwjk	105000000
-𪷿	vwjk	0
 学员	vwjl	20200000
 演员	vwjl	85200000
 沉吟	vwjo	5340000
@@ -93017,7 +89345,6 @@ encoder:
 𤁖	vwkf	0
 渖	vwki	264000
 𤃜	vwkk	0
-𪸛	vwkk	0
 濱	vwkl	4250000
 演	vwko	49400000
 𣿌	vwkr	0
@@ -93081,7 +89408,6 @@ encoder:
 学会	vwob	82800000
 学徒	vwob	17300000
 𤀕	vwob	0
-𪸯	vwoc	0
 深入	vwod	88300000
 𣿈	vwoe	0
 深	vwof	301000000
@@ -93091,7 +89417,6 @@ encoder:
 觉得	vwok	397000000
 𣺑	vwol	0
 𣼂	vwol	0
-𪸕	vwol	0
 𤀿	vwoo	0
 㵳	vwop	7520
 𣽬	vwot	0
@@ -93128,7 +89453,6 @@ encoder:
 𤉠	vwru	0
 涴	vwry	598000
 深色	vwry	3660000
-𪶭	vwry	0
 𣸦	vwrz	0
 演讲	vwsb	28800000
 滓	vwse	1460000
@@ -93138,7 +89462,6 @@ encoder:
 深交	vwso	4330000
 溟	vwso	1540000
 𣼗	vwso	0
-𪷪	vwso	0
 深望	vwsq	28200
 学说	vwsv	10700000
 演说	vwsv	5470000
@@ -93165,7 +89488,6 @@ encoder:
 𤁷	vwul	0
 𣿪	vwun	0
 淀粉	vwuo	14600000
-𪷩	vwuu	0
 深为	vwuv	1360000
 𣸈	vwux	0
 沁源	vwvg	357000
@@ -93192,7 +89514,6 @@ encoder:
 沉溺	vwvy	3870000
 深远	vwwb	9190000
 学过	vwwd	5670000
-𪸊	vwwf	0
 学家	vwwg	23900000
 沉寂	vwwi	5980000
 澝	vwwl	48900
@@ -93222,7 +89543,6 @@ encoder:
 沁阳	vwyk	552000
 沈阳	vwyk	82100000
 泌阳	vwyk	505000
-𪶭	vwym	0
 学费	vwyn	13100000
 沉降	vwyr	1530000
 沉陷	vwyr	510000
@@ -93238,7 +89558,6 @@ encoder:
 𤀓	vwzk	0
 𤁂	vwzl	0
 洝	vwzm	369000
-𪷛	vwzn	0
 浓缩	vwzw	10300000
 演绎	vwzx	27800000
 学好	vwzy	6330000
@@ -93251,7 +89570,6 @@ encoder:
 湀	vxag	534000
 泥土	vxba	3490000
 堻	vxbb	46900
-𪸑	vxbb	0
 津	vxbd	39100000
 𣻷	vxbd	0
 汉城	vxbh	4550000
@@ -93310,7 +89628,6 @@ encoder:
 湋	vxjm	58400
 𤁵	vxjn	0
 澼	vxjs	55300
-𪸰	vxjs	0
 澄	vxju	12900000
 𣹢	vxju	0
 汉中	vxjv	6280000
@@ -93421,7 +89738,6 @@ encoder:
 泽普	vxuk	196000
 涵盖	vxul	11300000
 濜	vxul	25400
-𪿉	vxul	0
 涵养	vxun	2100000
 漏粉	vxuo	85300
 泥塑	vxuz	1290000
@@ -93454,14 +89770,12 @@ encoder:
 浸	vxwx	17900000
 汉字	vxwy	60800000
 㵍	vxwz	4090
-𪷡	vxxf	0
 汿	vxxi	19200
 𤁍	vxxi	0
 𣲺	vxxs	0
 涰	vxxx	28200
 溊	vxxx	23400
 𣴫	vxxx	0
-𪶡	vxxx	0
 汉子	vxya	5680000
 汉阳	vxyk	2350000
 波阳	vxyk	159000
@@ -93525,14 +89839,12 @@ encoder:
 涨跌	vyjm	16300000
 𣽻	vykh	0
 𣶻	vyki	0
-𪶺	vyki	0
 𣹝	vykq	0
 沸水	vykv	2420000
 溺水	vykv	2110000
 涨幅	vyla	14300000
 䀀	vylk	17800
 梁山	vyll	3810000
-𪷢	vylo	0
 汲县	vylz	51100
 滁县	vylz	55500
 𣿃	vylz	0
@@ -93572,7 +89884,6 @@ encoder:
 汤勺	vyrs	288000
 㲽	vysa	4250
 𣽔	vysb	0
-𪲭	vysf	0
 涩	vysi	16300000
 澀	vysi	4010000
 𥁤	vysl	0
@@ -93607,12 +89918,10 @@ encoder:
 㵫	vyyk	5730
 𣻭	vyyl	0
 泐	vyym	250000
-𪶚	vyym	0
 漝	vyyn	33100
 濯	vyyn	2800000
 汤阴	vyyq	515000
 𣹩	vyyq	0
-𪷮	vyys	0
 溺	vyyt	6930000
 𣴆	vyyt	0
 𣷺	vyyx	0
@@ -93648,16 +89957,13 @@ encoder:
 𣹤	vzjm	0
 𣷢	vzjq	0
 㖳	vzjr	3710
-𪷍	vzjw	0
 㴩	vzjy	5090
 㵖	vzjz	3960
 漅	vzkf	28700
 淄	vzki	1770000
-𪷭	vzki	0
 𣺤	vzkk	0
 𣿍	vzkl	0
 𥂖	vzkl	0
-𪶯	vzkm	0
 治水	vzkv	1930000
 淥	vzkv	110000
 渗水	vzkv	1010000
@@ -93666,7 +89972,6 @@ encoder:
 𣶄	vzlk	0
 𣳺	vzll	0
 𣻀	vzlo	0
-𪷬	vzlo	0
 𣾧	vzly	0
 浚县	vzlz	486000
 涘	vzma	2210000
@@ -93697,8 +90002,6 @@ encoder:
 𤄋	vzsw	0
 治病	vzta	6640000
 治疗	vzty	74700000
-𪶬	vzuf	0
-𪶹	vzuf	0
 汝州	vzvn	624000
 𣴍	vzvv	0
 渗漏	vzvx	2320000
@@ -93709,7 +90012,6 @@ encoder:
 𣸏	vzxm	0
 泼	vzxs	8980000
 𣷕	vzxs	0
-𪷌	vzxw	0
 汝阳	vzyk	342000
 灉	vzyn	516000
 灣	vzyz	15800000
@@ -93747,7 +90049,6 @@ encoder:
 迀	waed	30800
 宁南	wael	529000
 逼真	wael	9910000
-𫒓	waeo	0
 宁蒗	waev	306000
 富蕴	waez	207000
 迗	wagd	88300
@@ -93782,7 +90083,6 @@ encoder:
 𨒘	walm	0
 之内	walo	35500000
 宁冈	walo	73300
-𫑞	walo	0
 邐	walt	78500
 宁县	walz	5050000
 富县	walz	393000
@@ -93968,7 +90268,6 @@ encoder:
 社保	wbnj	10500000
 空白	wbnk	50300000
 运作	wbnm	27600000
-𫑤	wbno	0
 宣化	wbnr	1140000
 进化	wbnr	10700000
 进货	wbnr	9500000
@@ -93982,7 +90281,6 @@ encoder:
 运行	wboi	130000000
 进行	wboi	583000000
 𨘧	wbol	0
-𫑧	wbor	0
 运往	wbos	1920000
 空仓	wboy	1720000
 进仓	wboy	283000
@@ -93998,7 +90296,6 @@ encoder:
 𨘝	wbrn	0
 𨒮	wbro	0
 完毕	wbrr	31900000
-𫑡	wbrr	0
 宣言	wbsa	37900000
 宣讲	wbsb	2520000
 宣读	wbse	5630000
@@ -94139,7 +90436,6 @@ encoder:
 𡩞	wdai	0
 𡬈	wdai	0
 𣦍	wdai	0
-𪧙	wdai	0
 㝓	wdaj	4050
 寄	wdaj	223000000
 𡧻	wdaj	0
@@ -94152,7 +90448,6 @@ encoder:
 㿾	wdal	6130
 𡪲	wdal	0
 𧵒	wdal	0
-𪧑	wdal	0
 㝫	wdam	3930
 㲰	wdam	4430
 宺	wdan	22000
@@ -94168,7 +90463,6 @@ encoder:
 𡧒	wdar	0
 𡩲	wdar	0
 𡪊	wdar	0
-𫜨	wdar	0
 𡧊	wday	0
 𡩸	wdaz	0
 𡪑	wdaz	0
@@ -94185,7 +90479,6 @@ encoder:
 𡧱	wdbj	0
 𡫸	wdbj	0
 𡬋	wdbj	0
-𪧽	wdbj	0
 宗	wdbk	47800000
 宣	wdbk	41200000
 寐	wdbk	4290000
@@ -94196,12 +90489,9 @@ encoder:
 𡩮	wdbl	0
 𡪓	wdbl	0
 𧹆	wdbl	0
-𪧶	wdbl	0
 宑	wdbn	36100
 㝬	wdbo	3750
 𡧢	wdbo	0
-𫑣	wdbo	0
-𪧮	wdbq	0
 完	wdbr	246000000
 鶎	wdbr	959
 𡩃	wdbr	0
@@ -94237,8 +90527,6 @@ encoder:
 𡨲	wdcr	0
 宝	wdcs	469000000
 㝡	wdcx	5300
-𪧴	wdcx	0
-𪧖	wddj	0
 𧵿	wddl	0
 衬托	wddm	5340000
 守势	wddq	404000
@@ -94259,7 +90547,6 @@ encoder:
 寛	wdel	5480000
 𡩖	wdel	0
 𡨄	wdeo	0
-𪨀	wdeo	0
 定期	wdeq	106000000
 过期	wdeq	23300000
 𡨜	wdet	0
@@ -94272,9 +90559,6 @@ encoder:
 𡧰	wdez	0
 𡩧	wdez	0
 𡩴	wdez	0
-𪧡	wdez	0
-𪧱	wdez	0
-𪧸	wdez	0
 𡨾	wdfb	0
 𨕝	wdfb	0
 㝝	wdff	4070
@@ -94284,16 +90568,13 @@ encoder:
 𡧳	wdfj	0
 寴	wdfl	39600
 𡫎	wdfm	0
-𪧹	wdfp	0
 𡪎	wdfr	0
 𡫊	wdfs	0
 寭	wdfw	28000
 𢚠	wdfw	0
-𪨁	wdfz	0
 过硬	wdga	10600000
 𡩳	wdgb	0
 𡫼	wdgb	0
-𪧷	wdgc	0
 䢇	wdgd	3410
 定夺	wdgd	1070000
 𡫦	wdgd	0
@@ -94313,7 +90594,6 @@ encoder:
 宥	wdgq	5030000
 家	wdgq	1100000000
 𡧘	wdgq	0
-𪧼	wdgq	0
 𡧉	wdgr	0
 𡫰	wdgr	0
 𪀱	wdgr	0
@@ -94323,15 +90603,11 @@ encoder:
 𤠊	wdgs	0
 𢥜	wdgu	0
 𢥛	wdgw	0
-𪬜	wdgw	0
 𡧭	wdgy	0
 𡫌	wdgy	0
 宏	wdgz	71800000
-𪧵	wdgz	0
 室	wdhb	549000000
-𪧳	wdhh	0
 𪀥	wdhr	0
-𪧩	wdhu	0
 宬	wdhy	462000
 过盛	wdhy	311000
 𡩍	wdhy	0
@@ -94372,7 +90648,6 @@ encoder:
 额	wdjg	90500000
 𡧲	wdji	0
 𡨌	wdji	0
-𪧚	wdji	0
 宫	wdjj	99700000
 𡩾	wdjj	0
 𡫆	wdjj	0
@@ -94406,7 +90681,6 @@ encoder:
 𡬗	wdju	0
 𧯜	wdju	0
 𧯳	wdju	0
-𪧛	wdju	0
 愙	wdjw	66500
 𢞩	wdjw	0
 𠢆	wdjy	0
@@ -94422,7 +90696,6 @@ encoder:
 𡫝	wdka	0
 𡪂	wdkb	0
 𡪸	wdkb	0
-𪧿	wdkb	0
 𡨰	wdkc	0
 𩤡	wdkc	0
 定时	wdkd	15900000
@@ -94433,13 +90706,11 @@ encoder:
 𡪪	wdkg	0
 宙	wdki	8240000
 审	wdki	51700000
-𪧔	wdki	0
 寮	wdkk	13800000
 𠝳	wdkk	0
 𠠙	wdkk	0
 𡩦	wdkk	0
 𡪏	wdkk	0
-𪧧	wdkk	0
 寳	wdkl	4660000
 覾	wdkl	22400
 賓	wdkl	7290000
@@ -94480,9 +90751,7 @@ encoder:
 㝤	wdlb	4370
 寗	wdlb	68400
 𡩋	wdlb	0
-𫁼	wdlb	0
 宜	wdlc	64100000
-𪧻	wdle	0
 𡩈	wdlf	0
 𡩼	wdlf	0
 寏	wdlg	28000
@@ -94505,7 +90774,6 @@ encoder:
 定岗	wdll	434000
 𡫨	wdll	0
 𧢘	wdll	0
-𪿨	wdll	0
 𡫄	wdlm	0
 𡫵	wdlm	0
 𣰨	wdlm	0
@@ -94518,7 +90786,6 @@ encoder:
 𡩂	wdlo	0
 𡬔	wdlp	0
 𨭧	wdlp	0
-𫇩	wdlq	0
 䴐	wdlr	4540
 定购	wdlr	10800000
 𡕹	wdlr	0
@@ -94531,7 +90798,6 @@ encoder:
 寬	wdls	23400000
 𡪍	wdlu	0
 𡫅	wdlu	0
-𪺧	wdlu	0
 憲	wdlw	5680000
 𡫇	wdlw	0
 𢜇	wdlw	0
@@ -94556,7 +90822,6 @@ encoder:
 𡧪	wdmh	0
 𡧿	wdmh	0
 𡨉	wdmh	0
-𪧺	wdmh	0
 㝚	wdmi	3800
 宱	wdmi	24100
 蜜	wdmi	42600000
@@ -94576,8 +90841,6 @@ encoder:
 𡪳	wdml	0
 𡪽	wdml	0
 𧶡	wdml	0
-𪧫	wdml	0
-𪧬	wdml	0
 守敌	wdmm	166000
 过年	wdmm	15900000
 𡪣	wdmm	0
@@ -94598,7 +90861,6 @@ encoder:
 𡪉	wdmy	0
 过敏	wdmz	11600000
 𡨑	wdmz	0
-𪧪	wdmz	0
 𡧛	wdnd	0
 定做	wdne	11600000
 𡨯	wdne	0
@@ -94611,8 +90873,6 @@ encoder:
 定向	wdnj	10800000
 𢳔	wdnm	0
 𤛝	wdnm	0
-𪧰	wdnm	0
-𪧜	wdnn	0
 定价	wdno	27200000
 𡨁	wdno	0
 𡩟	wdno	0
@@ -94623,7 +90883,6 @@ encoder:
 𡨇	wdnr	0
 𡪆	wdnr	0
 定位	wdns	59500000
-𪧢	wdnu	0
 定息	wdnw	213000
 𡧺	wdnx	0
 𨜳	wdny	0
@@ -94647,7 +90906,6 @@ encoder:
 蹇	wdoj	4090000
 𠹟	wdoj	0
 过得	wdok	17200000
-𪧲	wdok	0
 賽	wdol	27500000
 赛	wdol	141000000
 𡫛	wdol	0
@@ -94667,7 +90925,6 @@ encoder:
 𦢽	wdoo	0
 寥	wdop	1370000
 𡫱	wdop	0
-𪧕	wdop	0
 𦞫	wdoq	0
 鶱	wdor	60900
 謇	wdos	780000
@@ -94675,7 +90932,6 @@ encoder:
 𡧴	wdos	0
 寒	wdot	82200000
 𡬜	wdot	0
-𪧝	wdot	0
 𡨿	wdou	0
 𡪹	wdou	0
 𢞝	wdou	0
@@ -94688,7 +90944,6 @@ encoder:
 弿	wdoy	105000
 过分	wdoy	21200000
 𡧋	wdoy	0
-𪧠	wdoy	0
 㝐	wdoz	4410
 𡨭	wdoz	0
 𡩊	wdoz	0
@@ -94737,17 +90992,14 @@ encoder:
 𡫥	wdrj	0
 𡫲	wdrj	0
 𡬚	wdrj	0
-𪧞	wdrj	0
 守备	wdrk	876000
 𡨩	wdrk	0
-𪧯	wdrk	0
 䙾	wdrl	3350
 𡧸	wdrl	0
 𡩅	wdrl	0
 𡫛	wdrl	0
 𥁗	wdrl	0
 𧶉	wdrl	0
-𫁻	wdrl	0
 𡨥	wdrm	0
 𢼊	wdrm	0
 𢽉	wdrm	0
@@ -94773,7 +91025,6 @@ encoder:
 𡪬	wdry	0
 宼	wdrz	28800
 𪁶	wdrz	0
-𪧗	wdrz	0
 㝘	wdsa	3930
 𡫑	wdsb	0
 𡫓	wdsb	0
@@ -94793,7 +91044,6 @@ encoder:
 定产	wdsm	257000
 𡫀	wdsm	0
 𡫣	wdsm	0
-𪧨	wdsm	0
 过夜	wdsn	4800000
 𡧽	wdsn	0
 㝠	wdso	4980
@@ -94812,7 +91062,6 @@ encoder:
 㝗	wdsx	3950
 㝑	wdsy	3850
 𨓓	wdsy	0
-𫂊	wdte	0
 实	wdtg	151000000
 过头	wdtg	19500000
 过问	wdtj	5530000
@@ -94849,7 +91098,6 @@ encoder:
 叜	wdux	42600
 过快	wdux	5800000
 𡬎	wduz	0
-𪧤	wduz	0
 定兴	wdva	439000
 守法	wdvb	39600000
 𡪦	wdvb	0
@@ -94858,7 +91106,6 @@ encoder:
 过活	wdvm	1230000
 定州	wdvn	1020000
 过激	wdvn	2550000
-𪧟	wdvn	0
 宨	wdvr	51800
 逑	wdvs	1550000
 𡨃	wdvs	0
@@ -94869,7 +91116,6 @@ encoder:
 𡬀	wdwc	0
 𡬏	wdwc	0
 𡨺	wdwd	0
-𪧦	wdwd	0
 𡬇	wdwg	0
 𡬄	wdwk	0
 㝲	wdwl	3950
@@ -94910,7 +91156,6 @@ encoder:
 𡫽	wdwz	0
 𡩌	wdxb	0
 𡩿	wdxb	0
-𪹦	wdxb	0
 定居	wdxe	6070000
 𡧖	wdxf	0
 𡪧	wdxf	0
@@ -94930,7 +91175,6 @@ encoder:
 𦥉	wdxj	0
 㝩	wdxk	4110
 𠝬	wdxk	0
-𪨂	wdxk	0
 賔	wdxl	30900
 𡧝	wdxl	0
 𡧾	wdxl	0
@@ -94941,7 +91185,6 @@ encoder:
 𡧐	wdxo	0
 𡫕	wdxr	0
 㝊	wdxs	4280
-𪧒	wdxs	0
 𡪼	wdxu	0
 𡧕	wdxx	0
 𡨤	wdxx	0
@@ -94949,7 +91192,6 @@ encoder:
 𡪅	wdxy	0
 𨝢	wdxy	0
 𡪚	wdxz	0
-𪧥	wdxz	0
 字	wdya	693000000
 守卫	wdya	4700000
 定陵	wdyb	258000
@@ -94985,7 +91227,6 @@ encoder:
 翧	wdyy	68700
 𡦻	wdyy	0
 𨜌	wdyy	0
-𫆟	wdyy	0
 宆	wdyz	38000
 宖	wdyz	33200
 𡨻	wdyz	0
@@ -94994,17 +91235,13 @@ encoder:
 鞌	wdze	41900
 𡧵	wdze	0
 案	wdzf	103000000
-𪧘	wdzf	0
-𫐽	wdzf	0
 頞	wdzg	99000
 𡧑	wdzg	0
 𡩀	wdzg	0
 𡩽	wdzg	0
 𩓘	wdzg	0
 𧊹	wdzi	0
-𪧓	wdzi	0
 过细	wdzk	544000
-𪾐	wdzk	0
 䀂	wdzl	7790
 實	wdzl	29500000
 寶	wdzl	52600000
@@ -95023,13 +91260,11 @@ encoder:
 䴁	wdzr	5570
 定婚	wdzr	329000
 鴳	wdzr	36000
-𫜯	wdzr	0
 寣	wdzs	73000
 㝥	wdzu	4380
 定编	wdzw	391000
 𡪾	wdzw	0
 𡩝	wdzx	0
-𪧾	wdzx	0
 䢿	wdzy	3710
 定级	wdzy	1100000
 𠡓	wdzy	0
@@ -95069,7 +91304,6 @@ encoder:
 𨙕	wejn	0
 赛跑	wejr	3000000
 𨘏	wejr	0
-𫑢	wejr	0
 寒暑	wekb	1310000
 𨘦	wekb	0
 𨕡	weke	0
@@ -95085,9 +91319,7 @@ encoder:
 𦳖	weld	0
 𨗲	welj	0
 遭罪	welk	455000
-𫉙	welo	0
 邁	welz	6200000
-𫑨	wemb	0
 𨕇	wemi	0
 赛程	wemj	6210000
 寒气	wemy	2980000
@@ -95097,7 +91329,6 @@ encoder:
 遳	weob	27100
 宽余	weom	170000
 寒舍	weom	800000
-𫒂	weox	0
 赛后	wepa	4690000
 遭受	wepw	22100000
 寒风	weqo	7050000
@@ -95156,7 +91387,6 @@ encoder:
 𨖇	wfds	0
 䢞	wffa	3430
 𨗆	wfgl	0
-𫒍	wfgs	0
 𨗇	wfgw	0
 遷	wfgy	3300000
 速成	wfhv	6340000
@@ -95174,7 +91404,6 @@ encoder:
 𨗷	wflj	0
 𨖒	wflo	0
 𨕞	wfme	0
-𫑻	wfmh	0
 速算	wfml	781000
 𨔼	wfmy	0
 宋体	wfnf	48700000
@@ -95184,10 +91413,8 @@ encoder:
 逨	wfoo	67300
 𨙛	wfoo	0
 𨗺	wfow	0
-𫒁	wfow	0
 𨘱	wfpx	0
 述评	wfsa	4740000
-𫒏	wfsj	0
 速调	wfsl	131000
 速效	wfso	2500000
 鶐	wfsr	19700
@@ -95196,7 +91423,6 @@ encoder:
 速记	wfsy	2810000
 速冻	wfth	2240000
 速度	wftv	184000000
-𫑛	wfvv	0
 速溶	wfvw	720000
 速写	wfwa	1950000
 𨙤	wfwr	0
@@ -95208,7 +91434,6 @@ encoder:
 𨔣	wfyj	0
 襟翼	wfyy	188000
 𨖝	wfzd	0
-𫒇	wfzm	0
 𨓾	wgaj	0
 还款	wgbb	5920000
 逐项	wgbg	1490000
@@ -95232,7 +91457,6 @@ encoder:
 还要	wgfv	123000000
 宏大	wggd	10400000
 寄存	wggi	3790000
-𫑺	wggi	0
 还原	wggn	30700000
 还有	wggq	317000000
 突袭	wggs	9330000
@@ -95273,7 +91497,6 @@ encoder:
 还价	wgno	2190000
 寄信	wgns	4970000
 家伙	wgnu	35900000
-𫑰	wgoa	0
 还会	wgob	63700000
 家人	wgod	93400000
 逐行	wgoi	893000
@@ -95431,7 +91654,6 @@ encoder:
 连贯	whzl	3210000
 连绵	whzn	4420000
 军纪	whzy	587000
-𫑙	wiaa	0
 补丁	wiai	47100000
 补正	wiai	1490000
 𨑵	wiay	0
@@ -95477,7 +91699,6 @@ encoder:
 补益	wiuo	888000
 𧉌	wivv	0
 𨒷	wivv	0
-𫑙	wivv	0
 寂寞	wiwe	116000000
 补遗	wiwj	581000
 补选	wiwm	614000
@@ -95558,7 +91779,6 @@ encoder:
 逞强	wjyj	3170000
 𨔗	wjyj	0
 宫廷	wjym	5550000
-𫒊	wjym	0
 遗孀	wjzf	555000
 逞能	wjzq	470000
 启发	wjzv	12400000
@@ -95613,7 +91833,6 @@ encoder:
 神仙	wknl	14700000
 神像	wknr	2230000
 宴会	wkob	16500000
-𫑼	wkob	0
 𨕲	wkoi	0
 𨔫	wkor	0
 𨕟	wkor	0
@@ -95702,7 +91921,6 @@ encoder:
 宜山	wlll	305000
 𨓒	wlmb	0
 祖籍	wlmc	1720000
-𫒎	wlmm	0
 祖先	wlmr	8200000
 视乎	wlmu	615000
 𨘩	wlmz	0
@@ -95722,7 +91940,6 @@ encoder:
 𪆹	wlrz	0
 𨓹	wlsc	0
 宜章	wlsk	451000
-𫒉	wlsk	0
 宜良	wlsx	463000
 视为	wluv	26200000
 宜兴	wlva	6220000
@@ -95817,11 +92034,8 @@ encoder:
 𣙅	wmhf	0
 啔	wmhj	43000
 䁉	wmhl	6170
-𫏛	wmhl	0
 选区	wmho	2540000
 造成	wmhv	236000000
-𪭯	wmhx	0
-𪧈	wmhy	0
 䋯	wmhz	3500
 迮	wmid	160000
 𨑶	wmid	0
@@ -95857,7 +92071,6 @@ encoder:
 适时	wmkd	13400000
 𢿭	wmke	0
 𦠰	wmke	0
-𪭲	wmke	0
 𢩊	wmkg	0
 㧂	wmki	5190
 追星	wmkm	6220000
@@ -95881,7 +92094,6 @@ encoder:
 𧢞	wmll	0
 㲢	wmlm	4620
 𢨿	wmlo	0
-𪭰	wmlo	0
 㼐	wmlp	4570
 选购	wmlr	40400000
 鶣	wmlr	25100
@@ -95894,7 +92106,6 @@ encoder:
 𨕀	wmma	0
 户籍	wmmc	10700000
 𨖬	wmmc	0
-𫆼	wmmc	0
 选手	wmmd	19200000
 𢨮	wmme	0
 𢨵	wmme	0
@@ -95902,7 +92113,6 @@ encoder:
 𣘼	wmmf	0
 牢笼	wmmg	1060000
 𢩏	wmmi	0
-𫒋	wmmi	0
 啓	wmmj	3270000
 牢靠	wmmj	1220000
 选种	wmmj	540000
@@ -95939,12 +92149,10 @@ encoder:
 造化	wmnr	3690000
 适合	wmoa	245000000
 𥲽	wmob	0
-𪭱	wmob	0
 迁入	wmod	1790000
 迭	wmod	5150000
 𢨨	wmod	0
 透彻	wmoh	5710000
-𪭰	wmoj	0
 邌	wmok	25800
 𨙢	wmol	0
 遾	wmoo	25600
@@ -95963,7 +92171,6 @@ encoder:
 透镜	wmps	1170000
 造反	wmpx	3560000
 顅	wmqg	29600
-𫗹	wmqg	0
 𠶳	wmqj	0
 𧡌	wmql	0
 必胜	wmqm	6030000
@@ -95981,7 +92188,6 @@ encoder:
 户外	wmri	51200000
 户名	wmrj	15100000
 𢩁	wmrj	0
-𫒐	wmrj	0
 必备	wmrk	26300000
 𨘯	wmrm	0
 𣢖	wmro	0
@@ -96009,7 +92215,6 @@ encoder:
 𢩞	wmsp	0
 扆	wmsr	237000
 造诣	wmsr	2980000
-𫇚	wmsr	0
 𢩀	wmss	0
 𢨶	wmsu	0
 房	wmsy	573000000
@@ -96028,7 +92233,6 @@ encoder:
 𦂟	wmtz	0
 追悼	wmui	4130000
 追悔	wmum	1500000
-𫑱	wmuo	0
 扊	wmuu	32200
 选举	wmva	15800000
 宪法	wmvb	28800000
@@ -96145,15 +92349,12 @@ encoder:
 𨘐	wnnn	0
 𨖽	wnob	0
 𨗭	wnob	0
-𫑫	wnod	0
 𨗮	wnoe	0
 𨘤	wnol	0
 宿舍	wnom	59800000
 𨗔	wnon	0
-𫒈	wnos	0
 𨕵	wnqx	0
 𨓅	wnrd	0
-𫑬	wnrd	0
 𨕉	wnrx	0
 宿主	wnsc	2530000
 邀请	wnsc	59000000
@@ -96192,18 +92393,14 @@ encoder:
 𥦽	woai	0
 䆟	woaj	3610
 䢔	woaj	3910
-𫂋	woal	0
-𫑪	woal	0
 窿	woam	1400000
 𥦴	woao	0
 𥥍	woau	0
 𥥋	woax	0
-𫑜	woax	0
 窍	woaz	7130000
 窐	wobb	172000
 窪	wobb	2670000
 𥧀	wobb	0
-𪥝	wobg	0
 容城	wobh	254000
 逾越	wobh	3060000
 空	wobi	488000000
@@ -96243,7 +92440,6 @@ encoder:
 𥥙	woby	0
 𥤭	wobz	0
 𥦳	wobz	0
-𪨉	wocd	0
 𥥯	woce	0
 𥦌	woce	0
 𥨋	woce	0
@@ -96285,7 +92481,6 @@ encoder:
 𥩀	wogf	0
 䆣	wogh	4790
 𨓇	wogl	0
-𪪋	wogl	0
 䆜	wogq	3850
 䆥	wogq	4170
 𥥒	wogq	0
@@ -96300,7 +92495,6 @@ encoder:
 䆖	wogz	4030
 窒	wohb	3540000
 𥥻	wohb	0
-𫂄	wohc	0
 𥤥	wohd	0
 穿	wohi	154000000
 𥥰	wohs	0
@@ -96317,10 +92511,8 @@ encoder:
 𥨮	woia	0
 𨢛	woif	0
 䆽	woig	3750
-𫂍	woij	0
 𥦇	woik	0
 竀	woil	39100
-𫂁	woiw	0
 𢽦	woix	0
 𥦐	woix	0
 𥨣	woiy	0
@@ -96354,7 +92546,6 @@ encoder:
 𥦙	wojr	0
 𥦬	wojr	0
 𪃾	wojr	0
-𫜛	wojr	0
 䆸	woju	4250
 𥥷	woju	0
 𥨰	woju	0
@@ -96362,8 +92553,6 @@ encoder:
 𥦗	wojw	0
 𥧁	wojw	0
 𥩇	wojw	0
-𪬲	wojw	0
-𪠱	wojx	0
 𥨪	wojy	0
 䆗	wojz	3720
 容量	woka	99400000
@@ -96385,7 +92574,6 @@ encoder:
 𥥉	woki	0
 竂	wokk	39100
 𥨕	wokm	0
-𫂀	wokm	0
 𥦕	woko	0
 𨒛	woko	0
 䆞	wokr	3990
@@ -96402,12 +92590,10 @@ encoder:
 𥧄	wokz	0
 𥥼	wolb	0
 𥧒	wolb	0
-𫁼	wolb	0
 𥥐	wolc	0
 䆚	wold	3810
 𥥚	wold	0
 𥥝	wold	0
-𫁻	wold	0
 䆩	wolg	4220
 𥦺	wolg	0
 帘	woli	13200000
@@ -96444,7 +92630,6 @@ encoder:
 𥨱	wolz	0
 窂	womb	42000
 𥥶	womb	0
-𫁽	womb	0
 𥤺	womd	0
 𥩎	wome	0
 途	womf	28900000
@@ -96476,14 +92661,11 @@ encoder:
 𥨚	womy	0
 䆧	womz	3850
 䆤	wonc	4120
-𫂃	wonc	0
 𥩄	wond	0
 𨑸	wond	0
 䆿	wonf	4500
 𩕥	wong	0
-𫂂	woni	0
 𥥩	wonj	0
-𫂆	wonj	0
 𥨵	wonl	0
 𥨂	wonm	0
 𥨃	wonq	0
@@ -96500,7 +92682,6 @@ encoder:
 𥦊	woob	0
 𥧚	woob	0
 𥨁	woob	0
-𫑥	woob	0
 𡨙	wood	0
 𨑹	wood	0
 窣	wooe	170000
@@ -96511,12 +92692,10 @@ encoder:
 𧯉	wooj	0
 𥨹	wook	0
 𨗀	wook	0
-𪧣	wook	0
 窥	wool	18500000
 窺	wool	3700000
 𥥸	woom	0
 𥨅	woom	0
-𫁿	woom	0
 窔	wooo	394000
 𥤹	wooo	0
 𥦑	wooo	0
@@ -96534,7 +92713,6 @@ encoder:
 𥥄	wooy	0
 𥦋	wooy	0
 𪚨	wooz	0
-𫂉	wooz	0
 容错	wope	5690000
 𥦓	wopf	0
 䆺	wopk	3650
@@ -96575,7 +92753,6 @@ encoder:
 𥥱	worr	0
 𨔩	worr	0
 𪄑	worr	0
-𫂌	worr	0
 穸	wors	257000
 𥤯	wors	0
 𥦱	wors	0
@@ -96588,7 +92765,6 @@ encoder:
 窇	wory	127000
 𥨟	wory	0
 𦫪	wory	0
-𫂅	wory	0
 窎	worz	31100
 窛	worz	289000
 窵	worz	32100
@@ -96609,12 +92785,9 @@ encoder:
 𥥴	wosr	0
 䆫	wosw	3800
 䆡	wosx	4310
-𫑜	wosx	0
-𫁺	wosy	0
 窲	wote	26000
 𥦖	wote	0
 𥧇	wote	0
-𫂊	wote	0
 窦	wotg	6530000
 𥥵	wouc	0
 𥧋	woue	0
@@ -96643,7 +92816,6 @@ encoder:
 䆮	wowx	3830
 𥧿	wowx	0
 𥨊	wowx	0
-𫂈	wowx	0
 𥥁	wowz	0
 𥦐	woxa	0
 𥧬	woxb	0
@@ -96700,7 +92872,6 @@ encoder:
 𥥅	woyz	0
 𥥈	woyz	0
 𥦷	woyz	0
-𫁾	woyz	0
 梥	wozf	26200
 𥨀	wozi	0
 𥧺	wozj	0
@@ -96715,7 +92886,6 @@ encoder:
 𥧑	wozo	0
 𥧰	wozp	0
 䆓	wozr	3930
-𫜟	wozr	0
 𥤳	wozs	0
 𥨉	wozs	0
 𨑪	wozs	0
@@ -96728,14 +92898,12 @@ encoder:
 𥥆	wozy	0
 窋	wozz	74700
 窟	wozz	6100000
-𫂇	wozz	0
 逅	wpaj	948000
 返工	wpbi	2280000
 近来	wpbk	29200000
 逓	wpbl	85200
 祈求	wpdv	5040000
 遥控	wpdw	15900000
-𫒃	wpec	0
 遁	wpel	6120000
 近期	wpeq	96700000
 遥	wpez	21100000
@@ -96785,17 +92953,14 @@ encoder:
 𨖠	wpwl	0
 宾客	wpwr	3870000
 𨘅	wpxb	0
-𫑩	wpxb	0
 𨗿	wpxo	0
 返	wpxs	70000000
 𨘓	wpxw	0
 𨔕	wpxx	0
 宾阳	wpyk	613000
-𫑶	wpyq	0
 𨖿	wpyu	0
 𨗽	wpzq	0
 返乡	wpzz	2070000
-𫑽	wqaj	0
 𨖢	wqcc	0
 冗长	wqch	1750000
 𨑙	wqda	0
@@ -96892,8 +93057,6 @@ encoder:
 逸	wrrs	33600000
 逸	wrrs	0
 𨗧	wrrs	0
-𫑲	wrrz	0
-𫑷	wrrz	0
 迎新	wrsf	7460000
 客商	wrsu	8010000
 𨒟	wrtd	0
@@ -96940,7 +93103,6 @@ encoder:
 𨖣	wrzs	0
 农奴	wrzx	531000
 𨘺	wrzz	0
-𫑾	wrzz	0
 礻	wsaa	274000
 𥛉	wsac	0
 𥘏	wsae	0
@@ -96963,7 +93125,6 @@ encoder:
 𥘞	wsax	0
 𥚜	wsay	0
 𥜊	wsaz	0
-𫁅	wsaz	0
 𥙞	wsbb	0
 𥛇	wsbb	0
 𥛈	wsbb	0
@@ -96979,11 +93140,9 @@ encoder:
 𨧽	wsbp	0
 𥚨	wsbq	0
 𥙕	wsbr	0
-𫀿	wsbr	0
 𥜃	wsbu	0
 䄊	wsbw	5390
 祎	wsby	492000
-𫒒	wsby	0
 祛	wsbz	12200000
 𥘟	wsbz	0
 𥘡	wsbz	0
@@ -96992,8 +93151,6 @@ encoder:
 祷	wscd	3060000
 𥙟	wsce	0
 𨔉	wsci	0
-𫀷	wsck	0
-𫁔	wscm	0
 䄝	wscn	4290
 禡	wscu	64500
 𥚅	wscz	0
@@ -97059,7 +93216,6 @@ encoder:
 祬	wshb	44400
 祴	wshe	597000
 𥜤	wshh	0
-𫁀	wshi	0
 房东	wshk	10400000
 䄀	wshm	19300
 禨	wsho	45800
@@ -97072,7 +93228,6 @@ encoder:
 𥚚	wsih	0
 祉	wsii	1590000
 𥛨	wsii	0
-𫀵	wsij	0
 𥙺	wsik	0
 𥛳	wsik	0
 䄔	wsil	5100
@@ -97100,7 +93255,6 @@ encoder:
 𥙙	wsjl	0
 𥛍	wsjl	0
 𥛒	wsjl	0
-𫁐	wsjl	0
 禕	wsjm	168000
 𨘿	wsjn	0
 𥚄	wsjo	0
@@ -97114,7 +93268,6 @@ encoder:
 𥚧	wsju	0
 𥜉	wsju	0
 𥜨	wsju	0
-𫁋	wsjx	0
 𥚠	wsjy	0
 𥜫	wsjz	0
 䄠	wska	13800
@@ -97127,7 +93280,6 @@ encoder:
 禪	wske	3880000
 禫	wske	88200
 遧	wske	32400
-𫁁	wske	0
 祼	wskf	2150000
 禯	wskg	40100
 𥔻	wskg	0
@@ -97141,7 +93293,6 @@ encoder:
 𥚕	wskk	0
 𥛰	wskk	0
 𥛼	wskk	0
-𫁊	wskl	0
 𥘤	wskm	0
 𥘷	wskm	0
 𥛹	wskm	0
@@ -97159,12 +93310,10 @@ encoder:
 𥙧	wskz	0
 𥚥	wskz	0
 𥛧	wskz	0
-𫁃	wskz	0
 𥚳	wslb	0
 祖	wslc	41100000
 𥚼	wslc	0
 𥘝	wsld	0
-𫀸	wsld	0
 䄃	wslg	5860
 𥚻	wslg	0
 房贴	wsli	111000
@@ -97174,13 +93323,10 @@ encoder:
 𨙎	wslk	0
 䄣	wsll	5820
 房山	wsll	2660000
-𫀼	wsll	0
 𥛄	wslm	0
-𫁒	wsln	0
 祸	wslo	35300000
 禛	wslo	271000
 𥛺	wslo	0
-𫀳	wslo	0
 視	wslr	65400000
 视	wslr	322000000
 𥜰	wslt	0
@@ -97199,7 +93345,6 @@ encoder:
 𥘥	wsme	0
 𥘪	wsme	0
 𥛏	wsme	0
-𫁓	wsme	0
 䄏	wsmg	4950
 祅	wsmg	853000
 䄉	wsmh	5600
@@ -97212,8 +93357,6 @@ encoder:
 房租	wsml	6650000
 𥛯	wsml	0
 𥜓	wsml	0
-𫀹	wsml	0
-𫒅	wsml	0
 䢟	wsmo	3430
 祑	wsmo	84200
 遃	wsmp	19100
@@ -97221,7 +93364,6 @@ encoder:
 祣	wsmr	48000
 𪄬	wsmr	0
 𥘜	wsms	0
-𫀽	wsms	0
 遊	wsmy	50500000
 𥙁	wsmy	0
 𥙢	wsmy	0
@@ -97239,8 +93381,6 @@ encoder:
 房价	wsno	20400000
 迹	wsno	14400000
 𥛩	wsno	0
-𫁆	wsnr	0
-𫁇	wsnr	0
 𥛲	wsnu	0
 𥙢	wsnx	0
 𥛭	wsnx	0
@@ -97256,7 +93396,6 @@ encoder:
 𥙄	wsok	0
 𥛾	wsok	0
 𥚤	wsom	0
-𫁏	wsom	0
 祄	wson	38100
 䄥	wsoo	5000
 䢒	wsoo	3730
@@ -97265,7 +93404,6 @@ encoder:
 𥚒	wsoo	0
 𥜋	wsoo	0
 𨘰	wsoo	0
-𫀻	wsoo	0
 𥘼	wsop	0
 祾	wsor	59200
 禝	wsor	38500
@@ -97302,7 +93440,6 @@ encoder:
 𡎺	wsrb	0
 𥚊	wsrb	0
 𥛝	wsrc	0
-𫁄	wsrf	0
 祇	wsrh	3830000
 迹象	wsrj	15300000
 𥘮	wsrj	0
@@ -97318,14 +93455,12 @@ encoder:
 禶	wsrl	40400
 𨘆	wsrl	0
 𥛷	wsrm	0
-𫁉	wsrm	0
 䄢	wsrn	6370
 𥚺	wsrn	0
 禓	wsro	36900
 𥘨	wsro	0
 𥚯	wsro	0
 𥛙	wsro	0
-𫁂	wsro	0
 禙	wsrq	114000
 䃾	wsrr	4540
 𥘇	wsrr	0
@@ -97344,7 +93479,6 @@ encoder:
 𥙅	wssl	0
 房产	wssm	188000000
 䄙	wsso	4420
-𫀺	wssr	0
 𥘸	wssu	0
 𥚆	wssw	0
 𥘞	wssx	0
@@ -97388,7 +93522,6 @@ encoder:
 𥙇	wswr	0
 𥜚	wswr	0
 䄘	wsws	4720
-𫑸	wsws	0
 祲	wswx	75500
 𥜐	wswx	0
 𥘚	wswz	0
@@ -97399,11 +93532,9 @@ encoder:
 禟	wsxj	104000
 𥜢	wsxj	0
 𥜮	wsxj	0
-𫁎	wsxj	0
 禄	wsxk	10600000
 𥛽	wsxk	0
 𥜑	wsxk	0
-𫁈	wsxk	0
 𥚵	wsxl	0
 𥚏	wsxo	0
 祓	wsxs	478000
@@ -97412,7 +93543,6 @@ encoder:
 䄌	wsxx	4960
 𨖅	wsxy	0
 𥛭	wsxz	0
-𫁋	wsxz	0
 房子	wsya	65700000
 𥘆	wsyd	0
 𥘉	wsyd	0
@@ -97429,7 +93559,6 @@ encoder:
 𥘬	wsyn	0
 𥜔	wsyn	0
 𥘳	wsys	0
-𪬙	wsyw	0
 𥙈	wsyx	0
 𥙥	wsyx	0
 祀	wsyy	2470000
@@ -97455,8 +93584,6 @@ encoder:
 𥙓	wszl	0
 𥛐	wszl	0
 𥚇	wszm	0
-𫀱	wszm	0
-𫀽	wszm	0
 𨓞	wszn	0
 𥙩	wszo	0
 𨒨	wszo	0
@@ -97464,7 +93591,6 @@ encoder:
 𥚝	wszq	0
 𥘍	wszt	0
 𥙪	wszu	0
-𫁑	wszx	0
 𨕕	wszy	0
 禌	wszz	107000
 𥘢	wszz	0
@@ -97485,7 +93611,6 @@ encoder:
 褆	wtai	222000
 𧘔	wtai	0
 𧘿	wtai	0
-𫑟	wtai	0
 袔	wtaj	87900
 袷	wtaj	898000
 裿	wtaj	25700
@@ -97555,15 +93680,12 @@ encoder:
 𧘚	wtbz	0
 𧘢	wtbz	0
 𧘧	wtbz	0
-𫌶	wtbz	0
-𫌹	wtbz	0
 襵	wtcc	21200
 𧙫	wtce	0
 𧚂	wtce	0
 𧛇	wtch	0
 𧜅	wtcj	0
 襀	wtcl	26500
-𫌻	wtcl	0
 𧟓	wtcm	0
 𧜧	wtcn	0
 𧚫	wtcq	0
@@ -97574,7 +93696,6 @@ encoder:
 襊	wtcx	23900
 𧚥	wtcx	0
 𧜮	wtcx	0
-𫍓	wtcx	0
 𧚊	wtcz	0
 𧛔	wtcz	0
 遮掩	wtdg	8240000
@@ -97582,7 +93703,6 @@ encoder:
 遮挡	wtdk	3110000
 衬	wtds	10900000
 襅	wteb	30400
-𫍅	wteb	0
 褀	wtec	64800
 䢏	wted	3460
 𧜿	wtef	0
@@ -97623,7 +93743,6 @@ encoder:
 𧛮	wtfb	0
 䙏	wtfd	5670
 襦	wtfg	684000
-𫍐	wtfi	0
 𧚏	wtfj	0
 𧜦	wtfj	0
 襋	wtfl	22800
@@ -97632,7 +93751,6 @@ encoder:
 襴	wtfl	49900
 襽	wtfl	20600
 𧙞	wtfl	0
-𫌺	wtfm	0
 𧜁	wtfq	0
 䘤	wtfs	4320
 实惠	wtfw	18100000
@@ -97640,7 +93758,6 @@ encoder:
 实权	wtfx	1220000
 䙅	wtfz	5440
 袏	wtgb	443000
-𫌿	wtgc	0
 褥	wtgd	2260000
 𧘬	wtge	0
 𧜒	wtge	0
@@ -97654,7 +93771,6 @@ encoder:
 𧙛	wtgl	0
 襻	wtgm	217000
 䘠	wtgo	13400
-𫌳	wtgq	0
 𧛍	wtgr	0
 袱	wtgs	671000
 𧘹	wtgs	0
@@ -97672,7 +93788,6 @@ encoder:
 裓	wthe	52500
 䘬	wthg	3880
 𧜆	wthg	0
-𫌴	wthg	0
 䙁	wthh	5240
 𧘪	wthi	0
 𧙅	wthj	0
@@ -97680,14 +93795,12 @@ encoder:
 𧝊	wthk	0
 𧛢	wthm	0
 𧝞	wtho	0
-𫌭	wtho	0
 𧜳	wthr	0
 䘝	wths	3640
 襪	wths	8750000
 𧙠	wths	0
 裢	wthw	149000
 𧘸	wthz	0
-𫍋	wthz	0
 𧘕	wtia	0
 补	wtid	73400000
 𧝲	wtig	0
@@ -97744,9 +93857,6 @@ encoder:
 裋	wtju	43900
 𧜄	wtju	0
 𧞫	wtju	0
-𫍆	wtju	0
-𫍎	wtju	0
-𫍏	wtju	0
 𧜐	wtjw	0
 𧙊	wtjx	0
 𧜇	wtjy	0
@@ -97771,7 +93881,6 @@ encoder:
 𧝊	wtkh	0
 䘥	wtki	4080
 袖	wtki	32100000
-𫌰	wtki	0
 䙯	wtkj	4150
 裮	wtkk	31500
 褿	wtkk	23400
@@ -97781,7 +93890,6 @@ encoder:
 𧞭	wtkk	0
 𧟂	wtkk	0
 𧟔	wtkk	0
-𫍌	wtkk	0
 䘷	wtkl	3930
 褞	wtkl	204000
 𧛕	wtkl	0
@@ -97836,7 +93944,6 @@ encoder:
 䙬	wtlz	4220
 褵	wtlz	95000
 𧞵	wtlz	0
-𫌼	wtlz	0
 𨕾	wtma	0
 衽	wtmb	891000
 袵	wtmb	58300
@@ -97875,13 +93982,11 @@ encoder:
 𧜃	wtmy	0
 𧚀	wtmz	0
 𧚃	wtmz	0
-𫌽	wtmz	0
 实例	wtna	51800000
 裑	wtnc	299000
 袝	wtnd	133000
 裫	wtnd	19400
 𧛼	wtnd	0
-𫍒	wtnd	0
 裨	wtne	1260000
 实体	wtnf	18300000
 襍	wtnf	103000
@@ -97902,12 +94007,10 @@ encoder:
 𧝈	wtnu	0
 𧞤	wtnx	0
 𧟝	wtnx	0
-𫍁	wtnx	0
 𧘒	wtoa	0
 𧛛	wtoc	0
 𧟑	wtoc	0
 䘹	wtoe	4330
-𫍑	wtof	0
 𧟒	wtog	0
 䙕	wtoi	4000
 实行	wtoi	70600000
@@ -97971,7 +94074,6 @@ encoder:
 衹	wtrh	746000
 䙱	wtri	3780
 襡	wtri	53800
-𫌱	wtri	0
 实名	wtrj	95500000
 袧	wtrj	403000
 袼	wtrj	150000
@@ -97984,8 +94086,6 @@ encoder:
 襸	wtrl	19900
 𧚓	wtrl	0
 𧝝	wtrl	0
-𫌸	wtrl	0
-𫍃	wtrl	0
 袶	wtrm	29000
 𧜨	wtrm	0
 𧚧	wtrn	0
@@ -97993,7 +94093,6 @@ encoder:
 𧞓	wtrn	0
 裼	wtro	211000
 𨒮	wtro	0
-𫍀	wtro	0
 褙	wtrq	211000
 袳	wtrr	34000
 裩	wtrr	47100
@@ -98038,7 +94137,6 @@ encoder:
 𧜢	wtsw	0
 衿	wtsx	4190000
 𧚅	wtsx	0
-𫌮	wtsy	0
 𧚪	wtsz	0
 𧘞	wtte	0
 褲	wttf	11600000
@@ -98063,16 +94161,13 @@ encoder:
 𤇷	wtuo	0
 𨓩	wtuo	0
 裧	wtuu	21000
-𫍄	wtuu	0
 𧝮	wtuw	0
 𧞋	wtux	0
 裷	wtuy	29400
 实数	wtuz	710000
 褛	wtuz	1440000
-𫌵	wtvr	0
 䘢	wtwa	4410
 𧚬	wtwb	0
-𫍇	wtwb	0
 䘺	wtwd	3960
 褌	wtwf	1090000
 褳	wtwf	40700
@@ -98109,7 +94204,6 @@ encoder:
 𧙔	wtxb	0
 𧙻	wtxb	0
 𧜶	wtxb	0
-𫌲	wtxb	0
 𧘥	wtxe	0
 褬	wtxf	23500
 𧜾	wtxf	0
@@ -98122,7 +94216,6 @@ encoder:
 𧚼	wtxj	0
 䘵	wtxk	4640
 襇	wtxk	32300
-𫍔	wtxk	0
 𧚔	wtxl	0
 𧛰	wtxl	0
 𧝴	wtxl	0
@@ -98142,7 +94235,6 @@ encoder:
 𧛋	wtxw	0
 𧞎	wtxw	0
 裰	wtxx	249000
-𫍂	wtxx	0
 𧜛	wtxy	0
 褄	wtxz	98900
 𧜱	wtxz	0
@@ -98183,7 +94275,6 @@ encoder:
 䙎	wtzg	4370
 褖	wtzg	463000
 𧚴	wtzi	0
-𫌾	wtzi	0
 袽	wtzj	82100
 䙒	wtzk	5030
 𧛾	wtzl	0
@@ -98197,7 +94288,6 @@ encoder:
 䘪	wtzr	3860
 䙠	wtzr	4250
 𧘾	wtzr	0
-𫍍	wtzr	0
 𧞌	wtzu	0
 𧞦	wtzu	0
 𧟆	wtzu	0
@@ -98238,7 +94328,6 @@ encoder:
 送餐	wuir	946000
 道上	wuiv	5770000
 逆回	wujj	92700
-𫒑	wujn	0
 㘏	wujr	4580
 迷路	wujr	8330000
 道路	wujr	151000000
@@ -98246,7 +94335,6 @@ encoder:
 送别	wujy	2560000
 道光	wukg	2040000
 遂昌	wukk	782000
-𫑹	wukm	0
 遵照	wuky	9230000
 送电	wukz	915000
 𨒾	wuli	0
@@ -98319,7 +94407,6 @@ encoder:
 递加	wuyj	64500
 递	wuyz	27600000
 逆	wuzi	81200000
-𫑳	wuzm	0
 送给	wuzo	40400000
 𨕜	wuzo	0
 遡	wuzq	478000
@@ -98376,7 +94463,6 @@ encoder:
 𠕹	wwag	0
 𠖨	wwag	0
 𠖈	wwai	0
-𫑮	wwai	0
 𠖏	wwaj	0
 𠃢	wwan	0
 𩠫	wwan	0
@@ -98389,7 +94475,6 @@ encoder:
 𠖑	wwbk	0
 𠖚	wwbk	0
 𠖟	wwbk	0
-𫑭	wwbk	0
 𠖫	wwbl	0
 𠕻	wwbr	0
 𠖣	wwbu	0
@@ -98399,8 +94484,6 @@ encoder:
 密云	wwbz	5660000
 𠖖	wwcu	0
 冣	wwcx	178000
-𪞖	wwcx	0
-𪫎	wwde	0
 䢘	wwds	3730
 密探	wwdw	1760000
 𠖉	wweg	0
@@ -98432,7 +94515,6 @@ encoder:
 𦊅	wwgs	0
 𤏷	wwgu	0
 密码	wwgx	1360000000
-𪞗	wwgy	0
 军	wwhe	142000000
 皲	wwhx	640000
 密切	wwhy	49400000
@@ -98446,15 +94528,12 @@ encoder:
 𢻼	wwix	0
 𢼀	wwix	0
 𢼐	wwix	0
-𪞓	wwji	0
 冨	wwjk	1910000
 𠖐	wwjk	0
 密匙	wwka	281000
 𠔸	wwke	0
 𢍔	wwke	0
 𦋐	wwke	0
-𫅵	wwke	0
-𪴉	wwkf	0
 𠖇	wwkg	0
 𨕫	wwki	0
 𣍍	wwkk	0
@@ -98474,7 +94553,6 @@ encoder:
 𢚞	wwlw	0
 𠖗	wwlx	0
 密县	wwlz	242000
-𫒄	wwlz	0
 㓃	wwmh	4970
 𨕠	wwmi	0
 𨖄	wwmj	0
@@ -98488,7 +94566,6 @@ encoder:
 鹤	wwnr	46100000
 𠕿	wwnr	0
 𣤇	wwnr	0
-𫜕	wwnr	0
 密信	wwns	287000
 𠕳	wwod	0
 罙	wwof	89500
@@ -98496,7 +94573,6 @@ encoder:
 𠖩	wwog	0
 𠖧	wwoi	0
 𠖪	wwoi	0
-𪞓	wwoj	0
 𠖋	wwok	0
 覭	wwol	30900
 𨙇	wwol	0
@@ -98507,10 +94583,8 @@ encoder:
 密令	wwow	845000
 鼆	wwow	26000
 𠖝	wwow	0
-𪞕	wwox	0
 鄍	wwoy	45000
 𨔎	wwoy	0
-𪞒	wwoy	0
 𠕺	wwoz	0
 密钥	wwpq	1300000
 𠖒	wwpr	0
@@ -98530,7 +94604,6 @@ encoder:
 𨑻	wwrd	0
 𦉲	wwre	0
 䪴	wwrg	3550
-𫗮	wwrg	0
 农	wwrh	191000000
 沊	wwrk	34600
 𠛌	wwrk	0
@@ -98547,7 +94620,6 @@ encoder:
 鸩	wwrr	479000
 𣢌	wwrr	0
 𩵫	wwrr	0
-𫛸	wwrr	0
 冤	wwrs	9370000
 𠕸	wwrs	0
 冩	wwru	1210000
@@ -98556,7 +94628,6 @@ encoder:
 褪色	wwry	4750000
 邥	wwry	31100
 𠠹	wwry	0
-𪞑	wwry	0
 㓂	wwrz	4540
 𠖜	wwsb	0
 密谋	wwse	2330000
@@ -98567,7 +94638,6 @@ encoder:
 密谈	wwsu	587000
 𠖃	wwsu	0
 密闭	wwtd	2520000
-𪞔	wwte	0
 密度	wwtv	21500000
 冞	wwuf	192000
 邃	wwug	880000
@@ -98800,7 +94870,6 @@ encoder:
 字距	wyjh	249000
 边距	wyjh	386000
 官员	wyjl	48100000
-𫒆	wyjl	0
 初中	wyjv	77500000
 辽中	wyjv	425000
 字量	wyka	37000
@@ -98829,7 +94898,6 @@ encoder:
 𨔌	wyps	0
 初犯	wyqy	499000
 迅猛	wyqy	11200000
-𫑦	wyrk	0
 官邸	wyrs	4160000
 边贸	wyrs	768000
 逊色	wyry	8540000
@@ -99098,7 +95166,6 @@ encoder:
 登场	xaby	34300000
 登报	xady	750000
 登基	xaeb	1800000
-𫙟	xaed	0
 登载	xaeh	4900000
 马克	xaej	11000000
 登机	xafq	2210000
@@ -99160,7 +95227,6 @@ encoder:
 垦荒	xbes	237000
 慰劳	xbew	829000
 𢻀	xbex	0
-𫅯	xbez	0
 𢑤	xbfj	0
 𢑧	xbfj	0
 颈椎	xbfn	4740000
@@ -99188,7 +95254,6 @@ encoder:
 𤲿	xbjk	0
 𢽤	xbjm	0
 𦘤	xbjo	0
-𪠯	xbjx	0
 晝	xbka	1850000
 畫	xbka	57400000
 𤲯	xbka	0
@@ -99225,15 +95290,12 @@ encoder:
 𩒔	xblg	0
 帇	xbli	250000
 𥁞	xblk	0
-𪟘	xblk	0
 㞪	xbll	3780
 𢽰	xblm	0
-𪨋	xbln	0
 𦐯	xblo	0
 𧶁	xblo	0
 𣃏	xblp	0
 𪂪	xblr	0
-𫜌	xblr	0
 𢃳	xbly	0
 𡞒	xblz	0
 𦘚	xblz	0
@@ -99255,7 +95317,6 @@ encoder:
 歗	xbnr	25900
 鷫	xbnr	36400
 粛	xbnu	454000
-𪭌	xbnw	0
 彟	xbnx	77700
 彠	xbnx	41600
 𢑫	xbob	0
@@ -99274,7 +95335,6 @@ encoder:
 𦄳	xboz	0
 𢑵	xbpk	0
 𡬶	xbqd	0
-𪨆	xbqd	0
 𢑿	xbqf	0
 𣕡	xbqf	0
 𠙛	xbqq	0
@@ -99317,10 +95377,8 @@ encoder:
 层层	xbxb	9600000
 𢑑	xbxb	0
 𦘞	xbxb	0
-𪹩	xbxb	0
 䫗	xbxg	3200
 𩒸	xbxg	0
-𪪏	xbxg	0
 𧎂	xbxi	0
 𠜘	xbxk	0
 𢑨	xbxk	0
@@ -99340,7 +95398,6 @@ encoder:
 叚	xbxx	201000
 𢑰	xbxx	0
 𣆸	xbxx	0
-𪠭	xbxx	0
 𦐱	xbxy	0
 𨛃	xbxy	0
 𦘣	xbyb	0
@@ -99449,8 +95506,6 @@ encoder:
 寻求	xddv	83200000
 𨳼	xdeb	0
 𨶱	xdeb	0
-𫕤	xdec	0
-𫕚	xdej	0
 𨵴	xdel	0
 閧	xdeo	180000
 𨶷	xdeo	0
@@ -99476,7 +95531,6 @@ encoder:
 𨶶	xdgb	0
 𨳓	xdgd	0
 𨷼	xdgg	0
-𫕪	xdgg	0
 𨳫	xdgi	0
 𨳾	xdgj	0
 𨵫	xdgj	0
@@ -99518,8 +95572,6 @@ encoder:
 𨶴	xdjb	0
 閫	xdjf	1100000
 𨵓	xdji	0
-𫕘	xdji	0
-𫕠	xdji	0
 閭	xdjj	1190000
 闆	xdjj	1150000
 𨷰	xdjj	0
@@ -99539,13 +95591,11 @@ encoder:
 闧	xdjr	29200
 𨵃	xdjr	0
 𨷤	xdjr	0
-𫕡	xdjr	0
 闢	xdjs	1700000
 闓	xdju	94400
 闦	xdju	22000
 𨶮	xdju	0
 𨶿	xdju	0
-𫕟	xdju	0
 𨴽	xdjw	0
 䦔	xdka	3680
 𨵀	xdka	0
@@ -99561,11 +95611,9 @@ encoder:
 𨴝	xdke	0
 𨶤	xdke	0
 𨵚	xdkf	0
-𫕨	xdkg	0
 閘	xdki	1620000
 𨳸	xdki	0
 𨴁	xdki	0
-𫕜	xdki	0
 閶	xdkk	62800
 𨵝	xdkk	0
 𨶺	xdkk	0
@@ -99586,7 +95634,6 @@ encoder:
 閖	xdkv	106000
 寻常	xdkw	13800000
 寻思	xdkw	3410000
-𫕩	xdkw	0
 䦰	xdkz	3350
 閹	xdkz	3930000
 𨴄	xdkz	0
@@ -99631,7 +95678,6 @@ encoder:
 𨴬	xdmj	0
 䦭	xdmk	3120
 𡮤	xdmk	0
-𫕢	xdmk	0
 䦗	xdml	3290
 寻租	xdml	1010000
 寻衅	xdml	601000
@@ -99656,7 +95702,6 @@ encoder:
 𨵹	xdne	0
 闑	xdnf	29200
 閥	xdnh	2150000
-𫕝	xdnh	0
 閵	xdni	1990000
 𨳢	xdni	0
 闎	xdnk	22600
@@ -99665,7 +95710,6 @@ encoder:
 䦝	xdno	3450
 𨴧	xdnp	0
 䦧	xdnr	3710
-𫕙	xdnr	0
 𨶲	xdnu	0
 𨳭	xdnx	0
 𨷍	xdnz	0
@@ -99689,13 +95733,11 @@ encoder:
 䦵	xdoo	3510
 閦	xdoo	71800
 𨷬	xdoo	0
-𫕦	xdoo	0
 𨶪	xdop	0
 䦲	xdos	3750
 閼	xdot	1410000
 閝	xdow	35100
 𨶟	xdox	0
-𫕧	xdox	0
 闀	xdoy	1030000
 𨳚	xdoy	0
 𨴶	xdoy	0
@@ -99736,7 +95778,6 @@ encoder:
 𨵶	xdro	0
 𨴢	xdrr	0
 𨶙	xdrr	0
-𫕞	xdrt	0
 闧	xdrw	29200
 𨷟	xdrw	0
 𨷺	xdrw	0
@@ -99746,7 +95787,6 @@ encoder:
 𨶠	xdrz	0
 誾	xdsa	104000
 𨷙	xdsb	0
-𫕣	xdsb	0
 𨳳	xdsc	0
 𨴲	xdse	0
 𨳑	xdsh	0
@@ -99933,8 +95973,6 @@ encoder:
 𥁝	xglk	0
 颇具	xglo	6160000
 𨾕	xgni	0
-𫙮	xgnk	0
-𫙱	xgoo	0
 骑兵	xgpo	7290000
 鴂	xgrz	58300
 颇为	xguv	10400000
@@ -99992,7 +96030,6 @@ encoder:
 㿹	xibu	5860
 皮球	xicd	2640000
 𤿬	xice	0
-𪾷	xicy	0
 𤿋	xidm	0
 皮鞋	xieb	11600000
 𠦁	xied	0
@@ -100010,7 +96047,6 @@ encoder:
 𥀸	xifl	0
 皮棉	xifn	443000
 疏松	xifo	3470000
-𪾶	xifz	0
 㿵	xigg	5300
 𠠉	xigk	0
 臩	xign	79600
@@ -100042,13 +96078,11 @@ encoder:
 𥀤	xils	0
 㿸	xilx	6930
 皮毛	ximh	5380000
-𪾵	ximo	0
 蛋白	xink	18000000
 皮货	xinr	259000
 皮质	xipe	7190000
 皮肤	xiqb	60000000
 㿪	xiqs	8340
-𪾴	xiri	0
 疏解	xirl	419000
 疏忽	xiro	6740000
 𤿦	xirr	0
@@ -100093,7 +96127,6 @@ encoder:
 壁画	xjak	4790000
 𩏡	xjal	0
 𩏱	xjal	0
-𫗏	xjal	0
 𩎟	xjbk	0
 𩎨	xjbk	0
 𩏆	xjbk	0
@@ -100159,7 +96192,6 @@ encoder:
 𩏘	xjln	0
 䪏	xjlo	3370
 䯄	xjlo	3320
-𫗑	xjlx	0
 韋	xjmb	9220000
 韔	xjmc	56300
 韚	xjme	21000
@@ -100246,9 +96278,7 @@ encoder:
 𩎢	xjzx	0
 壁垒	xjzz	5360000
 驶出	xjzz	1090000
-𫙧	xkae	0
 𨋬	xkaf	0
-𫙬	xkai	0
 𠜉	xkak	0
 脀	xkaq	38700
 烝	xkau	239000
@@ -100274,12 +96304,10 @@ encoder:
 𩨎	xkeo	0
 剥落	xkev	1570000
 承蒙	xkew	1740000
-𫐰	xkfk	0
 丞相	xkfl	2420000
 录相	xkfl	595000
 尿检	xkfo	292000
 剥夺	xkgd	8040000
-𫙥	xkgr	0
 𩧨	xkia	0
 尿频	xkik	1130000
 𢾧	xkix	0
@@ -100304,7 +96332,6 @@ encoder:
 承受	xkpw	40100000
 录象	xkrj	7070000
 犀角	xkrl	302000
-𫙩	xkrr	0
 尿急	xkrx	943000
 承包	xkry	19300000
 𦫠	xkry	0
@@ -100323,7 +96350,6 @@ encoder:
 届满	xkve	2070000
 尿液	xkvs	2100000
 驲	xkvv	41000
-𫙯	xkwz	0
 隶属	xkxm	7600000
 骡子	xkya	1070000
 承办	xkyo	50700000
@@ -100351,7 +96377,6 @@ encoder:
 眉毛	xlmh	9140000
 观看	xlml	73100000
 勇气	xlmy	31800000
-𫙵	xlnl	0
 观众	xloo	36100000
 观念	xlos	43900000
 勇猛	xlqy	3950000
@@ -100379,7 +96404,6 @@ encoder:
 䪳	xmag	3580
 頵	xmag	53900
 𠹩	xmag	0
-𫗶	xmag	0
 𢧃	xmah	0
 𠧬	xmai	0
 𡰨	xmai	0
@@ -100392,11 +96416,9 @@ encoder:
 𢂫	xmal	0
 𢃆	xmal	0
 𢑺	xmal	0
-𪨘	xmal	0
 𢽏	xmam	0
 𣀆	xmam	0
 𦢱	xmaq	0
-𪱷	xmaq	0
 裠	xmar	36200
 鵘	xmar	21900
 𣩩	xmar	0
@@ -100432,7 +96454,6 @@ encoder:
 𡲌	xmbp	0
 㞡	xmbr	3680
 鷵	xmbr	24200
-𪵍	xmbr	0
 𨐧	xmbs	0
 𨐬	xmbs	0
 𪑐	xmbu	0
@@ -100466,13 +96487,11 @@ encoder:
 熨	xmdu	3480000
 慰	xmdw	9980000
 展	xmeh	307000000
-𪨪	xmeh	0
 居	xmej	155000000
 𡳰	xmej	0
 𠝭	xmek	0
 𡲷	xmem	0
 𡱒	xmeo	0
-𪨩	xmes	0
 屐	xmex	1020000
 𡰸	xmex	0
 𡱪	xmex	0
@@ -100484,25 +96503,21 @@ encoder:
 𡲙	xmfb	0
 㞟	xmfg	4210
 𨘘	xmfj	0
-𪨠	xmfk	0
 㞖	xmfl	3980
 属相	xmfl	1850000
 尾椎	xmfn	164000
-𪨫	xmfs	0
 屚	xmfv	24800
 𡲱	xmge	0
 屒	xmgh	27900
 𡲃	xmgh	0
 𡲫	xmgl	0
 骄	xmgn	9950000
-𪨦	xmgn	0
 𡳔	xmgp	0
 𡱂	xmgq	0
 𡱰	xmgq	0
 𡰽	xmgr	0
 㞘	xmgs	4380
 𡳁	xmgs	0
-𪨟	xmgs	0
 𠭝	xmgx	0
 𥖑	xmgx	0
 𡱐	xmgy	0
@@ -100511,7 +96526,6 @@ encoder:
 𧎰	xmhi	0
 𨃨	xmhj	0
 剭	xmhk	376000
-𪨭	xmhl	0
 𣪵	xmhq	0
 𡲽	xmhr	0
 𡳅	xmhr	0
@@ -100529,7 +96543,6 @@ encoder:
 𡱇	xmij	0
 劚	xmik	271000
 𡳵	xmik	0
-𪨞	xmik	0
 属	xmil	200000000
 𡲇	xmil	0
 𡳆	xmil	0
@@ -100546,7 +96559,6 @@ encoder:
 𢾂	xmix	0
 𣀻	xmix	0
 𡳚	xmja	0
-𪨡	xmjb	0
 𧲜	xmjg	0
 𩒫	xmjg	0
 𩓛	xmjg	0
@@ -100558,7 +96570,6 @@ encoder:
 屫	xmjl	18900
 𡲻	xmjl	0
 𡳯	xmjl	0
-𪨢	xmjl	0
 𡱶	xmjn	0
 𡳎	xmjn	0
 咫	xmjo	992000
@@ -100582,7 +96593,6 @@ encoder:
 屪	xmkk	31700
 𡲘	xmkk	0
 𣍁	xmkk	0
-𪨮	xmkk	0
 𡳬	xmkl	0
 犀	xmkm	4770000
 𡱳	xmkm	0
@@ -100602,14 +96612,12 @@ encoder:
 𡳒	xmkz	0
 𡳟	xmkz	0
 𤳰	xmkz	0
-𪾄	xmkz	0
 𡰯	xmli	0
 㔉	xmlk	4470
 刷	xmlk	44400000
 層	xmlk	46700000
 𡳳	xmlk	0
 屭	xmll	64500
-𪨹	xmll	0
 𣮮	xmlm	0
 屃	xmlo	102000
 屓	xmlo	44100
@@ -100624,7 +96632,6 @@ encoder:
 𡳱	xmlz	0
 𡳲	xmlz	0
 𡱁	xmma	0
-𪨚	xmmb	0
 屗	xmmd	42000
 𡱚	xmme	0
 𡱱	xmmg	0
@@ -100632,7 +96639,6 @@ encoder:
 𡱫	xmmh	0
 𠧮	xmmi	0
 𡳸	xmmi	0
-𪨧	xmmj	0
 㓾	xmmk	4170
 㞙	xmmk	3790
 𡰹	xmmk	0
@@ -100641,8 +96647,6 @@ encoder:
 𡲉	xmmk	0
 𡳕	xmmk	0
 𩡛	xmmk	0
-𪨥	xmmk	0
-𪨬	xmmk	0
 𡲤	xmml	0
 𡲔	xmmm	0
 𡲥	xmmm	0
@@ -100678,11 +96682,8 @@ encoder:
 𦤋	xmnl	0
 𡳺	xmnn	0
 𦧃	xmnn	0
-𪨜	xmnq	0
 𡳖	xmnr	0
-𪨯	xmnu	0
 𡳑	xmob	0
-𪨨	xmob	0
 𡰦	xmod	0
 𩧭	xmod	0
 屜	xmoe	91900
@@ -100690,13 +96691,11 @@ encoder:
 𡳥	xmoe	0
 㞞	xmoi	3900
 𤂞	xmok	0
-𪾈	xmok	0
 𡲜	xmol	0
 𡲰	xmom	0
 臋	xmoo	29900
 𡱎	xmoo	0
 𦡜	xmoo	0
-𪨙	xmoo	0
 𡲟	xmop	0
 𡳇	xmop	0
 㞕	xmoq	4350
@@ -100831,12 +96830,9 @@ encoder:
 屏	xmue	177000000
 屎	xmuf	24600000
 𡲚	xmuf	0
-𪨛	xmuh	0
 𠠮	xmuk	0
 属性	xmum	53700000
-𪯳	xmum	0
 尸首	xmun	949000
-𪵶	xmuq	0
 𡳉	xmur	0
 羼	xmuu	344000
 𡲴	xmuu	0
@@ -100888,14 +96884,10 @@ encoder:
 㞌	xmya	4190
 㞎	xmyi	4160
 尾巴	xmyi	14200000
-𫙢	xmyi	0
 局	xmyj	648000000
 𡲢	xmyj	0
-𪨝	xmyj	0
-𪨰	xmyj	0
 𠟉	xmyk	0
 𡱊	xmyk	0
-𪨣	xmyl	0
 甓	xmys	229000
 𤭸	xmys	0
 𡰳	xmyt	0
@@ -100932,7 +96924,6 @@ encoder:
 𤚌	xmzm	0
 𡱍	xmzo	0
 𡲼	xmzo	0
-𫇷	xmzo	0
 𡱑	xmzq	0
 𡱓	xmzq	0
 鶌	xmzr	22200
@@ -100949,7 +96940,6 @@ encoder:
 𡲬	xmzz	0
 𡲶	xmzz	0
 𡳡	xmzz	0
-𪨤	xmzz	0
 难于	xnad	4260000
 难堪	xnbe	4700000
 肃静	xncq	906000
@@ -101000,11 +96990,9 @@ encoder:
 艮	xoaa	5590000
 验	xobv	53400000
 𡬠	xods	0
-𪞍	xoeo	0
 履带	xoew	1330000
 验票	xofb	338000
 䫀	xogo	3910
-𫗴	xogo	0
 履历	xogy	2190000
 验车	xohe	452000
 既	xohr	142000000
@@ -101015,7 +97003,6 @@ encoder:
 验光	xokg	557000
 验算	xoml	340000
 验血	xoml	677000
-𪬩	xomw	0
 𩧦	xond	0
 驳倒	xonh	312000
 验货	xonr	2210000
@@ -101051,16 +97038,13 @@ encoder:
 堲	xoyb	26900
 𨂢	xoyj	0
 𡷦	xoyl	0
-𪟛	xoym	0
 䳭	xoyr	4690
 𪃹	xoyr	0
 验收	xozm	24400000
 𩨏	xpki	0
-𫙰	xpzg	0
 欢喜	xrbj	13800000
 欢声	xrbx	2030000
 欢聚	xrcx	3020000
-𫙪	xrez	0
 鸡西	xrfj	3110000
 尼龙	xrgm	6480000
 鸡东	xrhk	306000
@@ -101094,7 +97078,6 @@ encoder:
 𤼮	xsaz	0
 𥍠	xsaz	0
 𥍣	xsaz	0
-𪫉	xsbe	0
 頚	xsbg	353000
 颈	xsbg	20300000
 𩒍	xsbg	0
@@ -101135,7 +97118,6 @@ encoder:
 𥎘	xsfg	0
 𢎊	xsfh	0
 𢧱	xsfh	0
-𪴍	xsfk	0
 𧠸	xsfl	0
 𣮪	xsfm	0
 歠	xsfr	63600
@@ -101160,7 +97142,6 @@ encoder:
 䳫	xsgr	3850
 𠑻	xsgr	0
 𠬭	xsgr	0
-𫝂	xsgr	0
 𥎤	xsgu	0
 𥎥	xsgu	0
 尺码	xsgx	5300000
@@ -101172,7 +97153,6 @@ encoder:
 𥎕	xshs	0
 𣜽	xshy	0
 𤼸	xsia	0
-𪜞	xsie	0
 𣏗	xsif	0
 預	xsig	44500000
 预	xsig	117000000
@@ -101199,7 +97179,6 @@ encoder:
 𤼯	xsji	0
 𠭎	xsjj	0
 𪉝	xsjo	0
-𪿵	xsjq	0
 𠮄	xsjr	0
 𣤌	xsjr	0
 䜼	xsju	4060
@@ -101214,7 +97193,6 @@ encoder:
 𠚔	xsjz	0
 尽量	xska	65000000
 𩐂	xska	0
-𫙴	xska	0
 䂌	xskb	5190
 𥍽	xskb	0
 𠚫	xskd	0
@@ -101295,7 +97273,6 @@ encoder:
 𩝕	xsmo	0
 鍪	xsmp	78800
 𥍪	xsmp	0
-𪿴	xsmp	0
 𥍟	xsmq	0
 䱯	xsmr	4660
 鶩	xsmr	154000
@@ -101340,7 +97317,6 @@ encoder:
 𢄮	xspl	0
 𠮐	xspn	0
 㔇	xsqk	4510
-𪠳	xsqk	0
 𨩹	xsqp	0
 𥎒	xsqw	0
 癹	xsqx	197000
@@ -101391,10 +97367,8 @@ encoder:
 𠬴	xsuc	0
 𤼷	xsue	0
 𩔞	xsug	0
-𫋦	xsui	0
 㔁	xsuk	6000
 覴	xsul	30200
-𫙲	xsul	0
 㲪	xsum	4450
 𤉺	xsum	0
 𤊮	xsum	0
@@ -101418,7 +97392,6 @@ encoder:
 𥎙	xswl	0
 𠭺	xswm	0
 𥍯	xswx	0
-𪤃	xswy	0
 𡌭	xsxb	0
 𥍹	xsxb	0
 𩢂	xsxc	0
@@ -101455,7 +97428,6 @@ encoder:
 㕛	xsxs	4120
 双	xsxs	288000000
 𤼦	xsxs	0
-𫍰	xsxs	0
 㥤	xsxw	5980
 逫	xsxw	18700
 𥍵	xsxw	0
@@ -101465,7 +97437,6 @@ encoder:
 𤿵	xsxx	0
 𠭋	xsxy	0
 𡥍	xsxy	0
-𪠅	xsxy	0
 𡛒	xsxz	0
 𩥦	xsyc	0
 𣖶	xsyf	0
@@ -101543,7 +97514,6 @@ encoder:
 灵石	xuga	940000
 灵感	xuha	27200000
 𩨂	xujw	0
-𫙳	xulk	0
 屏山	xull	920000
 灵山	xull	2260000
 灵敏	xumz	5130000
@@ -101657,14 +97627,12 @@ encoder:
 预想	xxfl	1160000
 双柏	xxfn	352000
 桑树	xxfx	716000
-𫙡	xxgd	0
 预感	xxha	7610000
 双轨	xxhq	426000
 柔软	xxhr	16300000
 艰巨	xxhx	6290000
 双点	xxij	287000
 双频	xxik	1240000
-𫙫	xxkv	0
 双归	xxkx	41600
 预见	xxlr	7190000
 预购	xxlr	2210000
@@ -101810,7 +97778,6 @@ encoder:
 屈辱	xzgd	4590000
 骖	xzgp	404000
 𧕱	xzii	0
-𫙨	xzma	0
 屈从	xzoo	1500000
 骏	xzor	16400000
 𩨐	xzoz	0
@@ -101831,9 +97798,6 @@ encoder:
 𠄎	yaaa	0
 𤕪	yaaa	0
 𡥚	yaaj	0
-𪧉	yaao	0
-𪧊	yaax	0
-𫖖	yaax	0
 卫士	yaba	7150000
 𡤾	yabd	0
 阿城	yabh	1060000
@@ -101847,8 +97811,6 @@ encoder:
 𨸗	yaed	0
 司南	yael	174000
 𡥰	yael	0
-𪧌	yael	0
-𪧁	yaex	0
 𡦕	yafd	0
 孺	yafg	1200000
 司机	yafq	59300000
@@ -101857,7 +97819,6 @@ encoder:
 𨹙	yagj	0
 𡥢	yagz	0
 陚	yahi	26600
-𪧂	yahm	0
 卫戍	yahs	345000
 阷	yaii	26300
 𢌛	yaii	0
@@ -101870,7 +97831,6 @@ encoder:
 𨺤	yajk	0
 覗	yajl	767000
 隔	yajl	63900000
-𫖅	yajl	0
 㝃	yajr	4530
 陌路	yajr	2290000
 𣱇	yajr	0
@@ -101900,12 +97860,10 @@ encoder:
 孟	yalk	30400000
 𥁂	yalk	0
 隔山	yall	1180000
-𪧏	yaln	0
 孭	yalo	58700
 陃	yalo	57300
 勐	yaly	1120000
 孾	yalz	53100
-𪧋	yalz	0
 卫生	yamc	101000000
 陌生	yamc	43700000
 𡥊	yamh	0
@@ -101919,8 +97877,6 @@ encoder:
 𡥴	yanb	0
 𨾆	yani	0
 陌	yank	3650000
-𪧅	yank	0
-𪧇	yanr	0
 司徒	yaob	2730000
 𡤿	yaod	0
 㜾	yaon	5260
@@ -101953,10 +97909,7 @@ encoder:
 𡦍	yasc	0
 隔夜	yasn	2030000
 隔离	yaso	18700000
-𪧃	yaso	0
-𪧄	yaso	0
 𡥧	yast	0
-𫖖	yasx	0
 𡦶	yate	0
 隔阂	yats	2360000
 𨸶	yaua	0
@@ -102040,7 +97993,6 @@ encoder:
 那些	ybir	162000000
 陵园	ybjb	2730000
 隯	ybjd	39700
-𫗃	ybjk	0
 那里	ybkb	178000000
 那时	ybkd	45200000
 那曲	ybkk	1430000
@@ -102076,13 +98028,9 @@ encoder:
 𨺞	ybuz	0
 陆河	ybva	457000
 陆运	ybwb	517000
-𫒌	ybwg	0
 陆军	ybwh	9860000
 那边	ybwy	27000000
 陡壁	ybxj	240000
-𫖀	ybxj	0
-𪾃	ybyk	0
-𫜆	ybyr	0
 𦐃	ybyy	0
 陆续	ybze	22900000
 陆	ybzi	55100000
@@ -102127,14 +98075,12 @@ encoder:
 𧒢	ydai	0
 𠮞	ydaj	0
 𠮸	ydaj	0
-𪜓	ydaj	0
 乪	ydak	26900
 氹	ydak	283000
 𠃝	ydak	0
 𠃥	ydak	0
 𠃮	ydak	0
 𣄽	ydak	0
-𪜗	ydak	0
 𡶳	ydal	0
 𧠍	ydal	0
 𠃣	ydam	0
@@ -102149,14 +98095,10 @@ encoder:
 𩙱	ydan	0
 𩙺	ydao	0
 鳵	ydar	38000
-𪜑	ydar	0
-𫛴	ydar	0
-𫜐	ydar	0
 𨐾	ydas	0
 飞	ydat	278000000
 𠃧	ydat	0
 𥸦	ydau	0
-𪸱	ydau	0
 迅	ydaw	39200000
 𢝵	ydaw	0
 𩙻	ydaw	0
@@ -102227,7 +98169,6 @@ encoder:
 乙胺	ydqw	652000
 𠣫	ydrj	0
 𠝕	ydrr	0
-𪟕	ydrr	0
 鳭	ydrz	36700
 𠟀	ydrz	0
 丒	ydsa	116000
@@ -102241,10 +98182,8 @@ encoder:
 𤆕	ydsu	0
 忍	ydsw	117000000
 乙方	ydsy	2460000
-𪟂	ydsy	0
 乙类	ydug	590000
 乙烯	yduo	10400000
-𪹹	yduu	0
 乙烷	yduw	975000
 乙炔	ydux	1010000
 导游	ydvs	22000000
@@ -102253,7 +98192,6 @@ encoder:
 𠺥	ydwx	0
 𢖫	ydwz	0
 𠬛	ydxs	0
-𪠧	ydxs	0
 刀子	ydya	5020000
 𠚪	ydyd	0
 𢦝	ydyh	0
@@ -102264,7 +98202,6 @@ encoder:
 𤭀	ydys	0
 导弹	ydyu	11100000
 𤉎	ydyu	0
-𪹪	ydyu	0
 䎄	ydyy	4120
 刕	ydyy	89300
 綤	ydyz	27800
@@ -102278,7 +98215,6 @@ encoder:
 𨼣	yeae	0
 𨼿	yeag	0
 𨻇	yeaj	0
-𫖕	yebl	0
 𨹯	yebz	0
 隫	yeel	18000
 𨼞	yeez	0
@@ -102344,7 +98280,6 @@ encoder:
 𨼏	yggl	0
 𨺖	yggr	0
 𨽀	yggs	0
-𫖔	ygkk	0
 𨺍	ygkz	0
 𨻚	ygkz	0
 陇县	yglz	434000
@@ -102354,7 +98289,6 @@ encoder:
 𨻊	ygob	0
 陜	ygoo	383000
 陝	ygoo	434000
-𫖐	ygoo	0
 隳	ygou	403000
 𡟨	ygoz	0
 𨻤	ygoz	0
@@ -102373,7 +98307,6 @@ encoder:
 𡡙	ygqz	0
 𨻢	yguo	0
 𨺕	yguy	0
-𫖆	ygyb	0
 阨	ygyy	636000
 䧅	ygyz	3470
 䧀	ygzs	3620
@@ -102384,7 +98317,6 @@ encoder:
 隇	yhaz	18800
 民工	yhbi	12800000
 陘	yhbi	122000
-𪫄	yhbi	0
 陈规	yhbo	578000
 阵地	yhbv	10700000
 民丰	yhci	466000
@@ -102453,23 +98385,18 @@ encoder:
 卍	yiai	3200000
 𧎱	yiai	0
 𧥔	yiai	0
-𪪀	yiai	0
 也可	yiaj	55100000
 𨽚	yiaj	0
 𠛋	yiak	0
-𪾎	yiak	0
 岊	yial	467000
 𢁑	yial	0
-𪪆	yial	0
 𢽼	yiam	0
 𣀟	yiam	0
 𣬷	yiam	0
 𧤭	yiam	0
-𪪁	yiao	0
 巼	yiar	69000
 𢁋	yiar	0
 𣎞	yiar	0
-𪪂	yiar	0
 𢁍	yiau	0
 𥸿	yiau	0
 𢻷	yiax	0
@@ -102678,7 +98605,6 @@ encoder:
 加以	yjzo	38400000
 隄	ykai	154000
 𢌪	ykai	0
-𫕾	ykai	0
 𨻥	ykak	0
 阳城	ykbh	1340000
 𨼥	ykcx	0
@@ -102688,7 +98614,6 @@ encoder:
 𨹂	ykgr	0
 阳历	ykgy	1400000
 廸	ykia	229000
-𫕻	ykia	0
 𨸺	ykib	0
 𨸬	ykic	0
 阳虚	ykik	774000
@@ -102716,10 +98641,8 @@ encoder:
 𨻞	ykoj	0
 𨺬	ykon	0
 阳谷	ykoo	640000
-𪤣	ykrb	0
 陽	ykro	23400000
 𨹎	ykrr	0
-𫖇	ykry	0
 阳新	yksf	875000
 阳高	yksj	329000
 䧤	ykuc	3840
@@ -102732,7 +98655,6 @@ encoder:
 𨺯	ykwz	0
 𨻂	ykwz	0
 𨼚	ykwz	0
-𪬔	ykwz	0
 孙子	ykya	8560000
 阳台	ykzj	14900000
 孙女	ykzm	2420000
@@ -102824,7 +98746,6 @@ encoder:
 𢽄	ymix	0
 郔	ymiy	650000
 改口	ymja	2580000
-𪟙	ymja	0
 𧻅	ymjb	0
 駕	ymjc	5380000
 架	ymjf	171000000
@@ -102845,7 +98766,6 @@ encoder:
 㖙	ymjr	3610
 力图	ymjr	7370000
 鴐	ymjr	33800
-𫜪	ymjr	0
 𧦲	ymjs	0
 𤇞	ymju	0
 𥹌	ymju	0
@@ -102927,7 +98847,6 @@ encoder:
 𠂐	ymtd	0
 延庆	ymtg	3810000
 力度	ymtv	89800000
-𫃣	ymuf	0
 延烧	ymuh	286000
 改判	ymuk	845000
 改悔	ymum	192000
@@ -102949,7 +98868,6 @@ encoder:
 延边	ymwy	4240000
 延安	ymwz	12100000
 𢖰	ymwz	0
-𫖎	ymxb	0
 𩑦	ymxg	0
 力臂	ymxj	186000
 改观	ymxl	4260000
@@ -102966,14 +98884,12 @@ encoder:
 䝱	ymyl	3500
 𠠴	ymym	0
 𨹳	ymym	0
-𫄊	ymyn	0
 脅	ymyq	2440000
 𣢩	ymyr	0
 𩸻	ymyr	0
 改建	ymyx	11400000
 劦	ymyy	813000
 姭	ymyz	482000
-𪦄	ymyz	0
 劜	ymza	101000
 延续	ymze	25900000
 改线	ymzh	326000
@@ -103050,7 +98966,6 @@ encoder:
 办报	yody	555000
 除草	yoek	2820000
 坠落	yoev	11900000
-𫆡	yofj	0
 阶梯	yofu	7500000
 险要	yofv	1610000
 办厂	yogg	7960000
@@ -103064,10 +98979,7 @@ encoder:
 险别	yojy	109000
 除尘	yokb	4290000
 除非	yokc	38900000
-𫆛	yoko	0
 𨹉	yokv	0
-𫆠	yokz	0
-𫆤	yokz	0
 险峰	yolr	1440000
 险峻	yolz	2840000
 除	yomf	184000000
@@ -103118,7 +99030,6 @@ encoder:
 𨸣	yoyd	0
 羽	yoyo	0
 除了	yoyv	195000000
-𫖍	yoyy	0
 𨻔	yozq	0
 办好	yozy	7000000
 阶级	yozy	13000000
@@ -103127,13 +99038,11 @@ encoder:
 弧菌	ypej	287000
 𨺠	ypel	0
 孤本	ypfa	340000
-𫖈	ypgx	0
 𨻆	ypih	0
 𨺻	ypik	0
 𨽯	ypio	0
 弧光	ypkg	615000
 𨼠	ypki	0
-𫖊	yplb	0
 𨺄	ypmb	0
 䧟	ypnb	3930
 孤傲	ypnc	3260000
@@ -103162,7 +99071,6 @@ encoder:
 𦏲	ypyp	0
 䧦	ypyu	3960
 䧌	ypzm	3310
-𫖉	ypzx	0
 阴天	yqag	3620000
 阴魂	yqbz	1010000
 阴森	yqff	3380000
@@ -103226,7 +99134,6 @@ encoder:
 陶器	yrjj	7310000
 隆回	yrjj	522000
 隐患	yrjj	21500000
-𫖑	yrjk	0
 𨽊	yrjr	0
 𨽆	yrju	0
 隆昌	yrkk	689000
@@ -103309,14 +99216,12 @@ encoder:
 防虫	ysia	2300000
 防止	ysii	168000000
 䧚	ysjl	3280
-𫖗	ysjl	0
 𣯱	ysjm	0
 𨺥	ysjr	0
 䧐	ysjy	3560
 防尘	yskb	3110000
 防暑	yskb	1110000
 障	yske	15000000
-𫖏	yskl	0
 防水	yskv	29100000
 𨻫	yskz	0
 陪同	ysld	12200000
@@ -103325,8 +99230,6 @@ encoder:
 𨼨	ysly	0
 隡	ysmm	55600
 𢻮	ysmo	0
-𫖘	ysmz	0
-𫖄	ysnb	0
 𨻓	ysnj	0
 防伪	ysnu	9430000
 陪伴	ysnu	15700000
@@ -103358,7 +99261,6 @@ encoder:
 防盗	ystr	26900000
 忍痛	ystx	4360000
 防爆	ysuk	7680000
-𫖒	ysul	0
 防火	ysuo	14200000
 防污	ysvb	871000
 防洪	ysve	4160000
@@ -103423,7 +99325,6 @@ encoder:
 翄	ytex	50000
 𦐕	ytez	0
 䎔	ytfd	3830
-𫆡	ytfj	0
 𦑿	ytfk	0
 飞机	ytfq	55800000
 𦒊	ytfs	0
@@ -103468,14 +99369,11 @@ encoder:
 𠞨	ytkk	0
 𦑾	ytkk	0
 弱小	ytko	5380000
-𫆛	ytko	0
 弱水	ytkv	917000
 𠢜	ytky	0
 弱电	ytkz	2520000
 𦑎	ytkz	0
 𦑐	ytkz	0
-𫆠	ytkz	0
-𫆤	ytkz	0
 𦐘	ytlb	0
 𦑶	ytlk	0
 𦒗	ytlk	0
@@ -103511,7 +99409,6 @@ encoder:
 𣤩	ytnr	0
 𦑀	ytnr	0
 𪄶	ytnr	0
-𪵔	ytnr	0
 𨞩	ytny	0
 翠	ytoe	35900000
 飞行	ytoi	47000000
@@ -103524,7 +99421,6 @@ encoder:
 飞往	ytos	3630000
 𦐗	ytos	0
 䎆	ytow	3860
-𫆖	ytow	0
 翂	ytoy	39000
 䧪	ytoz	3310
 𡣀	ytoz	0
@@ -103536,7 +99432,6 @@ encoder:
 剹	ytpk	74000
 𥂔	ytpl	0
 𧢋	ytpl	0
-𪯯	ytpm	0
 雡	ytpn	25600
 飞船	ytpq	6010000
 𩘷	ytpq	0
@@ -103596,16 +99491,12 @@ encoder:
 𩢳	ytyc	0
 𦏽	ytyd	0
 羿	ytye	4700000
-𫗉	ytye	0
 䎍	ytyf	3700
 𦐔	ytyf	0
-𫆚	ytyf	0
 頨	ytyg	42000
 𦏵	ytyh	0
 𦐂	ytyh	0
-𫋷	ytyi	0
 䎌	ytyj	3890
-𫆜	ytyk	0
 毣	ytym	45700
 𢬙	ytym	0
 習	ytyn	4230000
@@ -103624,7 +99515,6 @@ encoder:
 𦐹	ytys	0
 羽	ytyt	90700000
 𦐭	ytyt	0
-𫆙	ytyu	0
 𪓦	ytyw	0
 翍	ytyx	139000
 䣁	ytyy	3600
@@ -103643,13 +99533,10 @@ encoder:
 弹指	yudr	2500000
 弹药	yuez	4610000
 𨺧	yufd	0
-𪫅	yufj	0
 粥样	yufu	1340000
 墜	yugb	5290000
 弹压	yugb	284000
 𨺰	yugd	0
-𫕿	yugd	0
-𪥪	yugg	0
 𩈁	yugk	0
 鐆	yugp	25400
 隊	yugq	71000000
@@ -103690,7 +99577,6 @@ encoder:
 𨸵	yway	0
 院士	ywba	17000000
 𨼈	ywbj	0
-𫖌	ywbk	0
 隨	ywbq	40500000
 院	ywbr	446000000
 随地	ywbv	12500000
@@ -103707,7 +99593,6 @@ encoder:
 𨽒	ywkk	0
 䧬	ywkl	3770
 随同	ywld	2320000
-𫖋	ywld	0
 䧮	ywlw	3230
 随手	ywmd	11800000
 𨹏	ywmh	0
@@ -103722,7 +99607,6 @@ encoder:
 𨼭	ywoy	0
 随后	ywpa	53500000
 𡓗	ywqb	0
-𫖁	ywqy	0
 随处	ywri	6270000
 𨻮	ywrm	0
 陀	ywrr	9890000
@@ -103763,7 +99647,6 @@ encoder:
 限至	yxhb	42300
 建瓯	yxho	557000
 建成	yxhv	40500000
-𫖂	yxiy	0
 建国	yxjc	34000000
 𨼔	yxjd	0
 隦	yxjs	22400
@@ -103799,7 +99682,6 @@ encoder:
 建房	yxws	4750000
 𨻗	yxxf	0
 䦽	yxxi	3310
-𫖓	yxxj	0
 𢙎	yxxw	0
 𨺝	yxxx	0
 𨺽	yxxx	0
@@ -103807,7 +99689,6 @@ encoder:
 建阳	yxyk	666000
 建始	yxzz	826000
 𨺘	yyai	0
-𪪃	yyam	0
 	yyba	0
 𦖫	yybc	0
 导	yybd	93100000
@@ -103842,7 +99723,6 @@ encoder:
 𢁅	yybm	0
 𢰞	yybm	0
 𢾞	yybm	0
-𪪄	yybm	0
 𨾧	yybn	0
 𩀃	yybn	0
 巺	yybo	187000
@@ -103877,9 +99757,7 @@ encoder:
 𣪐	yyhq	0
 𡕪	yyhr	0
 𨹸	yyjb	0
-𪬾	yyjk	0
 𠭵	yyjx	0
-𫖙	yykk	0
 㞯	yyll	3650
 𨹃	yymf	0
 羽毛	yymh	12500000
@@ -103951,7 +99829,6 @@ encoder:
 𢏚	yzbb	0
 𢎥	yzbd	0
 𠷎	yzbj	0
-𪿌	yzbl	0
 𤾊	yzbn	0
 𨞉	yzby	0
 㢪	yzbz	3690
@@ -103965,11 +99842,9 @@ encoder:
 張	yzch	102000000
 𨺮	yzcr	0
 𪓯	yzcw	0
-𪫖	yzcx	0
 㢽	yzcy	3580
 𢐓	yzcy	0
 𩱨	yzda	0
-𫚊	yzda	0
 弘扬	yzdy	9310000
 彃	yzeb	841000
 𢏴	yzeb	0
@@ -104012,12 +99887,10 @@ encoder:
 䥒	yzip	6740
 𢏾	yzir	0
 謽	yzis	29300
-𪫼	yziw	0
 㢭	yzix	3720
 𢏈	yzix	0
 𢾲	yzix	0
 𢿟	yzix	0
-𪫕	yzix	0
 勥	yziy	35000
 𢏍	yziy	0
 𡠥	yziz	0
@@ -104042,7 +99915,6 @@ encoder:
 𩱳	yzjl	0
 𩱶	yzjl	0
 𩎡	yzjm	0
-𪫗	yzjm	0
 𢑆	yzjn	0
 𢐀	yzjo	0
 𢐡	yzjo	0
@@ -104076,7 +99948,6 @@ encoder:
 𢐸	yzkl	0
 孔雀	yzkn	12300000
 彉	yzko	618000
-𪫙	yzko	0
 𨧮	yzkp	0
 𨯞	yzkp	0
 弰	yzkq	327000
@@ -104090,7 +99961,6 @@ encoder:
 𢑎	yzky	0
 𡝠	yzkz	0
 𡝡	yzkz	0
-𪫘	yzlb	0
 𢏕	yzld	0
 𢎭	yzli	0
 𢏎	yzlk	0
@@ -104101,7 +99971,6 @@ encoder:
 陋	yzlo	3280000
 𢏟	yzlo	0
 𨻨	yzlo	0
-𪫒	yzlo	0
 㢷	yzlr	3620
 䰜	yzly	4190
 鄪	yzly	22000
@@ -104112,7 +99981,6 @@ encoder:
 矤	yzma	52900
 𢐩	yzmi	0
 㣁	yzml	4120
-𪫔	yzml	0
 𥡀	yzmm	0
 𢎿	yzmo	0
 㢳	yzmr	3920
@@ -104132,7 +100000,6 @@ encoder:
 𩱲	yzna	0
 𩱳	yzna	0
 𩱶	yzna	0
-𫚋	yzna	0
 弗	yznd	30200000
 弣	yznd	30600
 𢎵	yznd	0
@@ -104154,7 +100021,6 @@ encoder:
 𤇝	yznu	0
 𢘍	yznw	0
 彏	yznx	28700
-𪫛	yznx	0
 㔗	yzny	4090
 弼	yzny	2280000
 𠡂	yzny	0
@@ -104207,7 +100073,6 @@ encoder:
 𩱠	yzra	0
 𡍵	yzrb	0
 阭	yzrd	87800
-𪫓	yzre	0
 㣅	yzrk	3780
 弥	yzrk	12300000
 𢏧	yzrl	0
@@ -104218,7 +100083,6 @@ encoder:
 𢏜	yzrr	0
 𢏤	yzrr	0
 𣩴	yzrr	0
-𪫜	yzrr	0
 㢩	yzrs	3900
 弤	yzrs	27200
 𢏉	yzrs	0
@@ -104374,7 +100238,6 @@ encoder:
 𥾧	zali	0
 𦁥	zalk	0
 𦂲	zalk	0
-𫅗	zall	0
 䋑	zalo	3780
 纚	zalt	65400
 𥾎	zand	0
@@ -104438,7 +100301,6 @@ encoder:
 红光	zbkg	4150000
 结晶	zbkk	14800000
 红星	zbkm	8180000
-𫄐	zbko	0
 结盟	zbkq	4930000
 结业	zbku	2400000
 结账	zblc	2370000
@@ -104494,7 +100356,6 @@ encoder:
 繥	zbuj	264000
 红火	zbuo	8760000
 𦅈	zbup	0
-𫅧	zbup	0
 红糖	zbut	1290000
 结为	zbuv	2600000
 繨	zbuw	52900
@@ -104528,7 +100389,6 @@ encoder:
 紶	zbzs	774000
 纭	zbzs	810000
 𦀖	zbzy	0
-𫅘	zbzy	0
 䌰	zccc	4800
 𦄑	zccx	0
 𦀳	zcds	0
@@ -104608,7 +100468,6 @@ encoder:
 𤋴	zdku	0
 𤎁	zdku	0
 𤎾	zdku	0
-𪹨	zdku	0
 𣲂	zdkv	0
 䣎	zdky	3250
 𡬲	zdld	0
@@ -104652,7 +100511,6 @@ encoder:
 𠡝	zdry	0
 𠡢	zdry	0
 𩾣	zdrz	0
-𫄪	zdrz	0
 紂	zdsa	194000
 纣	zdsa	883000
 𧚲	zdsr	0
@@ -104669,7 +100527,6 @@ encoder:
 𤳲	zdxi	0
 㜽	zdya	4930
 𩔪	zdyg	0
-𪩳	zdyi	0
 雝	zdyn	58500
 𪄉	zdyr	0
 𤮲	zdys	0
@@ -104677,7 +100534,6 @@ encoder:
 𦒩	zdyy	0
 𡿭	zdzd	0
 𤳤	zdzg	0
-𫗬	zdzg	0
 𠠗	zdzk	0
 𣰫	zdzm	0
 𡗇	zdzr	0
@@ -104699,8 +100555,6 @@ encoder:
 緙	zeea	86100
 缂	zeea	5040000
 𦅠	zeeb	0
-𫄰	zefb	0
-𫄹	zefk	0
 𦇠	zefw	0
 𦂍	zegj	0
 𦄩	zehk	0
@@ -104708,16 +100562,13 @@ encoder:
 𦇪	zehs	0
 䌍	zejc	5700
 𦅇	zejh	0
-𫅣	zejj	0
 䌯	zejn	5620
 纎	zeka	67500
 縸	zekg	131000
-𫅤	zekg	0
 𦄩	zekh	0
 緢	zeki	241000
 𦄧	zekk	0
 䌙	zeko	4140
-𫄳	zekq	0
 𦅶	zekr	0
 繊	zeku	406000
 𡌴	zelb	0
@@ -104748,7 +100599,6 @@ encoder:
 繖	zeqm	693000
 䌨	zerb	5200
 纄	zerc	32200
-𫄺	zerj	0
 𦃜	zerk	0
 𦀴	zesh	0
 𦃑	zesn	0
@@ -104756,7 +100606,6 @@ encoder:
 繱	zesw	49700
 𦇎	zesw	0
 续	zetg	51700000
-𫅜	zeuh	0
 𦆇	zeuj	0
 绁	zeva	647000
 𦄂	zewl	0
@@ -104769,7 +100618,6 @@ encoder:
 绁	zeza	647000
 姑姑	zeze	2820000
 緤	zezf	296000
-𫅞	zezf	0
 𦇴	zezh	0
 妓女	zezm	10400000
 𦃮	zezo	0
@@ -104795,7 +100643,6 @@ encoder:
 𦈡	zfgl	0
 𦅰	zfke	0
 𦆙	zfki	0
-𫅄	zfkm	0
 𦄏	zfkq	0
 緗	zfla	973000
 缃	zfla	2470000
@@ -104815,7 +100662,6 @@ encoder:
 䊾	zfvv	3460
 嫖宿	zfwn	161000
 繐	zfwz	635000
-𫄯	zfxb	0
 𦇉	zfxx	0
 𦇛	zfyl	0
 𦂪	zfym	0
@@ -104874,7 +100720,6 @@ encoder:
 叁仟	zgnm	128000
 叁亿	zgny	26500
 参会	zgob	3910000
-𫄸	zgoe	0
 𦇦	zgog	0
 綊	zgoo	559000
 𦄍	zgoo	0
@@ -104890,7 +100735,6 @@ encoder:
 𦁑	zgub	0
 𦂡	zguc	0
 缅怀	zgug	3790000
-𫅈	zgul	0
 𦆡	zgum	0
 参数	zguz	67900000
 参赛	zgwe	16100000
@@ -104906,7 +100750,6 @@ encoder:
 缭绕	zgzh	2990000
 紘	zgzs	1430000
 纮	zgzs	149000
-𫄛	zgzt	0
 线形	zhae	1430000
 纯正	zhai	6390000
 緘	zhaj	173000
@@ -104938,7 +100781,6 @@ encoder:
 线路	zhjr	50400000
 𦆃	zhjr	0
 线圈	zhju	2630000
-𫄷	zhjw	0
 𦃄	zhkc	0
 𦈗	zhkc	0
 𦇰	zhkj	0
@@ -105068,7 +100910,6 @@ encoder:
 𤖘	ziel	0
 𦲬	zier	0
 𪔫	ziex	0
-𪨵	ziex	0
 𦱧	zifa	0
 𨟻	zifd	0
 𣞆	ziff	0
@@ -105152,12 +100993,10 @@ encoder:
 𦁗	zikm	0
 𣎵	ziko	0
 𤖖	ziko	0
-𪞁	zikr	0
 𩇿	ziks	0
 𤕯	zikv	0
 𢠞	zikw	0
 𦻇	zikw	0
-𫄝	zikx	0
 𦱶	zilb	0
 𤕲	zilc	0
 𤖤	zilg	0
@@ -105172,7 +101011,6 @@ encoder:
 𥝄	zilz	0
 𡴍	zimb	0
 𦗷	zimc	0
-𫆶	zimc	0
 𢪇	zimd	0
 𩕣	zimg	0
 𤖢	zimi	0
@@ -105206,7 +101044,6 @@ encoder:
 𦯦	zinr	0
 𡴎	zinx	0
 𤕰	zinx	0
-𪞸	zioa	0
 𡑶	ziob	0
 𠇿	ziod	0
 𡴨	zioe	0
@@ -105251,15 +101088,12 @@ encoder:
 𤖕	zirf	0
 𨡓	zirf	0
 𧌜	ziri	0
-𪯢	ziri	0
 𤖅	zirk	0
 𤯧	zirl	0
 𧢼	zirl	0
 𪗊	zirn	0
 紪	zirr	160000
 𤖝	zirs	0
-𫄤	zirs	0
-𪻈	zirw	0
 𩿄	zirz	0
 櫱	zisf	35800
 𡘾	zisg	0
@@ -105271,10 +101105,8 @@ encoder:
 𡴫	ziso	0
 裝	zisr	44700000
 𧛬	zisr	0
-𫍊	zisr	0
 𥫋	ziss	0
 糱	zisu	32300
-𪞻	zisw	0
 㔎	zisy	4520
 孼	zisy	133000
 𤕸	zitb	0
@@ -105282,7 +101114,6 @@ encoder:
 𤖏	zitm	0
 牂	ziuc	76400
 𦆇	ziuj	0
-𪻉	ziuk	0
 𧡠	ziul	0
 𥽀	ziun	0
 𤉞	ziuu	0
@@ -105295,7 +101126,6 @@ encoder:
 𥚢	ziwb	0
 𨌗	ziwf	0
 𢄆	ziwl	0
-𪵚	ziwm	0
 𪓓	ziwx	0
 𡴄	ziwy	0
 𤖒	zixf	0
@@ -105332,13 +101162,11 @@ encoder:
 𤭽	ziys	0
 𦐉	ziyy	0
 𦴘	ziyy	0
-𪞼	ziyz	0
 𦫹	ziza	0
 祟	zizb	4310000
 𡴠	zizb	0
 𤕿	zizb	0
 𦱴	zize	0
-𪞹	zize	0
 牃	zizf	170000
 𠚐	zizf	0
 𣐯	zizf	0
@@ -105358,7 +101186,6 @@ encoder:
 𡭧	zizk	0
 𣈤	zizk	0
 𣑼	zizk	0
-𪻇	zizk	0
 𦮅	zizl	0
 𧵠	zizl	0
 𩨳	zizl	0
@@ -105456,10 +101283,8 @@ encoder:
 绢	zjqa	3680000
 台风	zjqo	15700000
 台胞	zjqr	1600000
-𫄻	zjrj	0
 娱乐	zjrk	552000000
 𦀝	zjrl	0
-𫄾	zjrz	0
 如意	zjsk	24800000
 台词	zjsy	7380000
 台北	zjtr	142000000
@@ -105474,7 +101299,6 @@ encoder:
 如潮	zjve	3040000
 台州	zjvn	26400000
 台湾	zjvs	71700000
-𫄍	zjvv	0
 邕宁	zjwa	301000
 织造	zjwm	2750000
 如实	zjwt	7850000
@@ -105493,7 +101317,6 @@ encoder:
 綥	zkan	26900
 𦀔	zkaz	0
 绅士	zkba	7940000
-𫅉	zkbu	0
 緋	zkca	4150000
 绯	zkca	6410000
 细长	zkch	3240000
@@ -105545,7 +101368,6 @@ encoder:
 𦆿	zkok	0
 细微	zkol	6960000
 𦃩	zkor	0
-𫅡	zkor	0
 纱锭	zkpw	178000
 绡	zkqa	834000
 细腻	zkqh	15400000
@@ -105556,9 +101378,7 @@ encoder:
 𣆄	zkro	0
 緄	zkrr	148000
 绲	zkrr	924000
-𪺑	zkru	0
 䋵	zkry	3700
-𫅇	zkrz	0
 妙语	zksb	4040000
 妙计	zkse	1900000
 绯闻	zktc	7040000
@@ -105610,7 +101430,6 @@ encoder:
 组配	zlfy	365000
 紻	zlgd	30000
 𩖂	zlgg	0
-𫅅	zlgs	0
 𦆎	zlgu	0
 组成	zlhv	71100000
 纳卡	zlia	410000
@@ -105632,7 +101451,6 @@ encoder:
 纳税	zlmu	16900000
 繀	zlni	215000
 纗	zlnl	42600
-𫅫	zlnl	0
 组件	zlnm	15600000
 组合	zloa	194000000
 納	zlod	17800000
@@ -105661,7 +101479,6 @@ encoder:
 贯注	zlvs	541000
 贯穿	zlwh	11200000
 贯通	zlwx	4600000
-𫄗	zlxs	0
 组办	zlyo	268000
 组建	zlyx	47400000
 姐妹	zlzb	35200000
@@ -105688,7 +101505,6 @@ encoder:
 𡞳	zmag	0
 𡣘	zmag	0
 𢑣	zmag	0
-𪦦	zmag	0
 奵	zmai	44500
 姃	zmai	532000
 媞	zmai	679000
@@ -105707,7 +101523,6 @@ encoder:
 婍	zmaj	70400
 𡄲	zmaj	0
 𡟵	zmaj	0
-𫅁	zmaj	0
 娅	zmak	6050000
 𡜔	zmak	0
 𡠽	zmak	0
@@ -105738,9 +101553,6 @@ encoder:
 𡜏	zmaz	0
 𡞄	zmaz	0
 𡞲	zmaz	0
-𪥿	zmaz	0
-𪦌	zmaz	0
-𪦵	zmaz	0
 女士	zmba	58100000
 纴	zmba	40100
 㛻	zmbb	3860
@@ -105749,7 +101561,6 @@ encoder:
 收款	zmbb	14900000
 𡣋	zmbd	0
 𦅯	zmbd	0
-𪦒	zmbd	0
 𣕁	zmbf	0
 嬈	zmbg	133000
 女工	zmbi	4190000
@@ -105784,7 +101595,6 @@ encoder:
 纁	zmbu	87000
 𡤥	zmbu	0
 𡤭	zmbu	0
-𫅪	zmbu	0
 㜇	zmbw	4360
 㥨	zmbw	4440
 娡	zmbw	42600
@@ -105807,14 +101617,10 @@ encoder:
 𡢅	zmbz	0
 𡢯	zmbz	0
 𡤦	zmbz	0
-𪥯	zmbz	0
-𪦈	zmbz	0
-𪦕	zmbz	0
 𡞗	zmcb	0
 𡤙	zmcc	0
 㛅	zmce	3770
 㛞	zmce	3610
-𪦇	zmch	0
 妦	zmci	162000
 𥿙	zmci	0
 𡟲	zmcj	0
@@ -105828,7 +101634,6 @@ encoder:
 𡣜	zmcm	0
 媋	zmco	42500
 婧	zmcq	6300000
-𪦖	zmcq	0
 㜵	zmcr	7320
 婊	zmcr	3260000
 𡛼	zmcs	0
@@ -105838,7 +101643,6 @@ encoder:
 收取	zmcx	68500000
 牟取	zmcx	1680000
 𡡔	zmcx	0
-𪦀	zmcy	0
 嫊	zmcz	77400
 𡛋	zmcz	0
 𡜯	zmcz	0
@@ -105890,7 +101694,6 @@ encoder:
 𡝅	zmer	0
 𡞁	zmer	0
 𡟉	zmer	0
-𪦋	zmes	0
 䌗	zmeu	3950
 嫬	zmeu	585000
 嫵	zmeu	1350000
@@ -105929,8 +101732,6 @@ encoder:
 孄	zmfl	31000
 孏	zmfl	36200
 𡤅	zmfl	0
-𪥺	zmfl	0
-𪦬	zmfl	0
 𡡵	zmfm	0
 㜛	zmfr	4230
 𡠇	zmfw	0
@@ -105978,7 +101779,6 @@ encoder:
 𡞋	zmgp	0
 𣂵	zmgp	0
 𤬌	zmgp	0
-𪦙	zmgp	0
 姷	zmgq	1150000
 彖	zmgq	497000
 𡝍	zmgq	0
@@ -105997,7 +101797,6 @@ encoder:
 𦂜	zmgu	0
 𦃱	zmgu	0
 嬘	zmgw	26000
-𪦑	zmgw	0
 媛	zmgx	8870000
 嫒	zmgx	471000
 𠭣	zmgx	0
@@ -106012,7 +101811,6 @@ encoder:
 姪	zmhb	3300000
 娙	zmhb	40500
 𥾑	zmhd	0
-𫅎	zmhd	0
 娀	zmhg	481000
 娆	zmhg	2250000
 娬	zmhi	45900
@@ -106037,18 +101835,14 @@ encoder:
 𡛟	zmhz	0
 䋏	zmid	3510
 婋	zmih	35500
-𪜢	zmih	0
 蠡	zmii	1860000
 𡡟	zmii	0
 𡢋	zmii	0
 𤬤	zmii	0
-𪥰	zmii	0
 㚲	zmij	4040
-𪦎	zmij	0
 劙	zmik	589000
 𠠞	zmik	0
 𡝃	zmik	0
-𪥷	zmik	0
 㜘	zmil	4720
 媜	zmil	171000
 𡟣	zmil	0
@@ -106060,10 +101854,8 @@ encoder:
 婿	zmiq	4320000
 𡜕	zmiq	0
 𡞚	zmiq	0
-𪦝	zmis	0
 𡤗	zmiu	0
 𡠛	zmiw	0
-𪥲	zmix	0
 娫	zmiy	36500
 綖	zmiy	519000
 𡜒	zmiy	0
@@ -106102,7 +101894,6 @@ encoder:
 𡣰	zmjj	0
 𡤑	zmjj	0
 𨃢	zmjj	0
-𪦻	zmjj	0
 㜭	zmjk	4700
 婛	zmjk	68300
 媔	zmjk	128000
@@ -106121,7 +101912,6 @@ encoder:
 𡠀	zmjl	0
 𡡽	zmjl	0
 𡢠	zmjl	0
-𪥼	zmjl	0
 媁	zmjm	60100
 嫩	zmjm	28600000
 挐	zmjm	79400
@@ -106130,7 +101920,6 @@ encoder:
 𣭠	zmjm	0
 𤯥	zmjm	0
 𤯯	zmjm	0
-𪦛	zmjm	0
 孉	zmjn	63300
 𡛰	zmjo	0
 收听	zmjp	11000000
@@ -106154,8 +101943,6 @@ encoder:
 𡣱	zmjr	0
 𡤎	zmjr	0
 𩶯	zmjr	0
-𪦸	zmjr	0
-𫜰	zmjr	0
 嫴	zmjs	60200
 𧧏	zmjs	0
 𨐞	zmjs	0
@@ -106231,7 +102018,6 @@ encoder:
 𡡝	zmkk	0
 𡡺	zmkk	0
 𡣲	zmkk	0
-𪦹	zmkk	0
 媢	zmkl	48300
 媪	zmkl	336000
 嬪	zmkl	2630000
@@ -106255,7 +102041,6 @@ encoder:
 㜳	zmkr	7740
 緮	zmkr	81900
 𡞪	zmkr	0
-𫅟	zmkr	0
 𡟄	zmks	0
 𡞷	zmku	0
 𡡐	zmku	0
@@ -106277,17 +102062,13 @@ encoder:
 𡞍	zmkz	0
 𡢧	zmkz	0
 𡤯	zmkz	0
-𪦓	zmkz	0
 嬣	zmla	47800
-𪥶	zmla	0
 㚩	zmlb	4100
 㛵	zmlb	3700
 姌	zmlb	390000
 媾	zmlb	839000
 𡜜	zmlb	0
 𡣈	zmlb	0
-𪦮	zmlb	0
-𪦲	zmlb	0
 姐	zmlc	89300000
 姛	zmld	182000
 𡛾	zmld	0
@@ -106303,7 +102084,6 @@ encoder:
 𡛢	zmlg	0
 𡞵	zmlg	0
 𡣬	zmlg	0
-𪦍	zmlg	0
 媧	zmlj	239000
 𡡿	zmlj	0
 嬒	zmlk	85300
@@ -106318,11 +102098,8 @@ encoder:
 𡣧	zmll	0
 𡤓	zmll	0
 𡤱	zmll	0
-𪦽	zmll	0
-𫍠	zmll	0
 𡛷	zmlm	0
 𡡹	zmlm	0
-𪦥	zmlm	0
 㜠	zmln	9340
 㜹	zmln	8220
 㛝	zmlo	3880
@@ -106364,12 +102141,10 @@ encoder:
 娥	zmmh	8840000
 嬟	zmmh	30400
 𡟶	zmmh	0
-𪦤	zmmh	0
 妰	zmmi	30000
 姡	zmmi	57900
 娫	zmmi	36500
 𡤌	zmmi	0
-𪥮	zmmi	0
 𡜲	zmmj	0
 𡞈	zmmj	0
 𡟐	zmmj	0
@@ -106386,7 +102161,6 @@ encoder:
 𢂬	zmml	0
 姩	zmmm	1580000
 𡝟	zmmm	0
-𪻓	zmmm	0
 㛼	zmmn	4150
 妷	zmmo	435000
 𡛇	zmmo	0
@@ -106402,8 +102176,6 @@ encoder:
 姂	zmmw	200000
 嫕	zmmw	108000
 𢟇	zmmw	0
-𪦅	zmmw	0
-𪬕	zmmw	0
 㚹	zmmy	4090
 㚺	zmmy	4000
 娇气	zmmy	859000
@@ -106506,7 +102278,6 @@ encoder:
 𡠪	zmoo	0
 𡣞	zmoo	0
 𢑓	zmoo	0
-𪦾	zmoo	0
 㜗	zmop	4000
 嫪	zmop	147000
 𡛧	zmop	0
@@ -106519,8 +102290,6 @@ encoder:
 𡡷	zmor	0
 㜬	zmos	4510
 𡞬	zmos	0
-𪦱	zmos	0
-𪦪	zmot	0
 㛋	zmou	3710
 𡤚	zmou	0
 姈	zmow	442000
@@ -106552,7 +102321,6 @@ encoder:
 嫍	zmpn	85800
 娦	zmpo	41800
 嫔	zmpo	1070000
-𪦭	zmpp	0
 𡛴	zmps	0
 𡜁	zmps	0
 收受	zmpw	5800000
@@ -106580,10 +102348,8 @@ encoder:
 𡤇	zmqm	0
 㚯	zmqo	3730
 𡛪	zmqp	0
-𪦃	zmqp	0
 𡞇	zmqq	0
 𡡈	zmqq	0
-𪥳	zmqq	0
 𡚺	zmqs	0
 𡛓	zmqs	0
 𡜫	zmqs	0
@@ -106601,14 +102367,11 @@ encoder:
 𡢼	zmrf	0
 𡚼	zmrh	0
 孎	zmri	61700
-𪦉	zmri	0
-𪦳	zmri	0
 姁	zmrj	56600
 姓名	zmrj	246000000
 姳	zmrj	935000
 𡜶	zmrj	0
 𡟔	zmrj	0
-𪦶	zmrj	0
 妳	zmrk	44700000
 姰	zmrk	113000
 婚	zmrk	65000000
@@ -106652,7 +102415,6 @@ encoder:
 𡠌	zmrr	0
 𡠰	zmrr	0
 𡡷	zmrr	0
-𪦠	zmrr	0
 㜶	zmrs	8260
 奺	zmrs	54900
 妁	zmrs	158000
@@ -106665,7 +102427,6 @@ encoder:
 𡟰	zmrs	0
 𡠶	zmrs	0
 𡤹	zmrs	0
-𪦔	zmrs	0
 㚬	zmrt	3810
 㚵	zmrt	4080
 婅	zmru	487000
@@ -106689,11 +102450,9 @@ encoder:
 𡠄	zmrz	0
 𡠎	zmrz	0
 𡡅	zmrz	0
-𪦗	zmrz	0
 妵	zmsc	579000
 㛙	zmse	3740
 媇	zmsf	144000
-𪜢	zmsh	0
 𡠁	zmsi	0
 𡡟	zmsi	0
 婄	zmsj	1220000
@@ -106736,7 +102495,6 @@ encoder:
 𣁭	zmte	0
 娴	zmtf	6590000
 㚧	zmtg	3690
-𪦊	zmtg	0
 㛠	zmtk	3730
 嫉	zmtm	3830000
 女将	zmtr	2930000
@@ -106755,11 +102513,9 @@ encoder:
 嬘	zmug	26000
 𡟝	zmug	0
 𡡦	zmug	0
-𪫞	zmug	0
 嫸	zmuj	29700
 嬉	zmuj	11800000
 女单	zmuk	1210000
-𫅊	zmuk	0
 嫡	zmul	1460000
 嬧	zmul	366000
 𡡀	zmul	0
@@ -106788,30 +102544,25 @@ encoder:
 𡟜	zmuz	0
 𦃉	zmuz	0
 𡤊	zmvb	0
-𪦧	zmvb	0
 𡠖	zmve	0
 姚	zmvr	28200000
 𡡃	zmvr	0
 㛏	zmvs	3820
 𠚣	zmvv	0
 婷	zmwa	30600000
-𪥹	zmwa	0
 婃	zmwb	1660000
 收割	zmwc	3840000
 𡝬	zmwc	0
-𪦺	zmwc	0
 婝	zmwd	53900
 㜕	zmwf	4060
 媈	zmwf	28500
 嬫	zmwf	1810000
 𡜻	zmwf	0
 𡣻	zmwf	0
-𪦡	zmwf	0
 嫁	zmwg	66200000
 𡡪	zmwg	0
 𧰺	zmwg	0
 嬯	zmwh	23200
-𪦼	zmwi	0
 婶	zmwk	1220000
 㛿	zmwl	5220
 㜴	zmwl	7490
@@ -106844,12 +102595,10 @@ encoder:
 㣽	zmwz	4060
 姲	zmwz	41000
 𡚿	zmwz	0
-𪦢	zmwz	0
 妇	zmxb	69700000
 𡞹	zmxb	0
 𡟽	zmxb	0
 𡠩	zmxb	0
-𫄴	zmxb	0
 駑	zmxc	106000
 𡣟	zmxc	0
 妞	zmxe	18300000
@@ -106873,12 +102622,10 @@ encoder:
 𦀢	zmxi	0
 𧉭	zmxi	0
 𪗭	zmxi	0
-𪦏	zmxi	0
 㜍	zmxj	4500
 娢	zmxj	49700
 娪	zmxj	70400
 𡝗	zmxj	0
-𪦟	zmxj	0
 娽	zmxk	26900
 嫝	zmxk	53000
 收录	zmxk	36900000
@@ -106887,7 +102634,6 @@ encoder:
 𡠑	zmxk	0
 𡢃	zmxk	0
 𨽽	zmxk	0
-𪦿	zmxk	0
 㛚	zmxl	3840
 媚	zmxl	39200000
 嫞	zmxl	58000
@@ -106903,7 +102649,6 @@ encoder:
 𢑩	zmxl	0
 𥅄	zmxl	0
 𧲁	zmxl	0
-𪦷	zmxl	0
 娓	zmxm	5250000
 拏	zmxm	379000
 收尾	zmxm	2330000
@@ -106924,7 +102669,6 @@ encoder:
 𡛄	zmxs	0
 𡟭	zmxs	0
 𡢄	zmxs	0
-𪥻	zmxs	0
 收买	zmxt	3160000
 𡠮	zmxu	0
 𤍻	zmxu	0
@@ -106937,7 +102681,6 @@ encoder:
 𡜢	zmxx	0
 𡢷	zmxx	0
 𡤕	zmxx	0
-𪥴	zmxx	0
 㐐	zmxy	5340
 努	zmxy	23800000
 嫏	zmxy	86600
@@ -106948,7 +102691,6 @@ encoder:
 䋈	zmxz	4350
 𡝓	zmxz	0
 𡞿	zmxz	0
-𪦆	zmxz	0
 女子	zmya	113000000
 好	zmya	1780000000
 𦁳	zmya	0
@@ -106959,7 +102701,6 @@ encoder:
 彜	zmye	145000
 𢑱	zmyg	0
 姄	zmyh	70900
-𪦞	zmyh	0
 她	zmyi	340000000
 妑	zmyi	90700
 絁	zmyi	61400
@@ -106984,12 +102725,8 @@ encoder:
 嬥	zmyn	47900
 收费	zmyn	91200000
 𡛯	zmyn	0
-𪦩	zmyn	0
 𩛗	zmyo	0
-𪦨	zmyq	0
 𪀮	zmyr	0
-𫜁	zmyr	0
-𫜍	zmyr	0
 女孩	zmys	104000000
 妫	zmys	2180000
 𡛣	zmys	0
@@ -107003,7 +102740,6 @@ encoder:
 縋	zmyw	450000
 缒	zmyw	289000
 𡜱	zmyw	0
-𪬋	zmyw	0
 妃	zmyy	16000000
 嬆	zmyy	25100
 𡚱	zmyy	0
@@ -107011,7 +102747,6 @@ encoder:
 𡟸	zmyy	0
 𡤖	zmyy	0
 𦑙	zmyy	0
-𪥾	zmyy	0
 嫐	zmyz	191000
 𡝦	zmyz	0
 𡢰	zmyz	0
@@ -107037,13 +102772,11 @@ encoder:
 妖娆	zmzh	4670000
 𡤲	zmzi	0
 始	zmzj	77700000
-𪦐	zmzj	0
 㜅	zmzk	4520
 𡜗	zmzk	0
 𡜪	zmzl	0
 𡟤	zmzl	0
 𡣨	zmzl	0
-𫍠	zmzl	0
 㚣	zmzm	4010
 㛌	zmzm	3670
 奻	zmzm	962000
@@ -107051,8 +102784,6 @@ encoder:
 緌	zmzm	98500
 𡜄	zmzm	0
 𡠯	zmzm	0
-𪦣	zmzm	0
-𪦴	zmzm	0
 收缴	zmzn	3570000
 纤维	zmzn	51100000
 𡤀	zmzn	0
@@ -107068,7 +102799,6 @@ encoder:
 姢	zmzq	222000
 㜧	zmzr	5090
 𡤻	zmzr	0
-𪥵	zmzr	0
 𡤣	zmzs	0
 嫣	zmzu	3700000
 收发	zmzv	26400000
@@ -107086,8 +102816,6 @@ encoder:
 𡝏	zmzy	0
 𡢵	zmzy	0
 𡤶	zmzy	0
-𪦚	zmzy	0
-𫅛	zmzy	0
 妶	zmzz	750000
 姦	zmzz	6520000
 娹	zmzz	43200
@@ -107099,7 +102827,6 @@ encoder:
 𡢫	zmzz	0
 𡣦	zmzz	0
 𡤡	zmzz	0
-𪦯	zmzz	0
 𦂢	znan	0
 𦆒	znaz	0
 𦁻	znbi	0
@@ -107116,7 +102843,6 @@ encoder:
 𦇈	zngb	0
 𦅳	znge	0
 絥	zngs	78200
-𫅔	zngs	0
 绵软	znhr	598000
 維	znia	25100000
 维	znia	138000000
@@ -107168,7 +102894,6 @@ encoder:
 𦃈	znxs	0
 嫂子	znya	3790000
 缎子	znya	484000
-𫄎	znyd	0
 𥿞	znyi	0
 绵阳	znyk	27800000
 绵延	znym	5310000
@@ -107193,7 +102918,6 @@ encoder:
 𥿐	zobz	0
 𦁌	zobz	0
 兦	zoda	56700
-𫅂	zodk	0
 以求	zodv	6480000
 以南	zoel	8760000
 𦅑	zoel	0
@@ -107203,7 +102927,6 @@ encoder:
 𦃏	zofq	0
 𦆧	zogb	0
 絺	zogl	147000
-𫅚	zogl	0
 以太	zogs	7200000
 𥿭	zogz	0
 以至	zohb	10500000
@@ -107212,7 +102935,6 @@ encoder:
 絎	zoia	189000
 绗	zoia	1540000
 縰	zoii	40500
-𫅥	zoii	0
 以此	zoir	21300000
 以上	zoiv	1280000000
 𢻲	zoix	0
@@ -107254,7 +102976,6 @@ encoder:
 以往	zoos	49300000
 以后	zopa	221000000
 紾	zopd	609000
-𫅑	zopd	0
 緰	zoqk	39400
 𦈕	zoqk	0
 以外	zori	172000000
@@ -107263,10 +102984,7 @@ encoder:
 纶	zorr	9010000
 𦆛	zorr	0
 纷争	zorx	4420000
-𫅃	zorz	0
-𫄟	zosc	0
 紟	zosx	551000
-𫅍	zosx	0
 𥾪	zotd	0
 以北	zotr	8110000
 以资	zotr	850000
@@ -107303,7 +103021,6 @@ encoder:
 総	zozw	67500000
 给出	zozz	19800000
 缓刑	zpae	966000
-𫄞	zpag	0
 𦁟	zpah	0
 𥿤	zpda	0
 䋸	zpel	4040
@@ -107335,7 +103052,6 @@ encoder:
 缓慢	zpuk	18700000
 绥江	zpvb	151000
 缓流	zpvs	383000
-𫄱	zpvs	0
 䋮	zpvv	3600
 绥滨	zpvw	148000
 绥宁	zpwa	171000
@@ -107359,7 +103075,6 @@ encoder:
 缓缓	zpzp	21400000
 𥾭	zpzs	0
 能干	zqae	7110000
-𫄿	zqar	0
 能动	zqbz	2100000
 能耗	zqcm	3760000
 紣	zqed	109000
@@ -107416,7 +103131,6 @@ encoder:
 约有	zrgq	11700000
 紙	zrha	75100000
 纸	zrha	137000000
-𫙚	zrhc	0
 终止	zrii	15300000
 綹	zrij	89900
 约占	zrij	6810000
@@ -107433,8 +103147,6 @@ encoder:
 绝非	zrkc	7460000
 终归	zrkx	825000
 𦅥	zrkz	0
-𫄘	zrkz	0
-𫄥	zrlg	0
 𥿸	zrli	0
 𦀦	zrli	0
 𦃭	zrll	0
@@ -107523,7 +103235,6 @@ encoder:
 㔃	zryy	5780
 㔢	zryy	5560
 𥿎	zryy	0
-𫄑	zryy	0
 终结	zrzb	10200000
 婚姻	zrzj	83800000
 绝妙	zrzk	5040000
@@ -107547,7 +103258,6 @@ encoder:
 𠫫	zsaz	0
 𠬀	zsaz	0
 统考	zsba	6810000
-𫄽	zsbd	0
 𣠎	zsbg	0
 𠫚	zsbi	0
 𠜸	zsbk	0
@@ -107558,14 +103268,12 @@ encoder:
 𧶀	zsbz	0
 𠫽	zscc	0
 𣮟	zscm	0
-𪵰	zscq	0
 𤫜	zscs	0
 𣠏	zscx	0
 𡊅	zseb	0
 卛	zsed	38000
 𠫘	zsed	0
 𨠢	zsef	0
-𪤞	zsef	0
 䪻	zseg	3280
 𠼷	zsej	0
 𣗺	zsej	0
@@ -107591,8 +103299,6 @@ encoder:
 奱	zsgd	66500
 軬	zsgf	30900
 𨠒	zsgf	0
-𫑅	zsgh	0
-𫋭	zsgi	0
 妨碍	zsgk	9720000
 畚	zsgk	412000
 𠫭	zsgk	0
@@ -107620,13 +103326,11 @@ encoder:
 𢿈	zsix	0
 𣀵	zsix	0
 𠄩	zsjb	0
-𫄼	zsjb	0
 𩢠	zsjc	0
 𠫺	zsje	0
 枲	zsjf	68900
 𠫪	zsjg	0
 𩒎	zsjg	0
-𫗰	zsjg	0
 𢦯	zsjh	0
 𦝕	zsjj	0
 刣	zsjk	33500
@@ -107641,7 +103345,6 @@ encoder:
 𩏹	zsjm	0
 𨾱	zsjn	0
 㣍	zsjp	3860
-𪱹	zsjq	0
 㰧	zsjr	5860
 綂	zsjr	33200
 𠬍	zsjr	0
@@ -107675,10 +103378,8 @@ encoder:
 缞	zskr	54000
 𦂊	zskr	0
 灓	zskv	169000
-𪶋	zskv	0
 繶	zskw	112000
 𢛋	zskw	0
-𫅩	zskw	0
 𠮘	zskx	0
 𨝣	zsky	0
 奙	zskz	23200
@@ -107708,7 +103409,6 @@ encoder:
 统筹	zsmc	13300000
 攣	zsmd	954000
 𩓎	zsmg	0
-𪭮	zsmh	0
 统制	zsml	176000
 𠬏	zsml	0
 𣭰	zsmm	0
@@ -107756,7 +103456,6 @@ encoder:
 臠	zsoo	59000
 𠬙	zsoo	0
 𦠬	zsoo	0
-𪠤	zsoo	0
 參	zsop	12200000
 夋	zsor	1380000
 𥜷	zsor	0
@@ -107835,7 +103534,6 @@ encoder:
 䌴	zsuq	4560
 𦇽	zsuq	0
 𤒞	zsuu	0
-𫅆	zsux	0
 𠢺	zsuy	0
 𣜨	zsuy	0
 嫡派	zsvp	43200
@@ -107852,10 +103550,7 @@ encoder:
 縴	zswm	190000
 缔造	zswm	5270000
 㓄	zswr	4050
-𪠢	zswr	0
-𫜑	zswr	0
 縍	zsws	31800
-𫅢	zsws	0
 𣟽	zswy	0
 戀	zswz	21400000
 𦆌	zsxg	0
@@ -107875,7 +103570,6 @@ encoder:
 紡	zsya	2580000
 纺	zsya	20300000
 𠠪	zsyd	0
-𫄵	zsym	0
 㽋	zsys	4030
 瓵	zsys	28500
 𠨫	zsys	0
@@ -107895,7 +103589,6 @@ encoder:
 𠫰	zszc	0
 繂	zsze	844000
 𢌹	zsze	0
-𫅦	zsze	0
 㕖	zszf	4040
 𦁛	zszf	0
 统练	zszh	32400
@@ -107922,7 +103615,6 @@ encoder:
 𦀠	zszn	0
 絯	zszo	440000
 𠫯	zszo	0
-𪠣	zszo	0
 𨥣	zszp	0
 䋭	zszq	3740
 𠫞	zszq	0
@@ -107995,7 +103687,6 @@ encoder:
 縂	zujw	351000
 𦈎	zuke	0
 断电	zukz	2950000
-𫄙	zukz	0
 繒	zulk	778000
 缯	zulk	571000
 𦂏	zumf	0
@@ -108014,7 +103705,6 @@ encoder:
 彝文	zuso	74200
 断交	zuso	506000
 彝良	zusx	184000
-𫄮	zute	0
 断头	zutg	672000
 𦅗	zutr	0
 繕	zuuj	1020000
@@ -108041,7 +103731,6 @@ encoder:
 断线	zuzh	4240000
 𥿬	zuzi	0
 缕	zuzm	13700000
-𫄦	zuzm	0
 断绝	zuzr	3260000
 縌	zuzw	756000
 发型	zvae	11500000
@@ -108090,7 +103779,6 @@ encoder:
 发狂	zvqc	2760000
 发胖	zvqu	2460000
 絩	zvrd	76700
-𫄧	zvrj	0
 发言	zvsa	132000000
 发亮	zvsj	10500000
 发音	zvsk	8380000
@@ -108124,7 +103812,6 @@ encoder:
 发函	zvxk	781000
 发难	zvxn	1890000
 䋝	zvzm	3480
-𫄕	zvzm	0
 发给	zvzo	46900000
 发怒	zvzx	4760000
 发出	zvzz	75600000
@@ -108144,7 +103831,6 @@ encoder:
 编者	zwbm	8140000
 綄	zwbr	856000
 繨	zwbu	52900
-𫄲	zwbu	0
 縖	zwcj	33700
 缩聚	zwcx	160000
 𦄎	zwcx	0
@@ -108159,11 +103845,9 @@ encoder:
 𢧰	zwfh	0
 緷	zwfk	117000
 縺	zwfk	1770000
-𫅖	zwgd	0
 𦃲	zwgq	0
 綟	zwgs	65700
 𦂽	zwgs	0
-𫅝	zwgs	0
 编码	zwgx	93900000
 綋	zwgz	399000
 婉转	zwhb	3200000
@@ -108203,7 +103887,6 @@ encoder:
 缝合	zwoa	2030000
 编入	zwod	1570000
 𦇶	zwoi	0
-𫄭	zwoj	0
 缩微	zwol	530000
 编创	zwoy	407000
 𦇶	zwoy	0
@@ -108216,7 +103899,6 @@ encoder:
 纄	zwrc	32200
 缝	zwrc	28200000
 紞	zwrd	641000
-𫅕	zwrh	0
 编外	zwri	412000
 𦂦	zwrj	0
 紽	zwrr	38000
@@ -108233,7 +103915,6 @@ encoder:
 繸	zwug	80600
 𦆥	zwui	0
 縌	zwuz	756000
-𫄫	zwvr	0
 编写	zwwa	27300000
 缩写	zwwa	6040000
 编定	zwwd	238000
@@ -108250,7 +103931,6 @@ encoder:
 𦆣	zwxs	0
 綰	zwya	174000
 绾	zwya	2470000
-𫄔	zwya	0
 编导	zwyd	2500000
 𦁅	zwyd	0
 缝隙	zwyk	5060000
@@ -108267,7 +103947,6 @@ encoder:
 缝纫	zwzy	4380000
 绽出	zwzz	415000
 绿豆	zxaj	12400000
-𫄢	zxak	0
 䋖	zxbd	4180
 绎	zxbi	1170000
 经	zxbi	423000000
@@ -108310,9 +103989,6 @@ encoder:
 緑	zxkv	31500000
 绿	zxkv	140000000
 经常	zxkw	117000000
-𫅀	zxkz	0
-𫄠	zxld	0
-𫄩	zxld	0
 经典	zxle	422000000
 𦃌	zxlx	0
 𦇹	zxlz	0
@@ -108352,7 +104028,6 @@ encoder:
 绿灯	zxua	3500000
 𦂤	zxue	0
 怒火	zxuo	6750000
-𫄶	zxuz	0
 怒江	zxvb	2030000
 绿州	zxvn	199000
 经济	zxvs	386000000
@@ -108360,7 +104035,6 @@ encoder:
 经学	zxvw	584000
 经过	zxwd	172000000
 怒视	zxwl	885000
-𫄣	zxwl	0
 綅	zxwx	247000
 经心	zxwz	362000
 𥿲	zxxe	0
@@ -108423,7 +104097,6 @@ encoder:
 紹	zyja	4040000
 绍	zyja	8910000
 繦	zyji	163000
-𫅨	zyji	0
 𦂆	zyjj	0
 好吃	zyjm	30500000
 好听	zyjp	20000000
@@ -108431,7 +104104,6 @@ encoder:
 级别	zyjy	235000000
 𦇤	zykk	0
 𣫳	zyle	0
-𪭭	zylh	0
 𥁉	zylk	0
 𦁧	zylk	0
 貫	zylo	5630000
@@ -108446,7 +104118,6 @@ encoder:
 好手	zymd	4550000
 𥿰	zymf	0
 綖	zymi	519000
-𫅙	zymi	0
 好看	zyml	48000000
 𦂹	zymn	0
 𦀻	zymo	0
@@ -108509,7 +104180,6 @@ encoder:
 好戏	zyxh	4620000
 纪录	zyxk	48500000
 䋼	zyxl	4570
-𫅠	zyxl	0
 母鸡	zyxr	2460000
 𦀩	zyxx	0
 好书	zyxy	12100000
@@ -108586,7 +104256,6 @@ encoder:
 𣤰	zzfr	0
 𪇱	zzfr	0
 出奇	zzga	8020000
-𫄡	zzgc	0
 𡗞	zzgd	0
 𨍃	zzgf	0
 出厂	zzgg	12400000
@@ -108679,7 +104348,6 @@ encoder:
 幼体	zznf	409000
 出售	zznj	131000000
 嚮	zznj	1190000
-𪢢	zznj	0
 出自	zznl	23600000
 出任	zznm	9130000
 𩞠	zzno	0
@@ -108720,7 +104388,6 @@ encoder:
 𣢄	zzro	0
 𦀷	zzrr	0
 𠤉	zzrs	0
-𪪟	zzrs	0
 𢛭	zzrw	0
 出色	zzry	43500000
 幽怨	zzry	2360000
@@ -108764,7 +104431,6 @@ encoder:
 糺	zzvv	159000
 絲	zzvv	29800000
 𠃏	zzvv	0
-𫅋	zzvv	0
 幻觉	zzvw	6250000
 幽深	zzvw	1910000
 丝袜	zzwa	11000000
@@ -108776,7 +104442,6 @@ encoder:
 幽邃	zzww	353000
 纞	zzwz	275000
 𢇀	zzxb	0
-𫄚	zzxe	0
 继承	zzxk	21300000
 𥃍	zzxl	0
 𥃎	zzxl	0
@@ -108809,7 +104474,6 @@ encoder:
 乣	zzza	45100
 𡋢	zzzb	0
 𦃒	zzzb	0
-𪪠	zzzd	0
 继续	zzze	254000000
 𢇂	zzze	0
 樂	zzzf	57100000
@@ -123519,6 +119183,7 @@ encoder:
 断断续续	zzzze	4160000
 纤维组织	zzzzj	308000
 结缔组织	zzzzj	1230000
+
 # 構詞碼（第四列）
 一			av
 丁			ai


### PR DESCRIPTION
1.
    * 因原编码错误，删除原有的所有 CJK-C 区编码。
    * 因原编码错漏，删除原有的 50 个 CJK-D 区编码。

2. 增加 CJK-C 区所有字符 4149 个，包含容错码共 4306 条。

3. 增加 CJK-D 区所有字符 222 个， 包含容错码共 249 条。

另注，现在用作显示扩展字符区的字体一般为 hanazono, 但其中许多字体显示与 UNICODE 标准并不完全符合。
以上提交的编码，均以 UNICODE 组织发布的 PDF 文件内的字样结构为准。